### PR TITLE
Fix: Use relative paths to allow generic mocha execution  2.0.12

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,5 @@
 # 2.0.12
-- fix: refactor tests so they can run alongside all other HF/API library tests
+- fix: use relative paths to allow generic mocha execution
 
 # 2.0.11
 - meta: bump bitfinex-api-node to v4

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+# 2.0.12
+- fix: refactor tests so they can run alongside all other HF/API library tests
+
 # 2.0.11
 - meta: bump bitfinex-api-node to v4
 

--- a/lib/testing/create_harness.js
+++ b/lib/testing/create_harness.js
@@ -2,7 +2,7 @@
 
 const _get = require('lodash/get')
 const _isFunction = require('lodash/isFunction')
-const AsyncEventEmitter = require('async_event_emitter')
+const AsyncEventEmitter = require('../async_event_emitter')
 const debug = require('debug')('bfx:hf:algo:testing:harness')
 
 module.exports = (instance = {}, aoDef = {}) => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-hf-algo",
-  "version": "2.0.11",
+  "version": "2.0.12",
   "description": "HF Algorithmic Order Module",
   "main": "index.js",
   "directories": {

--- a/test/iceberg/events/life_start.js
+++ b/test/iceberg/events/life_start.js
@@ -3,7 +3,7 @@
 
 const assert = require('assert')
 const Promise = require('bluebird')
-const onLifeStart = require('iceberg/events/life_start')
+const onLifeStart = require('../../../lib/iceberg/events/life_start')
 
 describe('iceberg:events:life_start', () => {
   it('submits orders on startup', (done) => {

--- a/test/iceberg/events/life_stop.js
+++ b/test/iceberg/events/life_stop.js
@@ -3,7 +3,7 @@
 
 const assert = require('assert')
 const Promise = require('bluebird')
-const onLifeStop = require('iceberg/events/life_stop')
+const onLifeStop = require('../../../lib/iceberg/events/life_stop')
 
 describe('iceberg:events:life_stop', () => {
   it('submits all known orders for cancellation', (done) => {

--- a/test/iceberg/events/orders_order_cancel.js
+++ b/test/iceberg/events/orders_order_cancel.js
@@ -2,7 +2,7 @@
 'use strict'
 
 const assert = require('assert')
-const onOrderCancel = require('iceberg/events/orders_order_cancel')
+const onOrderCancel = require('../../../lib/iceberg/events/orders_order_cancel')
 
 describe('iceberg:events:orders_order_cancel', () => {
   it('submits all known orders for cancellation & stops operation', (done) => {

--- a/test/iceberg/events/orders_order_fill.js
+++ b/test/iceberg/events/orders_order_fill.js
@@ -3,7 +3,7 @@
 
 const assert = require('assert')
 const Promise = require('bluebird')
-const onOrderFill = require('iceberg/events/orders_order_fill')
+const onOrderFill = require('../../../lib/iceberg/events/orders_order_fill')
 
 describe('iceberg:events:orders_order_fill', () => {
   const orderState = { 1: 'some_order_object' }

--- a/test/iceberg/events/self_submit_orders.js
+++ b/test/iceberg/events/self_submit_orders.js
@@ -3,7 +3,7 @@
 
 const Promise = require('bluebird')
 const assert = require('assert')
-const onSubmitOrders = require('iceberg/events/self_submit_orders')
+const onSubmitOrders = require('../../../lib/iceberg/events/self_submit_orders')
 
 describe('iceberg:events:self_submit_orders', () => {
   it('submits generated orders', (done) => {

--- a/test/iceberg/index.js
+++ b/test/iceberg/index.js
@@ -2,10 +2,10 @@
 'use strict'
 
 const assert = require('assert')
-const Iceberg = require('iceberg')
+const Iceberg = require('../../lib/iceberg')
 const { AOAdapter } = require('bfx-hf-ext-plugin-bitfinex')
-const initAO = require('host/init_ao')
-const createTestHarness = require('testing/create_harness')
+const initAO = require('../../lib/host/init_ao')
+const createTestHarness = require('../../lib/testing/create_harness')
 
 const adapter = new AOAdapter({})
 const params = {

--- a/test/iceberg/meta/init_state.js
+++ b/test/iceberg/meta/init_state.js
@@ -2,7 +2,7 @@
 'use strict'
 
 const assert = require('assert')
-const initState = require('iceberg/meta/init_state')
+const initState = require('../../../lib/iceberg/meta/init_state')
 
 describe('iceberg:meta:init_state', () => {
   it('sets initial remainingAmount', () => {

--- a/test/iceberg/meta/process_params.js
+++ b/test/iceberg/meta/process_params.js
@@ -3,7 +3,7 @@
 
 const assert = require('assert')
 const _isFinite = require('lodash/isFinite')
-const processParams = require('iceberg/meta/process_params')
+const processParams = require('../../../lib/iceberg/meta/process_params')
 
 describe('iceberg:meta:process_params', () => {
   it('adds EXCHANGE prefix for non-margin order types', () => {

--- a/test/iceberg/meta/validate_params.js
+++ b/test/iceberg/meta/validate_params.js
@@ -3,7 +3,7 @@
 
 const assert = require('assert')
 const _isString = require('lodash/isString')
-const validateParams = require('iceberg/meta/validate_params')
+const validateParams = require('../../../lib/iceberg/meta/validate_params')
 
 const validParams = {
   price: 1000,

--- a/test/iceberg/util/generate_orders.js
+++ b/test/iceberg/util/generate_orders.js
@@ -3,7 +3,7 @@
 
 const assert = require('assert')
 const _isFinite = require('lodash/isFinite')
-const generateOrders = require('iceberg/util/generate_orders')
+const generateOrders = require('../../../lib/iceberg/util/generate_orders')
 const { Config } = require('bfx-api-node-core')
 const { DUST } = Config
 

--- a/test/twap/events/data_managed_book.js
+++ b/test/twap/events/data_managed_book.js
@@ -3,8 +3,8 @@
 
 const assert = require('assert')
 const Promise = require('bluebird')
-const onDataManagedBook = require('twap/events/data_managed_book')
-const Config = require('twap/config')
+const onDataManagedBook = require('../../../lib/twap/events/data_managed_book')
+const Config = require('../../../lib/twap/config')
 
 const args = {
   symbol: 'tBTCUSD',

--- a/test/twap/events/data_trades.js
+++ b/test/twap/events/data_trades.js
@@ -3,8 +3,8 @@
 
 const assert = require('assert')
 const Promise = require('bluebird')
-const onDataTrades = require('twap/events/data_trades')
-const Config = require('twap/config')
+const onDataTrades = require('../../../lib/twap/events/data_trades')
+const Config = require('../../../lib/twap/config')
 
 const args = {
   symbol: 'tBTCUSD',

--- a/test/twap/events/life_start.js
+++ b/test/twap/events/life_start.js
@@ -3,8 +3,8 @@
 
 const assert = require('assert')
 const Promise = require('bluebird')
-const onLifeStart = require('twap/events/life_start')
-const Config = require('twap/config')
+const onLifeStart = require('../../../lib/twap/events/life_start')
+const Config = require('../../../lib/twap/config')
 
 describe('twap:events:life_start', () => {
   it('sets up interval & saves it on state', (done) => {

--- a/test/twap/events/life_stop.js
+++ b/test/twap/events/life_stop.js
@@ -1,7 +1,7 @@
 /* eslint-env mocha */
 'use strict'
 
-const onLifeStop = require('twap/events/life_stop')
+const onLifeStop = require('../../../lib/twap/events/life_stop')
 
 describe('twap:events:life_stop', () => {
   it('sets up interval & saves it on state', (done) => {

--- a/test/twap/events/orders_order_cancel.js
+++ b/test/twap/events/orders_order_cancel.js
@@ -2,7 +2,7 @@
 'use strict'
 
 const assert = require('assert')
-const onOrderCancel = require('twap/events/orders_order_cancel')
+const onOrderCancel = require('../../../lib/twap/events/orders_order_cancel')
 
 describe('twap:events:orders_order_cancel', () => {
   it('submits all known orders for cancellation & stops operation', (done) => {

--- a/test/twap/events/orders_order_fill.js
+++ b/test/twap/events/orders_order_fill.js
@@ -3,7 +3,7 @@
 
 const assert = require('assert')
 const Promise = require('bluebird')
-const onOrderFill = require('twap/events/orders_order_fill')
+const onOrderFill = require('../../../lib/twap/events/orders_order_fill')
 
 describe('twap:events:orders_order_fill', () => {
   const orderState = { 1: 'some_order_object' }

--- a/test/twap/events/self_interval_tick.js
+++ b/test/twap/events/self_interval_tick.js
@@ -4,8 +4,8 @@
 const assert = require('assert')
 const Promise = require('bluebird')
 const _isObject = require('lodash/isObject')
-const onIntervalTick = require('twap/events/self_interval_tick')
-const Config = require('twap/config')
+const onIntervalTick = require('../../../lib/twap/events/self_interval_tick')
+const Config = require('../../../lib/twap/config')
 
 const args = {
   priceTarget: 1000,

--- a/test/twap/meta/init_state.js
+++ b/test/twap/meta/init_state.js
@@ -2,7 +2,7 @@
 'use strict'
 
 const assert = require('assert')
-const initState = require('twap/meta/init_state')
+const initState = require('../../../lib/twap/meta/init_state')
 
 describe('twap:meta:init_state', () => {
   it('sets initial remainingAmount', () => {

--- a/test/twap/meta/process_params.js
+++ b/test/twap/meta/process_params.js
@@ -3,7 +3,7 @@
 
 const assert = require('assert')
 const _isFinite = require('lodash/isFinite')
-const processParams = require('twap/meta/process_params')
+const processParams = require('../../../lib/twap/meta/process_params')
 
 describe('twap:meta:process_params', () => {
   it('adds EXCHANGE prefix for non-margin order types', () => {

--- a/test/twap/meta/validate_params.js
+++ b/test/twap/meta/validate_params.js
@@ -3,7 +3,7 @@
 
 const assert = require('assert')
 const _isString = require('lodash/isString')
-const validateParams = require('twap/meta/validate_params')
+const validateParams = require('../../../lib/twap/meta/validate_params')
 
 const validParams = {
   orderType: 'LIMIT',


### PR DESCRIPTION
### Fixes:
- [x] use relative paths in tests

### PR status:
- [x] Version bumped
- [x] Change-log updated
- [ ] Tests added or updated
- [ ] Documentation updated
