### PR TITLE
allow post-only limit orders in accumulate/distribute algo

### DIFF
--- a/lib/accumulate_distribute/meta/gen_preview.js
+++ b/lib/accumulate_distribute/meta/gen_preview.js
@@ -19,7 +19,7 @@ const genOrderAmounts = require('../util/gen_order_amounts')
 const genPreview = (args = {}) => {
   const {
     symbol, sliceInterval, intervalDistortion, _margin, orderType, limitPrice,
-    hidden
+    hidden, postonly
   } = args
 
   const orderAmounts = genOrderAmounts(args)
@@ -39,6 +39,7 @@ const genPreview = (args = {}) => {
         symbol,
         amount,
         hidden,
+        postonly,
         price: limitPrice,
         cid: genCID(),
         type: _margin ? 'LIMIT' : 'EXCHANGE LIMIT'

--- a/lib/accumulate_distribute/meta/get_ui_def.js
+++ b/lib/accumulate_distribute/meta/get_ui_def.js
@@ -136,12 +136,14 @@ const getUIDef = () => ({
       component: 'input.checkbox',
       label: 'Post-Only',
       default: false,
-      customHelp: 'trading.postonlyorder_tooltip',
+      customHelp: `"Post Only" limit orders are orders that allow you to be sure to always pay the maker fee.
+      When placed, a "Post Only" limit order is either inserted into the orderbook or cancelled and not matched
+      with a pre-existing order`,
       disabled: {
         orderType: { neq: 'LIMIT' }
       }
     },
-    
+
     catchUp: {
       component: 'input.checkbox',
       label: 'Catch Up',

--- a/lib/accumulate_distribute/meta/get_ui_def.js
+++ b/lib/accumulate_distribute/meta/get_ui_def.js
@@ -30,7 +30,7 @@ const getUIDef = () => ({
 
   header: {
     component: 'ui.checkbox_group',
-    fields: ['catchUp', 'awaitFill', 'hidden']
+    fields: ['catchUp', 'awaitFill', 'hidden', 'postonly']
   },
 
   sections: [{
@@ -132,6 +132,16 @@ const getUIDef = () => ({
 
   fields: {
     // General section/header
+    postonly: {
+      component: 'input.checkbox',
+      label: 'Post-Only',
+      default: false,
+      customHelp: 'trading.postonlyorder_tooltip',
+      disabled: {
+        orderType: { neq: 'LIMIT' }
+      }
+    },
+    
     catchUp: {
       component: 'input.checkbox',
       label: 'Catch Up',

--- a/lib/accumulate_distribute/meta/process_params.js
+++ b/lib/accumulate_distribute/meta/process_params.js
@@ -38,6 +38,10 @@ const processParams = (data) => {
     params.intervalDistortion = 0
   }
 
+  if (params.orderType !== 'LIMIT') {
+    params.postonly = false
+  }
+
   if (params.orderType === 'RELATIVE') {
     params.relativeOffset = {
       type: params.offsetType.toLowerCase(),

--- a/lib/accumulate_distribute/meta/validate_params.js
+++ b/lib/accumulate_distribute/meta/validate_params.js
@@ -50,7 +50,7 @@ const validateParams = (args = {}, pairConfig = {}) => {
   const {
     limitPrice, amount, sliceAmount, orderType,
     intervalDistortion, amountDistortion, sliceInterval, relativeOffset,
-    relativeCap, catchUp, awaitFill, lev, _futures
+    relativeCap, catchUp, awaitFill, postonly, lev, _futures
   } = args
 
   if (!_includes(ORDER_TYPES, orderType)) return validationErrObj('orderType', `Invalid order type: ${orderType}`)
@@ -75,6 +75,9 @@ const validateParams = (args = {}, pairConfig = {}) => {
 
   if (orderType === 'LIMIT' && !_isFinite(limitPrice)) {
     return validationErrObj('limitPrice', 'Limit price required for LIMIT order type')
+  }
+  if (orderType === 'LIMIT' && !_isBoolean(postonly)) {
+    return 'Post only flag required for LIMIT order type'
   }
 
   if (_isObject(relativeCap)) {

--- a/lib/accumulate_distribute/meta/validate_params.js
+++ b/lib/accumulate_distribute/meta/validate_params.js
@@ -76,8 +76,9 @@ const validateParams = (args = {}, pairConfig = {}) => {
   if (orderType === 'LIMIT' && !_isFinite(limitPrice)) {
     return validationErrObj('limitPrice', 'Limit price required for LIMIT order type')
   }
+
   if (orderType === 'LIMIT' && !_isBoolean(postonly)) {
-    return 'Post only flag required for LIMIT order type'
+    return validationErrObj('postonly', 'Post only flag required for LIMIT order type')
   }
 
   if (_isObject(relativeCap)) {

--- a/lib/accumulate_distribute/util/generate_order.js
+++ b/lib/accumulate_distribute/util/generate_order.js
@@ -24,10 +24,10 @@ const generateOrder = (instance = {}) => {
   } = state
 
   const {
-    symbol, orderType, relativeOffset, relativeCap, limitPrice, _margin, hidden,
+    symbol, orderType, relativeOffset, relativeCap, limitPrice, _margin, hidden, postonly,
     lev, _futures
   } = args
-
+  
   const scheduledAmount = orderAmounts[Math.min(currentOrder, orderAmounts.length - 1)]
   const amount = scheduledAmount > 0
     ? Math.min(scheduledAmount, remainingAmount)
@@ -54,6 +54,7 @@ const generateOrder = (instance = {}) => {
     return new Order({
       ...sharedOrderParams,
       price: limitPrice,
+      postonly,
       cid: genCID(),
       type: _margin || _futures ? 'LIMIT' : 'EXCHANGE LIMIT',
       meta: { _HF: 1 }

--- a/lib/accumulate_distribute/util/generate_order.js
+++ b/lib/accumulate_distribute/util/generate_order.js
@@ -27,7 +27,7 @@ const generateOrder = (instance = {}) => {
     symbol, orderType, relativeOffset, relativeCap, limitPrice, _margin, hidden, postonly,
     lev, _futures
   } = args
-  
+
   const scheduledAmount = orderAmounts[Math.min(currentOrder, orderAmounts.length - 1)]
   const amount = scheduledAmount > 0
     ? Math.min(scheduledAmount, remainingAmount)

--- a/test/lib/accumulate_distribute/meta/validate_params.js
+++ b/test/lib/accumulate_distribute/meta/validate_params.js
@@ -28,6 +28,7 @@ const params = {
     delta: 0
   },
   catchUp: true,
+  postonly: false,
   awaitFill: true,
   lev: 3.3,
   _futures: true
@@ -116,6 +117,12 @@ describe('accumulate_distribute:meta:validate_params', () => {
     it('returns error when awaitFill field is not boolean', () => {
       const err = validateParams({ ...params, awaitFill: 'and' })
       assert.deepStrictEqual(err.field, 'awaitFill')
+      assert(_isString(err.message))
+    })
+
+    it('returns error when postonly field is not boolean', () => {
+      const err = validateParams({ ...params, postonly: 'and' })
+      assert.deepStrictEqual(err.field, 'postonly')
       assert(_isString(err.message))
     })
   })


### PR DESCRIPTION
### Description:
added post only orders for accumulate/distribute algorithmic orders

### New features:
- [ postonly orders option available for accumulate/distribute algo]
