### PR TITLE
twap: improve submit delay

### DIFF
--- a/lib/host/gen_helpers.js
+++ b/lib/host/gen_helpers.js
@@ -91,6 +91,12 @@ const genHelpers = (state = {}, adapter) => {
       pendingTimeouts = []
     },
 
+    timeout: (ms) => {
+      return new Promise((resolve) => {
+        setTimeout(resolve, ms)
+      })
+    },
+
     /**
      * Logs a string to the console, tagged by AO id/gid
      *

--- a/lib/twap/events/self_interval_tick.js
+++ b/lib/twap/events/self_interval_tick.js
@@ -21,7 +21,7 @@ const isTargetMet = require('../util/is_target_met')
 const onSelfIntervalTick = async (instance = {}) => {
   const { state = {}, h = {} } = instance
   const { orders = {}, args = {}, gid } = state
-  const { emit, debug } = h
+  const { emit, debug, timeout } = h
   const {
     priceTarget, tradeBeyondEnd, cancelDelay, submitDelay, priceDelta,
     orderType, sliceAmount, amount
@@ -46,6 +46,10 @@ const onSelfIntervalTick = async (instance = {}) => {
       debug('next tick would exceed total order amount, refusing')
       return
     }
+  }
+
+  if (submitDelay) {
+    await timeout(submitDelay)
   }
 
   let orderPrice
@@ -79,9 +83,8 @@ const onSelfIntervalTick = async (instance = {}) => {
   }
 
   const order = generateOrder(state, orderPrice)
-
   if (order) {
-    await emit('exec:order:submit:all', gid, [order], submitDelay)
+    await emit('exec:order:submit:all', gid, [order], 0)
   }
 }
 

--- a/test/lib/twap/events/self_interval_tick.js
+++ b/test/lib/twap/events/self_interval_tick.js
@@ -17,6 +17,12 @@ const args = {
   orderType: 'LIMIT'
 }
 
+const timeout = () => {
+  return new Promise((resolve) => {
+    setTimeout(resolve, 0)
+  })
+}
+
 describe('twap:events:self_interval_tick', () => {
   it('cancels if not trading beyond end period and there are orders', (done) => {
     onIntervalTick({
@@ -30,6 +36,7 @@ describe('twap:events:self_interval_tick', () => {
       },
 
       h: {
+        timeout,
         debug: () => {},
         emit: (eventName, gid, orders, delay) => {
           return new Promise((resolve) => {
@@ -58,6 +65,7 @@ describe('twap:events:self_interval_tick', () => {
       },
 
       h: {
+        timeout,
         debug: () => {},
         emit: (eventName, gid, orders, delay) => {
           return new Promise((resolve, reject) => {
@@ -81,6 +89,7 @@ describe('twap:events:self_interval_tick', () => {
       },
 
       h: {
+        timeout,
         debug: () => {},
         emit: (eventName, gid, orders, delay) => {
           return new Promise((resolve, reject) => {
@@ -109,12 +118,12 @@ describe('twap:events:self_interval_tick', () => {
       },
 
       h: {
+        timeout,
         debug: () => {},
         emit: (eventName, gid, orders, delay) => {
           return new Promise((resolve) => {
             assert.strictEqual(eventName, 'exec:order:submit:all')
             assert.strictEqual(gid, 100)
-            assert.strictEqual(delay, 200)
             assert.strictEqual(orders.length, 1)
 
             const [order] = orders
@@ -142,12 +151,12 @@ describe('twap:events:self_interval_tick', () => {
       },
 
       h: {
+        timeout,
         debug: () => {},
         emit: (eventName, gid, orders, delay) => {
           return new Promise((resolve) => {
             assert.strictEqual(eventName, 'exec:order:submit:all')
             assert.strictEqual(gid, 100)
-            assert.strictEqual(delay, 200)
             assert.strictEqual(orders.length, 1)
 
             const [order] = orders
@@ -175,6 +184,7 @@ describe('twap:events:self_interval_tick', () => {
       },
 
       h: {
+        timeout,
         debug: () => {},
         emit: (eventName, gid, orders, delay) => {
           return new Promise((resolve, reject) => {
@@ -203,6 +213,7 @@ describe('twap:events:self_interval_tick', () => {
       },
 
       h: {
+        timeout,
         debug: () => {},
         emit: (eventName, gid, orders, delay) => {
           return new Promise((resolve, reject) => {


### PR DESCRIPTION
with the current submit delay the algo takes  the price of an
orderbook first, then creates an order based on that price and
THEN waits for a default of 2 seconds before submitting it.
that means, when the order submit delay is triggered, an outdated
orderbook price was taken.

this PR applies the timeout before the price is set, providing
better prices that are more up to date.

it also reduces issues where an unfilled TWAP order was cancelled,
but was sitting still on the book, while the price for the
next order was already decided upon, leading the algo trading
against itself, constantly lowering or increasing the price by
calculating the mid-price too early. this problem will be fully
addressed in another PR