### PR TITLE
Fix: CID func usage & teardown race condition prevention

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,8 +1,13 @@
+# 2.0.11
+- meta: bump bitfinex-api-node to v4
+
 # 2.0.10
 - feature: add AOHost getAdapter()
 
 # 2.0.9
-- meta: bump bitfinex-api-node to v4
+- refactor: revert 2.0.8 nonce(), switch OCOCO onto internal cid gen
+- feature: AO Host 'exec:stop' now supports onCleanup()
+- refactor: error event handlers now have a pre-cleanup grace period
 
 # 2.0.8
 - refactor: use nonce() from bfx-api-node-util

--- a/lib/accumulate_distribute/meta/gen_preview.js
+++ b/lib/accumulate_distribute/meta/gen_preview.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { nonce } = require('bfx-api-node-util')
+const genCID = require('../../util/gen_client_id')
 const { Order } = require('bfx-api-node-models')
 const genOrderAmounts = require('../util/gen_order_amounts')
 
@@ -19,7 +19,7 @@ module.exports = (args = {}) => {
         symbol,
         amount,
         hidden,
-        cid: nonce(),
+        cid: genCID(),
         type: _margin ? 'MARKET' : 'EXCHANGE MARKET'
       }))
     } else if (orderType === 'LIMIT') {
@@ -28,7 +28,7 @@ module.exports = (args = {}) => {
         amount,
         hidden,
         price: limitPrice,
-        cid: nonce(),
+        cid: genCID(),
         type: _margin ? 'LIMIT' : 'EXCHANGE LIMIT'
       }))
     } else if (orderType === 'RELATIVE') {
@@ -37,7 +37,7 @@ module.exports = (args = {}) => {
         amount,
         hidden,
         price: 'RELATIVE',
-        cid: nonce(),
+        cid: genCID(),
         type: _margin ? 'LIMIT' : 'EXCHANGE LIMIT'
       }))
     } else {

--- a/lib/accumulate_distribute/util/generate_order.js
+++ b/lib/accumulate_distribute/util/generate_order.js
@@ -3,7 +3,7 @@
 const _isFinite = require('lodash/isFinite')
 const _isObject = require('lodash/isObject')
 const { Order } = require('bfx-api-node-models')
-const { nonce } = require('bfx-api-node-util')
+const genCID = require('../../util/gen_client_id')
 
 module.exports = (instance = {}) => {
   const { state = {}, h = {} } = instance
@@ -36,14 +36,14 @@ module.exports = (instance = {}) => {
   if (orderType === 'MARKET') {
     return new Order({
       ...sharedOrderParams,
-      cid: nonce(),
+      cid: genCID(),
       type: _margin || _futures ? 'MARKET' : 'EXCHANGE MARKET'
     })
   } else if (orderType === 'LIMIT') {
     return new Order({
       ...sharedOrderParams,
       price: limitPrice,
-      cid: nonce(),
+      cid: genCID(),
       type: _margin || _futures ? 'LIMIT' : 'EXCHANGE LIMIT'
     })
   } else if (orderType !== 'RELATIVE') {
@@ -149,7 +149,7 @@ module.exports = (instance = {}) => {
   return new Order({
     ...sharedOrderParams,
     price: finalPrice,
-    cid: nonce(),
+    cid: genCID(),
     type: _margin || _futures ? 'LIMIT' : 'EXCHANGE LIMIT'
   })
 }

--- a/lib/ao_host.js
+++ b/lib/ao_host.js
@@ -15,6 +15,7 @@ const onCancelAllOrders = require('./host/events/cancel_all_orders')
 const onUpdateState = require('./host/events/update_state')
 const onAssignChannel = require('./host/events/assign_channel')
 const onNotify = require('./host/events/notify')
+const onStop = require('./host/events/stop')
 const withAOUpdate = require('./host/with_ao_update')
 const bindWS2Bus = require('./host/ws2/bind_bus')
 const initAO = require('./host/init_ao')
@@ -356,16 +357,7 @@ class AOHost extends AsyncEventEmitter {
     state.ev.on('error:insufficient_balance', onInsufficientBalanceError.bind(null, this))
     state.ev.on('exec:order:submit:all', onSubmitAllOrders.bind(null, this))
     state.ev.on('exec:order:cancel:all', onCancelAllOrders.bind(null, this))
-    state.ev.on('exec:stop', async () => {
-      const inst = this.instances[gid]
-
-      if (!inst) { // instance may have already stopped
-        return
-      }
-
-      await this.emit('ao:stop', inst)
-      delete this.instances[gid] // implode
-    })
+    state.ev.on('exec:stop', onStop.bind(null, this, gid))
 
     const { declareEvents, declareChannels } = ao.meta || {}
 

--- a/lib/async_event_emitter.js
+++ b/lib/async_event_emitter.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const _isString = require('lodash/isString')
 const PI = require('p-iteration')
 
 /**
@@ -12,12 +13,24 @@ module.exports = class AsyncEventEmitter {
   }
 
   /**
-   * Removes all listeners, or only those for the specified event name
+   * Removes all listeners, only those for the specified event name, or those
+   * matching/not matching a regular expression
    *
-   * @param {string} eventName
+   * @param {string|RegExp} eventName - can be a regular expression
+   * @param {boolean} negativeMatch - if true, events not matching the regexp are deleted
    */
-  removeAllListeners (eventName) {
-    if (eventName) {
+  removeAllListeners (eventName, negativeMatch) {
+    if (eventName instanceof RegExp) {
+      const events = Object.keys(this.listeners)
+
+      for (let i = 0; i < events.length; i += 1) {
+        const evName = events[i]
+
+        if (eventName.test(evName) === !negativeMatch) {
+          delete this.listeners[evName]
+        }
+      }
+    } else if (_isString(eventName)) {
       delete this.listeners[eventName]
     } else {
       this.listeners = {}

--- a/lib/default_handlers/error_insufficient_balance.js
+++ b/lib/default_handlers/error_insufficient_balance.js
@@ -1,20 +1,30 @@
 'use strict'
 
+const delay = require('../util/delay')
+
+// How long orders are allowed to settle for before teardown
+const TEARDOWN_GRACE_PERIOD_MS = 1 * 1000
+
 /**
  * Cancel the AO if we try to submit an order without having enough balance
  *
  * @param {Object} instance
  * @param {Order} order - order which is below the min size for its symbol
  */
-module.exports = async (instance = {}, o) => {
+module.exports = async (instance = {}, o, notification) => {
   const { state = {}, h = {} } = instance
   const { gid, args = {}, orders = {} } = state
-  const { emit, debug } = h
+  const { emit, debug, notifyUI } = h
   const { cancelDelay } = args
+  const { text } = notification
 
   debug('received insufficient balance error for order: %f @ %f', o.amountOrig, o.price)
   debug('stopping order...')
 
-  await emit('exec:order:cancel:all', gid, orders, cancelDelay)
-  await emit('exec:stop')
+  await notifyUI('error', text)
+
+  await emit('exec:stop', async () => {
+    await delay(TEARDOWN_GRACE_PERIOD_MS)
+    await emit('exec:order:cancel:all', gid, orders, cancelDelay)
+  })
 }

--- a/lib/default_handlers/error_minimum_size.js
+++ b/lib/default_handlers/error_minimum_size.js
@@ -1,21 +1,33 @@
 'use strict'
 
+const delay = require('../util/delay')
+
+// How long orders are allowed to settle for before teardown
+const TEARDOWN_GRACE_PERIOD_MS = 1 * 1000
+
 /**
  * Cancel the AO if we try to submit an order below the minimum size, since it
  * means the remaining amount is below the min size (and therefore cannot fill)
  *
  * @param {Object} instance
  * @param {Order} order - order which is below the min size for its symbol
+ * @param {Object} notification - barebones notification object from BFX
+ * @param {Object} notification.text - original notification text
  */
-module.exports = async (instance = {}, o) => {
+module.exports = async (instance = {}, o, notification) => {
   const { state = {}, h = {} } = instance
   const { gid, args = {}, orders = {} } = state
-  const { emit, debug } = h
+  const { emit, debug, notifyUI } = h
   const { cancelDelay } = args
+  const { text } = notification
 
   debug('received minimum size error for order: %f @ %f', o.amountOrig, o.price)
   debug('stopping order...')
 
-  await emit('exec:order:cancel:all', gid, orders, cancelDelay)
-  await emit('exec:stop')
+  await notifyUI('error', text)
+
+  await emit('exec:stop', async () => {
+    await delay(TEARDOWN_GRACE_PERIOD_MS)
+    await emit('exec:order:cancel:all', gid, orders, cancelDelay)
+  })
 }

--- a/lib/default_handlers/orders_order_error.js
+++ b/lib/default_handlers/orders_order_error.js
@@ -1,5 +1,10 @@
 'use strict'
 
+const delay = require('../util/delay')
+
+// How long orders are allowed to settle for before teardown
+const TEARDOWN_GRACE_PERIOD_MS = 1 * 1000
+
 /**
  * @param {Object} instance
  */
@@ -12,6 +17,8 @@ module.exports = async (instance = {}) => {
   debug('receive generic order error event')
   debug('stopping order...')
 
-  await emit('exec:order:cancel:all', gid, orders, cancelDelay)
-  await emit('exec:stop')
+  await emit('exec:stop', async () => {
+    await delay(TEARDOWN_GRACE_PERIOD_MS)
+    await emit('exec:order:cancel:all', gid, orders, cancelDelay)
+  })
 }

--- a/lib/host/events/stop.js
+++ b/lib/host/events/stop.js
@@ -1,0 +1,32 @@
+'use strict'
+
+const _isFunction = require('lodash/isFunction')
+
+/**
+ * Stops execution of an algo order, and deletes it
+ *
+ * @param {Object} aoHost
+ * @param {string} gid - AO instance GID to operate on
+ * @param {Function?} onCleanup - called before the instance is destroyed
+ */
+module.exports = async (aoHost, gid, onCleanup) => {
+  const inst = aoHost.instances[gid]
+
+  if (!inst) { // instance may have already stopped
+    return
+  }
+
+  // Prevent further AO operations, but allow order cancellations
+  inst.state.ev.removeAllListeners(/exec:order:cancel/, true)
+
+  // Handle AO-specific cleanup tasks
+  if (_isFunction(onCleanup)) {
+    await onCleanup()
+  }
+
+  // Let the host teardown (unsubs from channels, persists, etc)
+  await aoHost.emit('ao:stop', inst)
+
+  // implode
+  delete aoHost.instances[gid]
+}

--- a/lib/host/init_ao_state.js
+++ b/lib/host/init_ao_state.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { nonce } = require('bfx-api-node-util')
+const clientID = require('../util/gen_client_id')
 const _isFunction = require('lodash/isFunction')
 const AsyncEventEmitter = require('../async_event_emitter')
 
@@ -31,7 +31,7 @@ module.exports = (aoDef = {}, args = {}) => {
     ? initState(params)
     : {}
 
-  const gid = nonce() + ''
+  const gid = clientID() + ''
 
   return {
     channels: [],

--- a/lib/iceberg/util/generate_orders.js
+++ b/lib/iceberg/util/generate_orders.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { Order } = require('bfx-api-node-models')
-const { nonce } = require('bfx-api-node-util')
+const genCID = require('../../util/gen_client_id')
 const { Config } = require('bfx-api-node-core')
 const { DUST } = Config
 
@@ -39,7 +39,7 @@ module.exports = (state = {}) => {
     ) {
       orders.push(new Order({
         ...sharedOrderParams,
-        cid: nonce(),
+        cid: genCID(),
         type: orderType,
         amount: rem,
         hidden: true
@@ -49,7 +49,7 @@ module.exports = (state = {}) => {
 
   orders.push(new Order({
     ...sharedOrderParams,
-    cid: nonce(),
+    cid: genCID(),
     type: orderType,
     amount: sliceOrderAmount
   }))

--- a/lib/ococo/util/generate_initial_order.js
+++ b/lib/ococo/util/generate_initial_order.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { Order } = require('bfx-api-node-models')
-const { nonce } = require('bfx-api-node-util')
+const genCID = require('../../util/gen_client_id')
 
 module.exports = (instance = {}) => {
   const { state = {} } = instance
@@ -25,14 +25,14 @@ module.exports = (instance = {}) => {
   if (orderType === 'MARKET') {
     return new Order({
       ...sharedOrderParams,
-      cid: nonce(),
+      cid: genCID(),
       type: _margin || _futures ? 'MARKET' : 'EXCHANGE MARKET'
     })
   } else if (orderType === 'LIMIT') {
     return new Order({
       ...sharedOrderParams,
       price: +orderPrice,
-      cid: nonce(),
+      cid: genCID(),
       type: _margin || _futures ? 'LIMIT' : 'EXCHANGE LIMIT'
     })
   } else {

--- a/lib/ococo/util/generate_oco_order.js
+++ b/lib/ococo/util/generate_oco_order.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { Order } = require('bfx-api-node-models')
-const { nonce } = require('bfx-api-node-util')
+const genCID = require('../../util/gen_client_id')
 
 module.exports = (instance = {}) => {
   const { state = {} } = instance
@@ -11,7 +11,7 @@ module.exports = (instance = {}) => {
     _margin, _futures
   } = args
 
-  const cid = nonce()
+  const cid = genCID()
   const sharedOrderParams = {
     symbol,
     amount: ocoAmount

--- a/lib/ping_pong/events/life_start.js
+++ b/lib/ping_pong/events/life_start.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { nonce } = require('bfx-api-node-util')
+const genCID = require('../../util/gen_client_id')
 const { Order } = require('bfx-api-node-models')
 const _isEmpty = require('lodash/isEmpty')
 
@@ -28,7 +28,7 @@ module.exports = async (instance = {}) => {
       ...sharedOrderParams,
 
       price,
-      cid: nonce(),
+      cid: genCID(),
       type: _margin || _futures ? Order.type.LIMIT : Order.type.EXCHANGE_LIMIT,
       amount: pingAmount
     })
@@ -47,7 +47,7 @@ module.exports = async (instance = {}) => {
       ...sharedOrderParams,
 
       price,
-      cid: nonce(),
+      cid: genCID(),
       type: _margin || _futures ? Order.type.LIMIT : Order.type.EXCHANGE_LIMIT,
       amount: -pongAmount
     })

--- a/lib/ping_pong/events/orders_order_fill.js
+++ b/lib/ping_pong/events/orders_order_fill.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { Order } = require('bfx-api-node-models')
-const { nonce } = require('bfx-api-node-util')
+const genCID = require('../../util/gen_client_id')
 const { Config } = require('bfx-api-node-core')
 const { DUST } = Config
 
@@ -61,7 +61,7 @@ module.exports = async (instance = {}, order) => {
           ...sharedOrderParams,
 
           price: pingPrice,
-          cid: nonce(),
+          cid: genCID(),
           type: _margin || _futures ? Order.type.LIMIT : Order.type.EXCHANGE_LIMIT,
           amount: pingAmount
         })
@@ -83,7 +83,7 @@ module.exports = async (instance = {}, order) => {
     ...sharedOrderParams,
 
     price: pongPrice,
-    cid: nonce(),
+    cid: genCID(),
     type: _margin || _futures ? Order.type.LIMIT : Order.type.EXCHANGE_LIMIT,
     amount: -pongAmount
   })

--- a/lib/ping_pong/meta/gen_preview.js
+++ b/lib/ping_pong/meta/gen_preview.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { nonce } = require('bfx-api-node-util')
+const genCID = require('../../util/gen_client_id')
 const { Order } = require('bfx-api-node-models')
 const genPingPongTable = require('../util/gen_ping_pong_table')
 
@@ -15,7 +15,7 @@ module.exports = (args = {}) => {
     orders.push(new Order({
       symbol,
       price,
-      cid: nonce(),
+      cid: genCID(),
       type: _margin ? Order.type.LIMIT : Order.type.EXCHANGE_LIMIT,
       amount: pingAmount,
       hidden
@@ -28,7 +28,7 @@ module.exports = (args = {}) => {
     orders.push(new Order({
       symbol,
       price,
-      cid: nonce(),
+      cid: genCID(),
       type: _margin ? Order.type.LIMIT : Order.type.EXCHANGE_LIMIT,
       amount: -pongAmount,
       hidden

--- a/lib/twap/util/generate_order.js
+++ b/lib/twap/util/generate_order.js
@@ -2,7 +2,7 @@
 
 const _isString = require('lodash/isString')
 const { Order } = require('bfx-api-node-models')
-const { nonce } = require('bfx-api-node-util')
+const genCID = require('../../util/gen_client_id')
 const { Config } = require('bfx-api-node-core')
 const { DUST } = Config
 
@@ -32,7 +32,7 @@ module.exports = (state = {}, price) => {
 
   return new Order({
     ...baseOrderParams,
-    cid: nonce(),
+    cid: genCID(),
     amount: rem,
     type: _isString(orderType)
       ? orderType

--- a/lib/util/delay.js
+++ b/lib/util/delay.js
@@ -1,0 +1,13 @@
+'use strict'
+
+const Promise = require('bluebird')
+
+/**
+ * Resolves after a specified number of millisecondso
+ *
+ * @param {number} ms
+ * @return {Promise} p
+ */
+module.exports = async (ms) => {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}

--- a/lib/util/delay.js
+++ b/lib/util/delay.js
@@ -3,7 +3,7 @@
 const Promise = require('bluebird')
 
 /**
- * Resolves after a specified number of millisecondso
+ * Resolves after a specified number of milliseconds
  *
  * @param {number} ms
  * @return {Promise} p

--- a/lib/util/gen_client_id.js
+++ b/lib/util/gen_client_id.js
@@ -1,0 +1,7 @@
+'use strict'
+
+let last = Date.now()
+
+module.exports = () => {
+  return last++
+}

--- a/lib/util/gen_client_id.js
+++ b/lib/util/gen_client_id.js
@@ -3,5 +3,7 @@
 let last = Date.now()
 
 module.exports = () => {
-  return last++
+  const now = Date.now()
+  last = (last < now) ? now : last + 1
+  return last
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-hf-algo",
-  "version": "2.0.10",
+  "version": "2.0.11",
   "description": "HF Algorithmic Order Module",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
### Description:
Switches OCOCO onto the internal CID generation function, and adds an `onCleanup` parameter to the `'exec:stop'` AO host event, allowing callers to wrap up their work before the AO instance is imploded.

### New features:
- [x] `exec:stop` now supports an `onCleanup` callback, must return promise

### Fixes:
- [x] OCOCO cid generation
- [x] generic error handler race condition (multiple orders submitted, 1st triggers error, rest are not cancelled)

### PR status:
- [x] Version bumped
- [x] Change-log updated
- [ ] Tests added or updated
- [ ] Documentation updated
