### PR TITLE
single atomic cancellation while resuming orders issue fixed

### DIFF
--- a/lib/ao_host.js
+++ b/lib/ao_host.js
@@ -475,11 +475,17 @@ class AOHost extends AsyncEventEmitter {
     }
 
     // Cancel existing orders
-    for (let i = 0; i < this.orderSnapshot.length; i += 1) {
-      if (this.orderSnapshot[i].gid === +gid) {
-        await this.adapter.cancelOrderWithDelay(
-          state.connection, 0, this.orderSnapshot[i]
-        )
+    if (this.orderSnapshot.gid === +gid) {
+      await this.adapter.cancelOrderWithDelay(
+        state.connection, 0, this.orderSnapshot
+      )
+    } else {
+      for (let i = 0; i < this.orderSnapshot.length; i += 1) {
+        if (this.orderSnapshot[i].gid === +gid) {
+          await this.adapter.cancelOrderWithDelay(
+            state.connection, 0, this.orderSnapshot[i]
+          )
+        }
       }
     }
 


### PR DESCRIPTION
While resuming the algo orders, the format of the received snapshot of active orders (when only one atomic order is active) wasn't as per the written logic for cancelling the active atomic orders. This is a fix to handle cancellation of active atomic order before resuming the algo order in order to prevent the same atomic order to be submitted twice.