### PR TITLE
ping_pong/get_ui_def: set default to int and not string

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+# 2.1.1
+- Ping/Pong: change default orderCount from string to number
+
 # 2.1.0
 - meta: switch to nyc for coverage and set/enforce limits
 - meta: add husky pre-commit test hook

--- a/lib/ping_pong/meta/get_ui_def.js
+++ b/lib/ping_pong/meta/get_ui_def.js
@@ -169,7 +169,7 @@ const getUIDef = () => ({
     orderCount: {
       component: 'input.number',
       label: 'Order Count',
-      default: '1'
+      default: 1
     },
 
     lev: {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-hf-algo",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "HF Algorithmic Order Module",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
### Description:
Linked to this issue: https://github.com/bitfinexcom/bfx-hf-ui/issues/171

The ping/pong order form was not displaying the ping/pong price input fields by default. This is because the default orderCount is currently set to a string.

### Breaking changes:
None

### New features:
None

### Fixes:
- [x] Fixes https://github.com/bitfinexcom/bfx-hf-ui/issues/171

### PR status:
- [x] Version bumped
- [x] Change-log updated
