### PR TITLE
v2.0.4 Fix: Always Unique Client ID

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+# 2.0.4
+- fix: make order client ID always unique
+
 # 2.0.3
 - all order types: add uiIcon field to ui definitions
 

--- a/lib/ao_host.js
+++ b/lib/ao_host.js
@@ -570,11 +570,6 @@ class AOHost extends AsyncEventEmitter {
           eventName,
           allOrders[ocid]
         )
-      } else {
-        debug(
-          'unknown order for AO %s cid %s, %f @ %f %s',
-          id, order.cid, order.amountOrig, order.price, order.status
-        )
       }
     })
   }

--- a/lib/util/gen_client_id.js
+++ b/lib/util/gen_client_id.js
@@ -1,5 +1,7 @@
 'use strict'
 
+let last = Date.now()
+
 module.exports = () => {
-  return Date.now()
+  return last++
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-hf-algo",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "HF Algorithmic Order Module",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
### Description:
Fixes client ID generation to be unique even when used in quick bursts (used to use `Date.now()` value)

### Fixes:
- [x] order client ID generation/matching

### PR status:
- [x] Version bumped
- [x] Change-log updated
- [ ] Tests added or updated
- [ ] Documentation updated
