### PR TITLE
Feature: Add AO host helper call traces to log output if DEBUG_TRACE 2.0.13

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+# 2.0.13
+- feature: add AO host helper call traces to log output if DEBUG_TRACE
+
 # 2.0.12
 - fix: use relative paths to allow generic mocha execution
 

--- a/lib/host/gen_helpers.js
+++ b/lib/host/gen_helpers.js
@@ -16,6 +16,16 @@ const MAX_SUBMIT_ATTEMPTS = 10
 module.exports = (state = {}, adapter) => {
   const { id, gid } = state
   const debug = Debug(`bfx:hf:algo:${id}:${gid}`)
+  const logHelperCall = (fmt, ...data) => {
+    const { DEBUG_TRACE } = process.env
+
+    if (DEBUG_TRACE) {
+      const { stack } = new Error()
+      debug(`${fmt} [%s]`, ...data, stack.split('\n')[3].trim())
+    } else {
+      debug(fmt, ...data)
+    }
+  }
 
   return {
 
@@ -38,7 +48,7 @@ module.exports = (state = {}, adapter) => {
      * @param {...any} eventArgs
      */
     emitSelf: async (eventName, ...eventArgs) => {
-      debug('emit self:%s', eventName)
+      logHelperCall('emitSelf: %s', eventName)
       await state.ev.emit(`self:${eventName}`, ...eventArgs)
     },
 
@@ -51,7 +61,7 @@ module.exports = (state = {}, adapter) => {
     emitSelfAsync: async (eventName, ...eventArgs) => {
       return new Promise((resolve, reject) => {
         setTimeout(() => {
-          debug('emit self:%s', eventName)
+          logHelperCall('emitSelfAsync: %s', eventName)
 
           state.ev
             .emit(`self:${eventName}`, ...eventArgs)
@@ -70,7 +80,7 @@ module.exports = (state = {}, adapter) => {
      * @param {...any} eventArgs
      */
     emit: async (eventName, ...eventArgs) => {
-      debug('emit %s', eventName)
+      logHelperCall('emit %s', eventName)
       await state.ev.emit(eventName, ...eventArgs)
     },
 
@@ -83,7 +93,7 @@ module.exports = (state = {}, adapter) => {
     emitAsync: async (eventName, ...eventArgs) => {
       return new Promise((resolve, reject) => {
         setTimeout(() => {
-          debug('emit %s', eventName)
+          logHelperCall('emitAsync %s', eventName)
 
           state.ev
             .emit(eventName, ...eventArgs)
@@ -102,7 +112,7 @@ module.exports = (state = {}, adapter) => {
      * @param {string} message - notification content
      */
     notifyUI: async (level, message) => {
-      debug('notify %s: %s', level, message)
+      logHelperCall('notify %s: %s', level, message)
       await state.ev.emit('notify', gid, level, message)
     },
 
@@ -116,9 +126,11 @@ module.exports = (state = {}, adapter) => {
      * @return {Object} nextState
      */
     cancelOrderWithDelay: async (state = {}, delay, order) => {
+      logHelperCall('cancelOrderWithDelay (%dms): %s', delay, order.toString())
+
       const { connection, orders = {} } = state
       const {
-        [order.cid + '']: knownOrder,
+        [order.cid + '']: knownOrder, // eslint-disable-line
         ...otherOrders
       } = orders
 
@@ -143,10 +155,16 @@ module.exports = (state = {}, adapter) => {
      * @return {Object} nextState
      */
     cancelAllOrdersWithDelay: async (state = {}, delay) => {
-      const { orders = {}, connection } = state
+      const { orders: orderMap = {}, connection } = state
+      const orders = Object.keys(orderMap)
+
+      logHelperCall(
+        'cancelAllOrdersWithDelay (%dms): %d orders',
+        delay, orders.length
+      )
 
       // NOTE: No await, in order to update cancelled order set immediately
-      PI.map(Object.values(orders), async (o) => {
+      PI.map(orders, async (o) => {
         return adapter.cancelOrderWithDelay(connection, delay, o)
       })
 
@@ -156,7 +174,7 @@ module.exports = (state = {}, adapter) => {
         orders: {},
         cancelledOrders: {
           ...state.cancelledOrders,
-          ...orders
+          ...orderMap
         }
       }
     },
@@ -173,6 +191,11 @@ module.exports = (state = {}, adapter) => {
      * @return {Object} nextState
      */
     submitOrderWithDelay: async (state = {}, delay, o, attempt = 1) => {
+      logHelperCall(
+        'submitOrderWithDelay (%dms, attempt %d): %s',
+        delay, attempt, o.toString()
+      )
+
       if (attempt > MAX_SUBMIT_ATTEMPTS) { // note state assumed already patched
         return state
       }
@@ -240,6 +263,8 @@ module.exports = (state = {}, adapter) => {
       const { ev } = state
       const handler = aoHost.onAOSelfEvent.bind(aoHost, instance, path)
 
+      logHelperCall('declareEvent: %s target %s', eventName, path)
+
       ev.on(eventName, handler)
     },
 
@@ -259,6 +284,11 @@ module.exports = (state = {}, adapter) => {
       const { gid } = state
       const { emit } = h
 
+      logHelperCall(
+        'declareChannel: %s filter %s', channel,
+        Object.keys(filter).map(k => `${k}=${filter[k]}`).join(', ')
+      )
+
       await emit('channel:assign', gid, channel, filter)
 
       return instance.state // updated ref
@@ -275,6 +305,8 @@ module.exports = (state = {}, adapter) => {
       const { h = {}, state = {} } = instance
       const { gid } = state
       const { emit } = h
+
+      logHelperCall('updateState: %o', update)
 
       await emit('state:update', gid, update)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-hf-algo",
-  "version": "2.0.12",
+  "version": "2.0.13",
   "description": "HF Algorithmic Order Module",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
### Description:
If the env var `DEBUG_TRACE` is truth-ey, AOHost helpers will log the caller's location alongside the usual message.

Also added logging to helpers that didn't have it before. Can be verbose, hence it's hidden behind an env var.

### New features:
- [x] `AOHost` helper call traces

### PR status:
- [x] Version bumped
- [x] Change-log updated
- [ ] Tests added or updated
- [ ] Documentation updated
