### PR TITLE
ma: fix SMA algo orders

### DIFF
--- a/lib/ma_crossover/events/life_start.js
+++ b/lib/ma_crossover/events/life_start.js
@@ -19,11 +19,14 @@ const onLifeStart = async (instance = {}) => {
 
   debug(
     'starting with long %s(%d) and short %s(%d)',
-    long.type.toUpperCase, long.args[0], short.type.toUpperCase(), short.args[0]
+    long.type.toUpperCase(), long.args[0], short.type.toUpperCase(), short.args[0]
   )
 
-  const LongIndicatorClass = HFI[long.type.toUpperCase()]
-  const ShortIndicatorClass = HFI[short.type.toUpperCase()]
+  const typeL = long.type.toUpperCase() === 'MA' ? 'SMA' : long.type.toUpperCase()
+  const typeS = short.type.toUpperCase() === 'MA' ? 'SMA' : short.type.toUpperCase()
+
+  const LongIndicatorClass = HFI[typeL]
+  const ShortIndicatorClass = HFI[typeS]
 
   const longIndicator = new LongIndicatorClass(long.args)
   const shortIndicator = new ShortIndicatorClass(long.args)


### PR DESCRIPTION
fixes:

```
bfx:hf:server:ws-server:algos error starting AO bfx-ma_crossover
for bitfinex: TypeError: ShortIndicatorClass is not a constructor
```

when `MA` was selected in the UI for the algo order type

additionally fixes the log output for the indicator class

how to reproduce:

1. in the ui, select a MA algo order
2. select the type `MA`
3. set periods
4. click submit, oder submit fails