### PR TITLE
reset priceTarget  and priceCondition for market orders

### DIFF
--- a/lib/twap/meta/process_params.js
+++ b/lib/twap/meta/process_params.js
@@ -19,6 +19,11 @@ const processParams = (data) => {
     params.orderType = `EXCHANGE ${params.orderType}`
   }
 
+  if (/MARKET/.test(params.orderType)) {
+    params.priceTarget = 'OB_MID'
+    params.priceCondition = 'MATCH_MIDPOINT'
+  }
+
   if (!params._futures) {
     delete params.lev
   }


### PR DESCRIPTION
In the UI,  the value of priceTarget and priceCondition isn't reset when user changes order type from limit to market. This is a fix to change these values as per required in case of market order type.