### PR TITLE
fix: NaN value for market orders

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+# 2.2.2
+
+- fix: log output: NaN value for generated market orders (OCOCO / MA Crossover)
+- fix: log output: NaN value for submitted market orders
+
 # 2.1.1
 - Ping/Pong: change default orderCount from string to number
 

--- a/lib/host/events/submit_all_orders.js
+++ b/lib/host/events/submit_all_orders.js
@@ -47,8 +47,8 @@ module.exports = async (aoHost, gid, orders, delay) => {
       o.meta._HF = 1
 
       debug(
-        'submitting order %s %f @ %f [gid %d]',
-        o.type, o.amount, o.price, o.cid, o.gid
+        'submitting order %s %f @ %s [gid %d]',
+        o.type, o.amount, o.price || 'MARKET', o.cid, o.gid
       )
 
       nextState = await submitOrderWithDelay(nextState, delay, o)

--- a/lib/ma_crossover/events/self_submit_order.js
+++ b/lib/ma_crossover/events/self_submit_order.js
@@ -20,7 +20,7 @@ const onSelfSubmitOrder = async (instance = {}) => {
   const order = generateOrder(instance)
 
   debug(
-    'generated order %s for %f @ %f',
+    'generated order %s for %f @ %s',
     order.type, order.amount, order.price || 'MARKET'
   )
 

--- a/lib/ococo/events/self_submit_initial_order.js
+++ b/lib/ococo/events/self_submit_initial_order.js
@@ -24,7 +24,7 @@ const onSelfSubmitInitialOrder = async (instance = {}) => {
   const order = generateInitialOrder(instance)
 
   debug(
-    'generated order %s for %f @ %f',
+    'generated order %s for %f @ %s',
     order.type, order.amount, order.price || 'MARKET'
   )
 

--- a/lib/ococo/events/self_submit_oco_order.js
+++ b/lib/ococo/events/self_submit_oco_order.js
@@ -24,7 +24,7 @@ const onSelfSubmitOCOOrder = async (instance = {}) => {
   const order = generateOCOOrder(instance)
 
   debug(
-    'generated order %s for %f @ %f',
+    'generated order %s for %f @ %s',
     order.type, order.amount, order.price || 'MARKET'
   )
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-hf-algo",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "HF Algorithmic Order Module",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
logged output was casted to NaN for market orders. this fix works for both

### Description:
...

### Breaking changes:
- [ ]

### New features:
- [ ]

### Fixes:
- [x] logged output was casted to NaN for market orders. this fix works for both


### PR status:
- [x] Version bumped
- [x] Change-log updated
- [ ] Tests added or updated
- [ ] Documentation updated
