### PR TITLE
twap: fix distort amount calc 

### DIFF
--- a/lib/twap/util/generate_order.js
+++ b/lib/twap/util/generate_order.js
@@ -27,7 +27,7 @@ const generateOrder = (state = {}, price) => {
   } = args
   let orderAmount = 0
 
-  if (_isFinite(amountDistortion)) {
+  if (_isFinite(amountDistortion) && amountDistortion > 0) {
     const plusOrMinus = Math.random() > 0.5 ? 1 : -1
     const randomPercentage = nBN(Math.random()).multipliedBy(amountDistortion).multipliedBy(plusOrMinus).toNumber() + 1 // random percentage from 1 to amountDistortion
     orderAmount = nBN(sliceAmount).multipliedBy(randomPercentage).toNumber()


### PR DESCRIPTION
don't calculate when the distortion is set to 0 (default value)
