### PR TITLE
Feature: Order creates OcO 2.0.6

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+# 2.0.6
+- feature: OCOCO type
+
 # 2.0.5
 - feature: futures support
 

--- a/docs/ococo.md
+++ b/docs/ococo.md
@@ -1,0 +1,25 @@
+<a name="OCOCO"></a>
+
+## OCOCO
+Order Creates OCO (or OCOCO) triggers an OCO order after an initial MARKET
+or LIMIT order fills.
+
+**Kind**: global variable  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| symbol | <code>string</code> | symbol to trade on |
+| orderType | <code>string</code> | initial order type, LIMIT or MARKET |
+| orderPrice | <code>number</code> | price for initial order if `orderType` is LIMIT |
+| amount | <code>number</code> | initial order amount |
+| _margin | <code>boolean</code> | if false, order type is prefixed with EXCHANGE |
+| _futures | <code>boolean</code> | if false, order type is prefixed with EXCHANGE |
+| action | <code>string</code> | initial order direction, Buy or Sell |
+| limitPrice | <code>number</code> | oco order limit price |
+| stopPrice | <code>number</code> | oco order stop price |
+| ocoAmount | <code>number</code> | oco order amount |
+| ocoAction | <code>string</code> | oco order direction, Buy or Sell |
+| submitDelaySec | <code>number</code> | submit delay in seconds |
+| cancelDelaySec | <code>number</code> | cancel delay in seconds |
+| lev | <code>number</code> | leverage for relevant markets |
+

--- a/index.js
+++ b/index.js
@@ -7,5 +7,6 @@ module.exports = {
   AccumulateDistribute: require('./lib/accumulate_distribute'),
   PingPong: require('./lib/ping_pong'),
   MACrossover: require('./lib/ma_crossover'),
+  OCOCO: require('./lib/ococo'),
   NoDataError: require('./lib/errors/no_data')
 }

--- a/lib/ococo/events/life_start.js
+++ b/lib/ococo/events/life_start.js
@@ -1,0 +1,8 @@
+'use strict'
+
+module.exports = async (instance = {}) => {
+  const { h = {} } = instance
+  const { emitSelf } = h
+
+  await emitSelf('submit_initial_order')
+}

--- a/lib/ococo/events/life_stop.js
+++ b/lib/ococo/events/life_stop.js
@@ -1,0 +1,3 @@
+'use strict'
+
+module.exports = async (instance = {}) => {}

--- a/lib/ococo/events/orders_order_cancel.js
+++ b/lib/ococo/events/orders_order_cancel.js
@@ -1,0 +1,17 @@
+'use strict'
+
+module.exports = async (instance = {}, order) => {
+  const { state = {}, h = {} } = instance
+  const { args = {}, orders = {}, gid, timeout } = state
+  const { emit, debug } = h
+  const { cancelDelay } = args
+
+  debug('detected atomic cancelation, stopping...')
+
+  if (timeout) {
+    clearTimeout(timeout)
+  }
+
+  await emit('exec:order:cancel:all', gid, orders, cancelDelay)
+  await emit('exec:stop')
+}

--- a/lib/ococo/events/orders_order_fill.js
+++ b/lib/ococo/events/orders_order_fill.js
@@ -1,0 +1,14 @@
+'use strict'
+
+module.exports = async (instance = {}) => {
+  const { state = {}, h = {} } = instance
+  const { updateState, emitSelf } = h
+  const { initialOrderFilled } = state
+
+  if (initialOrderFilled) {
+    await emitSelf('exec:stop')
+  } else {
+    await updateState(instance, { initialOrderFilled: true })
+    await emitSelf('submit_oco_order')
+  }
+}

--- a/lib/ococo/events/orders_order_fill.js
+++ b/lib/ococo/events/orders_order_fill.js
@@ -1,9 +1,16 @@
 'use strict'
 
-module.exports = async (instance = {}) => {
+const { Config } = require('bfx-api-node-core')
+const { DUST } = Config
+
+module.exports = async (instance = {}, order) => {
   const { state = {}, h = {} } = instance
   const { updateState, emitSelf } = h
   const { initialOrderFilled } = state
+
+  if (order.amount > DUST) { // partial fill
+    return
+  }
 
   if (initialOrderFilled) {
     await emitSelf('exec:stop')

--- a/lib/ococo/events/self_submit_initial_order.js
+++ b/lib/ococo/events/self_submit_initial_order.js
@@ -1,0 +1,19 @@
+'use strict'
+
+const generateInitialOrder = require('../util/generate_initial_order')
+
+module.exports = async (instance = {}) => {
+  const { state = {}, h = {} } = instance
+  const { emit, debug } = h
+  const { args = {}, gid } = state
+  const { submitDelay } = args
+
+  const order = generateInitialOrder(instance)
+
+  debug(
+    'generated order %s for %f @ %f',
+    order.type, order.amount, order.price || 'MARKET'
+  )
+
+  await emit('exec:order:submit:all', gid, [order], submitDelay)
+}

--- a/lib/ococo/events/self_submit_oco_order.js
+++ b/lib/ococo/events/self_submit_oco_order.js
@@ -1,0 +1,19 @@
+'use strict'
+
+const generateOCOOrder = require('../util/generate_oco_order')
+
+module.exports = async (instance = {}) => {
+  const { state = {}, h = {} } = instance
+  const { emit, debug } = h
+  const { args = {}, gid } = state
+  const { submitDelay } = args
+
+  const order = generateOCOOrder(instance)
+
+  debug(
+    'generated order %s for %f @ %f',
+    order.type, order.amount, order.price || 'MARKET'
+  )
+
+  await emit('exec:order:submit:all', gid, [order], submitDelay)
+}

--- a/lib/ococo/index.js
+++ b/lib/ococo/index.js
@@ -18,6 +18,26 @@ const getUIDef = require('./meta/get_ui_def')
 const serialize = require('./meta/serialize')
 const unserialize = require('./meta/unserialize')
 
+/**
+ * Order Creates OCO (or OCOCO) triggers an OCO order after an initial MARKET
+ * or LIMIT order fills.
+ *
+ * @name OCOCO
+ * @param {string} symbol - symbol to trade on
+ * @param {string} orderType - initial order type, LIMIT or MARKET
+ * @param {number} orderPrice - price for initial order if `orderType` is LIMIT
+ * @param {number} amount - initial order amount
+ * @param {boolean} _margin - if false, order type is prefixed with EXCHANGE
+ * @param {boolean} _futures - if false, order type is prefixed with EXCHANGE
+ * @param {string} action - initial order direction, Buy or Sell
+ * @param {number} limitPrice - oco order limit price
+ * @param {number} stopPrice - oco order stop price
+ * @param {number} ocoAmount - oco order amount
+ * @param {string} ocoAction - oco order direction, Buy or Sell
+ * @param {number} submitDelaySec - submit delay in seconds
+ * @param {number} cancelDelaySec - cancel delay in seconds
+ * @param {number} lev - leverage for relevant markets
+ */
 const OCOCO = defineAlgoOrder({
   id: 'bfx-ococo',
   name: 'OCOCO',

--- a/lib/ococo/index.js
+++ b/lib/ococo/index.js
@@ -1,0 +1,55 @@
+'use strict'
+
+const defineAlgoOrder = require('../define_algo_order')
+
+const validateParams = require('./meta/validate_params')
+const processParams = require('./meta/process_params')
+const initState = require('./meta/init_state')
+const onSelfSubmitInitialOrder = require('./events/self_submit_initial_order')
+const onSelfSubmitOCOOrder = require('./events/self_submit_oco_order')
+const onLifeStart = require('./events/life_start')
+const onLifeStop = require('./events/life_stop')
+const onOrdersOrderCancel = require('./events/orders_order_cancel')
+const onOrdersOrderFill = require('./events/orders_order_fill')
+const genOrderLabel = require('./meta/gen_order_label')
+const genPreview = require('./meta/gen_preview')
+const declareEvents = require('./meta/declare_events')
+const getUIDef = require('./meta/get_ui_def')
+const serialize = require('./meta/serialize')
+const unserialize = require('./meta/unserialize')
+
+const OCOCO = defineAlgoOrder({
+  id: 'bfx-ococo',
+  name: 'OCOCO',
+
+  meta: {
+    validateParams,
+    processParams,
+    declareEvents,
+    getUIDef,
+    genOrderLabel,
+    genPreview,
+    initState,
+    serialize,
+    unserialize
+  },
+
+  events: {
+    self: {
+      submit_initial_order: onSelfSubmitInitialOrder,
+      submit_oco_order: onSelfSubmitOCOOrder
+    },
+
+    life: {
+      start: onLifeStart,
+      stop: onLifeStop
+    },
+
+    orders: {
+      order_cancel: onOrdersOrderCancel,
+      order_fill: onOrdersOrderFill
+    }
+  }
+})
+
+module.exports = OCOCO

--- a/lib/ococo/meta/declare_events.js
+++ b/lib/ococo/meta/declare_events.js
@@ -1,0 +1,9 @@
+'use strict'
+
+module.exports = (instance = {}, host) => {
+  const { h = {} } = instance
+  const { declareEvent } = h
+
+  declareEvent(instance, host, 'self:submit_initial_order', 'submit_initial_order')
+  declareEvent(instance, host, 'self:submit_oco_order', 'submit_oco_order')
+}

--- a/lib/ococo/meta/gen_order_label.js
+++ b/lib/ococo/meta/gen_order_label.js
@@ -1,0 +1,14 @@
+'use strict'
+
+module.exports = (state = {}) => {
+  const { args = {} } = state
+  const {
+    orderType, orderPrice, amount, ocoAmount, limitPrice, stopPrice
+  } = args
+
+  return [
+    'OCOCO',
+    ` | ${amount} @ ${orderPrice || orderType} `,
+    ` | triggers ${ocoAmount} @ ${limitPrice} (stop ${stopPrice})`
+  ].join('')
+}

--- a/lib/ococo/meta/gen_preview.js
+++ b/lib/ococo/meta/gen_preview.js
@@ -1,0 +1,5 @@
+'use strict'
+
+module.exports = (args = {}) => {
+  return []
+}

--- a/lib/ococo/meta/get_ui_def.js
+++ b/lib/ococo/meta/get_ui_def.js
@@ -1,0 +1,146 @@
+module.exports = () => ({
+  label: 'Order Creates OcO',
+  id: 'bfx-ococo',
+
+  uiIcon: 'ma-crossover-active',
+  connectionTimeout: 10000,
+  actionTimeout: 10000,
+
+  header: {
+    component: 'ui.checkbox_group',
+    fields: ['hidden', 'postonly']
+  },
+
+  sections: [{
+    title: '',
+    name: 'general',
+    rows: [
+      ['orderType', 'orderPrice'],
+      ['amount', 'action']
+    ]
+  }, {
+    title: 'OcO Settings',
+    name: 'shortEMASettings',
+    fixed: true,
+
+    rows: [
+      ['limitPrice', 'stopPrice'],
+      ['ocoAmount', 'ocoAction']
+    ]
+  }, {
+    title: '',
+    name: 'submitSettings',
+    fixed: true,
+
+    rows: [
+      ['submitDelaySec', 'cancelDelaySec']
+    ]
+  }, {
+    title: '',
+    name: 'lev',
+    fullWidth: true,
+    rows: [
+      ['lev']
+    ],
+
+    visible: {
+      _context: { eq: 'f' }
+    }
+  }],
+
+  fields: {
+    submitDelaySec: {
+      component: 'input.number',
+      label: 'Submit Delay (sec)',
+      customHelp: 'Seconds to wait before submitting orders',
+      default: 1
+    },
+
+    cancelDelaySec: {
+      component: 'input.number',
+      label: 'Cancel Delay (sec)',
+      customHelp: 'Seconds to wait before cancelling orders',
+      default: 0
+    },
+
+    orderType: {
+      component: 'input.dropdown',
+      label: 'Order Type',
+      default: 'LIMIT',
+      options: {
+        LIMIT: 'Limit',
+        MARKET: 'Market'
+      }
+    },
+
+    amount: {
+      component: 'input.amount',
+      label: 'Amount $BASE',
+      customHelp: 'Initial Order amount',
+      priceField: 'orderPrice'
+    },
+
+    ocoAmount: {
+      component: 'input.amount',
+      label: 'Amount $BASE',
+      customHelp: 'OcO Order amount'
+    },
+
+    orderPrice: {
+      component: 'input.price',
+      label: 'Initial Order Price $QUOTE',
+
+      disabled: {
+        orderType: { eq: 'MARKET' }
+      }
+    },
+
+    limitPrice: {
+      component: 'input.price',
+      label: 'OcO Limit Price $QUOTE'
+    },
+
+    stopPrice: {
+      component: 'input.price',
+      label: 'OcO Stop Price $QUOTE'
+    },
+
+    lev: {
+      component: 'input.range',
+      label: 'Leverage',
+      min: 1,
+      max: 100,
+      default: 10
+    },
+
+    hidden: {
+      component: 'input.checkbox',
+      label: 'HIDDEN',
+      default: false
+    },
+
+    postonly: {
+      component: 'input.checkbox',
+      label: 'POST-ONLY',
+      default: false
+    },
+
+    action: {
+      component: 'input.radio',
+      label: 'Action',
+      options: ['Buy', 'Sell'],
+      inline: true,
+      default: 'Buy'
+    },
+
+    ocoAction: {
+      component: 'input.radio',
+      label: 'Action',
+      options: ['Buy', 'Sell'],
+      inline: true,
+      default: 'Buy'
+    }
+  },
+
+  actions: ['preview', 'submit']
+})

--- a/lib/ococo/meta/init_state.js
+++ b/lib/ococo/meta/init_state.js
@@ -1,0 +1,8 @@
+'use strict'
+
+module.exports = (args = {}) => {
+  return {
+    args,
+    initialOrderFilled: false
+  }
+}

--- a/lib/ococo/meta/process_params.js
+++ b/lib/ococo/meta/process_params.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const _isFinite = require('lodash/isFinite')
+
 module.exports = (data) => {
   const params = { ...data }
 
@@ -12,12 +14,22 @@ module.exports = (data) => {
     delete params.lev
   }
 
-  if (!params.cancelDelay) {
-    params.cancelDelay = 1500
+  if (params.cancelDelaySec) {
+    params.cancelDelay = params.cancelDelaySec * 1000
+    delete params.cancelDelaySec
   }
 
-  if (!params.submitDelay) {
-    params.submitDelay = 5000
+  if (params.submitDelaySec) {
+    params.submitDelay = params.submitDelaySec * 1000
+    delete params.submitDelaySec
+  }
+
+  if (!_isFinite(params.cancelDelay)) {
+    params.cancelDelay = 1000
+  }
+
+  if (!_isFinite(params.submitDelay)) {
+    params.submitDelay = 2000
   }
 
   if (params.action) {

--- a/lib/ococo/meta/process_params.js
+++ b/lib/ococo/meta/process_params.js
@@ -1,0 +1,40 @@
+'use strict'
+
+module.exports = (data) => {
+  const params = { ...data }
+
+  if (params._symbol) {
+    params.symbol = params._symbol
+    delete params._symbol
+  }
+
+  if (!params._futures) {
+    delete params.lev
+  }
+
+  if (!params.cancelDelay) {
+    params.cancelDelay = 1500
+  }
+
+  if (!params.submitDelay) {
+    params.submitDelay = 5000
+  }
+
+  if (params.action) {
+    if (params.action === 'Sell') {
+      params.amount = (+params.amount) * -1
+    }
+
+    delete params.action
+  }
+
+  if (params.ocoAction) {
+    if (params.ocoAction === 'Sell') {
+      params.ocoAmount = (+params.ocoAmount) * -1
+    }
+
+    delete params.ocoAction
+  }
+
+  return params
+}

--- a/lib/ococo/meta/serialize.js
+++ b/lib/ococo/meta/serialize.js
@@ -1,0 +1,11 @@
+'use strict'
+
+module.exports = (state = {}) => {
+  const { args = {}, label, name } = state
+
+  return {
+    label,
+    name,
+    args
+  }
+}

--- a/lib/ococo/meta/unserialize.js
+++ b/lib/ococo/meta/unserialize.js
@@ -1,0 +1,11 @@
+'use strict'
+
+module.exports = (loadedState = {}) => {
+  const { args = {}, name, label } = loadedState
+
+  return {
+    label,
+    name,
+    args
+  }
+}

--- a/lib/ococo/meta/validate_params.js
+++ b/lib/ococo/meta/validate_params.js
@@ -7,7 +7,7 @@ const ORDER_TYPES = ['MARKET', 'LIMIT']
 module.exports = (args = {}) => {
   const {
     orderPrice, amount, orderType, submitDelay, cancelDelay, limitPrice,
-    stopPrice, ocoAmount, lev, _futures
+    stopPrice, ocoAmount, lev, _futures, action, ocoAction
   } = args
 
   if (ORDER_TYPES.indexOf(orderType) === -1) return `Invalid order type: ${orderType}`
@@ -21,6 +21,9 @@ module.exports = (args = {}) => {
   if (!_isFinite(limitPrice)) return 'Invalid OCO limit price'
   if (!_isFinite(stopPrice)) return 'Invalid OCO stop price'
   if (!_isFinite(ocoAmount)) return 'Invalid OCO amount'
+
+  if (action !== 'Buy' && action !== 'Sell') return `Invalid action: ${action}`
+  if (ocoAction !== 'Buy' && ocoAction !== 'Sell') return `Invalid OCO action: ${ocoAction}`
 
   if (_futures) {
     if (!_isFinite(lev)) return 'Invalid leverage'

--- a/lib/ococo/meta/validate_params.js
+++ b/lib/ococo/meta/validate_params.js
@@ -1,0 +1,32 @@
+'use strict'
+
+const _isFinite = require('lodash/isFinite')
+
+const ORDER_TYPES = ['MARKET', 'LIMIT']
+
+module.exports = (args = {}) => {
+  const {
+    orderPrice, amount, orderType, submitDelay, cancelDelay, limitPrice,
+    stopPrice, ocoAmount, lev, _futures
+  } = args
+
+  if (ORDER_TYPES.indexOf(orderType) === -1) return `Invalid order type: ${orderType}`
+  if (!_isFinite(amount)) return 'Invalid amount'
+  if (!_isFinite(submitDelay) || submitDelay < 0) return 'Invalid submit delay'
+  if (!_isFinite(cancelDelay) || cancelDelay < 0) return 'Invalid cancel delay'
+  if (orderType === 'LIMIT' && !_isFinite(orderPrice)) {
+    return 'Limit price required for LIMIT order type'
+  }
+
+  if (!_isFinite(limitPrice)) return 'Invalid OCO limit price'
+  if (!_isFinite(stopPrice)) return 'Invalid OCO stop price'
+  if (!_isFinite(ocoAmount)) return 'Invalid OCO amount'
+
+  if (_futures) {
+    if (!_isFinite(lev)) return 'Invalid leverage'
+    if (lev < 1) return 'Leverage less than 1'
+    if (lev > 100) return 'Leverage greater than 100'
+  }
+
+  return null
+}

--- a/lib/ococo/util/generate_initial_order.js
+++ b/lib/ococo/util/generate_initial_order.js
@@ -1,0 +1,41 @@
+'use strict'
+
+const { Order } = require('bfx-api-node-models')
+const { nonce } = require('bfx-api-node-util')
+
+module.exports = (instance = {}) => {
+  const { state = {} } = instance
+  const { args = {} } = state
+  const {
+    amount, symbol, orderType, orderPrice, hidden, postonly, lev, _margin,
+    _futures
+  } = args
+
+  const sharedOrderParams = {
+    symbol,
+    amount,
+    hidden,
+    postonly
+  }
+
+  if (_futures) {
+    sharedOrderParams.lev = lev
+  }
+
+  if (orderType === 'MARKET') {
+    return new Order({
+      ...sharedOrderParams,
+      cid: nonce(),
+      type: _margin || _futures ? 'MARKET' : 'EXCHANGE MARKET'
+    })
+  } else if (orderType === 'LIMIT') {
+    return new Order({
+      ...sharedOrderParams,
+      price: +orderPrice,
+      cid: nonce(),
+      type: _margin || _futures ? 'LIMIT' : 'EXCHANGE LIMIT'
+    })
+  } else {
+    throw new Error(`unknown order type: ${orderType}`)
+  }
+}

--- a/lib/ococo/util/generate_oco_order.js
+++ b/lib/ococo/util/generate_oco_order.js
@@ -1,0 +1,39 @@
+'use strict'
+
+const { Order } = require('bfx-api-node-models')
+const { nonce } = require('bfx-api-node-util')
+
+module.exports = (instance = {}) => {
+  const { state = {} } = instance
+  const { args = {} } = state
+  const {
+    ocoAmount, symbol, limitPrice, stopPrice, hidden, postonly, lev,
+    _margin, _futures
+  } = args
+
+  const cid = nonce()
+  const sharedOrderParams = {
+    symbol,
+    amount: ocoAmount
+  }
+
+  if (_futures) {
+    sharedOrderParams.lev = lev
+  }
+
+  const o = new Order({
+    ...sharedOrderParams,
+    price: +limitPrice,
+    priceAuxLimit: +stopPrice,
+    oco: true,
+    cid: cid,
+    cidOCO: cid,
+    type: _margin || _futures ? 'LIMIT' : 'EXCHANGE LIMIT',
+    hidden,
+    postonly
+  })
+
+  console.log(JSON.stringify(o.toNewOrderPacket(), null, 2))
+
+  return o
+}

--- a/lib/ococo/util/generate_oco_order.js
+++ b/lib/ococo/util/generate_oco_order.js
@@ -33,7 +33,5 @@ module.exports = (instance = {}) => {
     postonly
   })
 
-  console.log(JSON.stringify(o.toNewOrderPacket(), null, 2))
-
   return o
 }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "twap_docs": "node_modules/jsdoc-to-markdown/bin/cli.js lib/twap/index.js > docs/twap.md",
     "pingpong_docs": "node_modules/jsdoc-to-markdown/bin/cli.js lib/ping_pong/index.js > docs/ping_pong.md",
     "ad_docs": "node_modules/jsdoc-to-markdown/bin/cli.js lib/accumulate_distribute/index.js > docs/accumulate_distribute.md",
-    "docs": "npm run aohost_docs && npm run helpers_docs && npm run iceberg_docs && npm run twap_docs && npm run ad_docs && npm run macrossover_docs && npm run pingpong_docs"
+    "ococo_docs": "node_modules/jsdoc-to-markdown/bin/cli.js lib/ococo/index.js > docs/ococo.md",
+    "docs": "npm run aohost_docs && npm run helpers_docs && npm run iceberg_docs && npm run twap_docs && npm run ad_docs && npm run macrossover_docs && npm run pingpong_docs && npm run ococo_docs"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-hf-algo",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "HF Algorithmic Order Module",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
### Description:
Adds a new order type that submits an OCO order after an initial LIMIT/MARKET order fills.

Pending documentation, feature-complete

### New features:
- [x] OCOCO

### PR status:
- [x] Version bumped
- [x] Change-log updated
- [ ] Tests added or updated
- [ ] Documentation updated

![Screenshot from 2020-01-22 13 58 16](https://user-images.githubusercontent.com/1319812/72872178-42aaed00-3d1f-11ea-8a72-434e5fea0916.png)