### PR TITLE
clearing interval while removing algo order instances

### DIFF
--- a/lib/ao_host.js
+++ b/lib/ao_host.js
@@ -170,7 +170,14 @@ class AOHost extends AsyncEventEmitter {
   onMetaReload () {
     Object.values(this.instances).forEach((instance = {}) => {
       const { state = {} } = instance
+      const { id, gid, interval = {} } = state
+
       state.ev.removeAllListeners()
+
+      if (!_isEmpty(interval)) {
+        clearInterval(interval)
+        debug('cleared interval for %s [gid %s]', id, gid)
+      }
     })
     this.instances = {}
     this.emit('meta:reload')


### PR DESCRIPTION
On meta reload, the instances of the algo orders are removed and later created as required when the users choose to reload the orders manually. However, the interval set for these instances aren't cleared while removing the instances causing a memory leak. This PR clears the interval for these active instances while removing those instances of algo orders.