### PR TITLE
Fix find all algos

### DIFF
--- a/lib/ao_host.js
+++ b/lib/ao_host.js
@@ -288,7 +288,13 @@ class AOHost extends AsyncEventEmitter {
   async loadAllAOs () {
     const { AlgoOrder } = this.db
 
-    const aos = await AlgoOrder.find(['active', '=', true])
+    const allAos = await AlgoOrder.getAll()
+    // get all active orders
+    const aos = Object.keys(allAos)
+      .map((gid) => allAos[gid].active ? allAos[gid] : null)
+      .filter(x => x)
+    // filter used in favor of AlgoOrder.find(['active', '=', true])
+    // which seems currently broken
     let ao
 
     for (let i = 0; i < aos.length; i += 1) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-hf-algo",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "HF Algorithmic Order Module",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
Currently is seems like the lowdb `find` validation is not working properly. As this is causing some big problems this pr hot fixes that by using `getAll` and mapping to validate active orders.