### PR TITLE
cancels all orders set by ma crossover algo on life_stop event

### DIFF
--- a/lib/ma_crossover/events/life_stop.js
+++ b/lib/ma_crossover/events/life_stop.js
@@ -8,6 +8,15 @@
  * @param {AOInstance} instance - AO instance
  * @returns {Promise} p - resolves on completion
  */
-const onLifeStop = async (instance = {}) => {}
+const onLifeStop = async (instance = {}) => {
+  const { state = {}, h = {} } = instance
+  const { args = {}, orders = {}, gid } = state
+  const { emit, debug } = h
+  const { cancelDelay } = args
+
+  debug('detected ma crossover algo cancelation, stopping...')
+
+  await emit('exec:order:cancel:all', gid, orders, cancelDelay)
+}
 
 module.exports = onLifeStop

--- a/test/lib/ma_crossover/events/life_stop.js
+++ b/test/lib/ma_crossover/events/life_stop.js
@@ -1,0 +1,25 @@
+/* eslint-env mocha */
+'use strict'
+
+const assert = require('assert')
+const onLifeStop = require('../../../../lib/ma_crossover/events/life_stop')
+
+describe('ma_crossover:events:life_stop', () => {
+  it('cancels all orders when ma crossover algo stopped', async () => {
+    let cancelledOrders = false
+
+    await onLifeStop({
+      h: {
+        updateState: () => {},
+        debug: () => {},
+        emit: (eventName) => {
+          if (eventName === 'exec:order:cancel:all') {
+            cancelledOrders = true
+          }
+        }
+      }
+    })
+
+    assert.ok(cancelledOrders, 'did not cancel all orders set by ma crossover algo')
+  })
+})


### PR DESCRIPTION
This cancels all of the atomic orders submitted by the ma crossover algo upon cancellation.