### PR TITLE
Feature: AO Host reconnect() 2.0.7

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+# 2.0.7
+- refactor: OCOCO now keeps 'ocoAction' and 'action' params
+- feature: add reconnect() method to AO Host
+
 # 2.0.6
 - feature: OCOCO type
 

--- a/lib/ao_host.js
+++ b/lib/ao_host.js
@@ -85,6 +85,10 @@ class AOHost extends AsyncEventEmitter {
     })
   }
 
+  reconnect () {
+    this.adapter.reconnect()
+  }
+
   close () {
     this.adapter.disconnect()
   }

--- a/lib/ococo/meta/process_params.js
+++ b/lib/ococo/meta/process_params.js
@@ -36,16 +36,12 @@ module.exports = (data) => {
     if (params.action === 'Sell') {
       params.amount = (+params.amount) * -1
     }
-
-    delete params.action
   }
 
   if (params.ocoAction) {
     if (params.ocoAction === 'Sell') {
       params.ocoAmount = (+params.ocoAmount) * -1
     }
-
-    delete params.ocoAction
   }
 
   return params

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-hf-algo",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "description": "HF Algorithmic Order Module",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
### Description:
Adds `reconnect()` to the AO host, tweaks OCOCO saved param set (see diff)

### PR status:
- [x] Version bumped
- [x] Change-log updated
- [ ] Tests added or updated
- [ ] Documentation updated
