### PR TITLE
Feature: Cancel known atomics on AO load, 2.0.14

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+# 2.0.14
+- feature: AO host now cancels AO orders in snapshot before restoring on load
+
 # 2.0.13
 - feature: add AO host helper call traces to log output if DEBUG_TRACE
 

--- a/lib/ao_host.js
+++ b/lib/ao_host.js
@@ -77,7 +77,8 @@ class AOHost extends AsyncEventEmitter {
 
     bindWS2Bus(this)
 
-    this.once('auth:success', () => {
+    this.adapter.once('order:snapshot', (snapshot) => {
+      this.orderSnapshot = snapshot
       this.loadAllAOs().then(() => {
         debug('loaded all known algorithmic orders')
       }).catch((err) => {
@@ -367,6 +368,15 @@ class AOHost extends AsyncEventEmitter {
 
     if (_isFunction(declareChannels)) {
       await declareChannels(this.instances[gid], this)
+    }
+
+    // Cancel existing orders
+    for (let i = 0; i < this.orderSnapshot.length; i += 1) {
+      if (this.orderSnapshot[i].gid === +gid) {
+        await this.adapter.cancelOrderWithDelay(
+          state.connection, 0, this.orderSnapshot[i]
+        )
+      }
     }
 
     await this.emit('ao:start', this.instances[gid])

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-hf-algo",
-  "version": "2.0.13",
+  "version": "2.0.14",
   "description": "HF Algorithmic Order Module",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
### Description:
When loading an AO, the host now cancels orders received in the snapshot that have the same GID as the AO being loaded.

Therefore, one can now safely run algo orders without the DMS flag enabled.

### New features:
- [x] AO Host now cancels known atomics on AO load

### PR status:
- [x] Version bumped
- [x] Change-log updated
- [ ] Tests added or updated
- [ ] Documentation updated
