### PR TITLE
prevent initial order to be submitted twice in oco order 

### DIFF
--- a/lib/ococo/events/life_start.js
+++ b/lib/ococo/events/life_start.js
@@ -11,10 +11,15 @@
  * @returns {Promise} p - resolves on completion
  */
 const onLifeStart = async (instance = {}) => {
-  const { h = {} } = instance
+  const { state = {}, h = {} } = instance
+  const { initialOrderFilled } = state
   const { emitSelf } = h
 
-  return emitSelf('submit_initial_order')
+  if (!initialOrderFilled) {
+    return emitSelf('submit_initial_order')
+  }
+
+  return emitSelf('submit_oco_order')
 }
 
 module.exports = onLifeStart

--- a/lib/ococo/meta/serialize.js
+++ b/lib/ococo/meta/serialize.js
@@ -12,12 +12,13 @@
  * @returns {object} pojo - DB-ready plain JS object
  */
 const serialize = (state = {}) => {
-  const { args = {}, label, name } = state
+  const { args = {}, label, name, initialOrderFilled } = state
 
   return {
     label,
     name,
-    args
+    args,
+    initialOrderFilled
   }
 }
 

--- a/lib/ococo/meta/unserialize.js
+++ b/lib/ococo/meta/unserialize.js
@@ -10,12 +10,13 @@
  * @returns {object} instanceState - ready for execution
  */
 const unserialize = (loadedState = {}) => {
-  const { args = {}, name, label } = loadedState
+  const { args = {}, name, label, initialOrderFilled } = loadedState
 
   return {
     label,
     name,
-    args
+    args,
+    initialOrderFilled
   }
 }
 

--- a/test/lib/ococo/events/life_start.js
+++ b/test/lib/ococo/events/life_start.js
@@ -1,0 +1,53 @@
+/* eslint-env mocha */
+'use strict'
+
+const assert = require('assert')
+const onLifeStart = require('../../../../lib/ococo/events/life_start')
+
+const getInstance = ({
+  params = {}, argParams = {}, stateParams = {}, helperParams = {}
+}) => ({
+  state: {
+    initialOrderFilled: false,
+    ...stateParams
+  },
+
+  h: {
+    updateState: async () => {},
+    emitSelf: async () => {},
+    ...helperParams
+  },
+
+  ...params
+})
+
+describe('ococo:events:life_start', () => {
+  it('submits initial order if intial order isn\'t filled', async () => {
+    const i = getInstance({
+      helperParams: {
+        emitSelf: async (eventName) => {
+          if (eventName === 'submit_oco_order') {
+            assert.ok(false, 'should not have submitted oco order')
+          }
+        }
+      }
+    })
+
+    await onLifeStart(i)
+  })
+
+  it('submits oco order if intial order is filled', async () => {
+    const i = getInstance({
+      stateParams: { initialOrderFilled: true },
+      helperParams: {
+        emitSelf: async (eventName) => {
+          if (eventName === 'submit_initial_order') {
+            assert.ok(false, 'should not have submitted initial order')
+          }
+        }
+      }
+    })
+
+    await onLifeStart(i)
+  })
+})


### PR DESCRIPTION
While resuming the oco algo order, we weren't keeping track if the initial submitted order was filled or not causing the algo to submit the same order twice. This fix checks if the initial order was filled or not and based on this, decides to resume with the required orders that needs to be submitted. 