### PR TITLE
cancel all orders set by acc/dis algo order on life stop event

### DIFF
--- a/lib/accumulate_distribute/events/life_stop.js
+++ b/lib/accumulate_distribute/events/life_stop.js
@@ -10,12 +10,18 @@
  * @returns {Promise} p
  */
 const onLifeStop = async (instance = {}) => {
-  const { state = {} } = instance
-  const { timeout } = state
+  const { state = {}, h = {} } = instance
+  const { timeout, args = {}, orders = {}, gid } = state
+  const { debug, emit } = h
+  const { cancelDelay } = args
 
   if (timeout) {
     clearTimeout(timeout)
   }
+
+  debug('detected acccumulate/distribute algo cancelation, stopping...')
+
+  await emit('exec:order:cancel:all', gid, orders, cancelDelay)
 }
 
 module.exports = onLifeStop

--- a/test/lib/accumulate_distribute/events/life_stop.js
+++ b/test/lib/accumulate_distribute/events/life_stop.js
@@ -12,6 +12,8 @@ const getInstance = ({
     timeout: null,
     ...stateParams
   },
+  h: helperParams,
+  args: argParams,
   ...params
 })
 
@@ -22,10 +24,35 @@ describe('accumulate_distribute:events:life_stop', () => {
         timeout: setTimeout(() => {
           assert.ok(false, 'timeout should have been cleared')
         }, 50)
+      },
+      helperParams: {
+        updateState: () => {},
+        debug: () => {},
+        emit: () => {}
       }
     })
 
     await lifeStop(i)
     return Promise.delay(55)
+  })
+
+  it('cancels all order set by the accumulate/distribute algo', async () => {
+    let cancelledOrders = false
+
+    const i = getInstance({
+      helperParams: {
+        updateState: () => {},
+        debug: () => {},
+        emit: (eventName) => {
+          if (eventName === 'exec:order:cancel:all') {
+            cancelledOrders = true
+          }
+        }
+      }
+    })
+
+    await lifeStop(i)
+
+    assert.ok(cancelledOrders, 'did not cancel all orders set by accumulate/distribute algo')
   })
 })


### PR DESCRIPTION
This cancels all of the atomic orders submitted by the acc/dis algo upon cancellation.