### PR TITLE
ping/pong: fix forms when ordercount was changed

### DIFF
--- a/lib/ping_pong/meta/get_ui_def.js
+++ b/lib/ping_pong/meta/get_ui_def.js
@@ -47,7 +47,7 @@ const getUIDef = () => ({
     ],
 
     visible: {
-      orderCount: { eq: 1 }
+      orderCount: { eq: '1' }
     }
   }, {
     title: '',
@@ -169,7 +169,7 @@ const getUIDef = () => ({
     orderCount: {
       component: 'input.number',
       label: 'Order Count',
-      default: 1
+      default: '1'
     },
 
     lev: {


### PR DESCRIPTION
steps to reproduce:

1. open the ping/pong order form
2. in order count, set value to 2
3. set it back to 1
4. there is no price field any more
5. resulting order after a submit has a price of '0'

the ui submits always strings, and the `eq` operator in the
form framework uses a strict equal comparision.

fixes: https://github.com/bitfinexcom/bfx-hf-ui/issues/171
