### PR TITLE
Feature: Add AOhost getAdapter(), bump to 2.0.10

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+# 2.0.10
+- feature: add AOHost getAdapter()
+
 # 2.0.9
 - meta: bump bitfinex-api-node to v4
 

--- a/lib/ao_host.js
+++ b/lib/ao_host.js
@@ -85,6 +85,10 @@ class AOHost extends AsyncEventEmitter {
     })
   }
 
+  getAdapter () {
+    return this.adapter
+  }
+
   reconnect () {
     this.adapter.reconnect()
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-hf-algo",
-  "version": "2.0.9",
+  "version": "2.0.10",
   "description": "HF Algorithmic Order Module",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
### Description:
Adds a `getAdapter()` func to `AOHost`

### New features:
- [x] AOHost `getAdapter()`

### PR status:
- [x] Version bumped
- [x] Change-log updated
- [ ] Tests added or updated
- [ ] Documentation updated
