### PR TITLE
twap: fix interval queing up

### DIFF
--- a/lib/host/gen_helpers.js
+++ b/lib/host/gen_helpers.js
@@ -92,9 +92,13 @@ const genHelpers = (state = {}, adapter) => {
     },
 
     timeout: (ms) => {
-      return new Promise((resolve) => {
-        setTimeout(resolve, ms)
+      let id = null
+
+      const p = new Promise((resolve) => {
+        id = setTimeout(resolve, ms)
       })
+
+      return [id, () => p]
     },
 
     /**

--- a/lib/twap/events/life_start.js
+++ b/lib/twap/events/life_start.js
@@ -15,8 +15,8 @@ const _isString = require('lodash/isString')
 const onLifeStart = async (instance = {}) => {
   const { state = {}, h = {} } = instance
   const { args = {} } = state
-  const { sliceInterval, priceTarget, priceCondition, orderType } = args
-  const { debug, emitSelf, updateState } = h
+  const { priceTarget, priceCondition, orderType } = args
+  const { debug, emitSelf } = h
 
   if (!/MARKET/.test(orderType)) {
     if (_isFinite(priceTarget) && _isString(priceCondition)) {
@@ -29,13 +29,7 @@ const onLifeStart = async (instance = {}) => {
     }
   }
 
-  const interval = setInterval(async () => {
-    await emitSelf('interval_tick')
-  }, sliceInterval)
-
-  debug('scheduled interval (%f s)', sliceInterval / 1000)
-
-  await updateState(instance, { interval })
+  await emitSelf('interval_tick')
 }
 
 module.exports = onLifeStart

--- a/lib/twap/events/life_stop.js
+++ b/lib/twap/events/life_stop.js
@@ -11,13 +11,13 @@
  */
 const onLifeStop = async (instance = {}) => {
   const { state = {}, h = {} } = instance
-  const { interval } = state
+  const { timeout } = state
   const { debug, updateState } = h
 
-  if (interval !== null) {
-    clearInterval(interval)
-    await updateState(instance, { interval: null })
-    debug('cleared interval')
+  if (timeout !== null) {
+    clearTimeout(timeout)
+    await updateState(instance, { timeout: null })
+    debug('cleared interval/timeout')
   }
 }
 

--- a/lib/twap/events/self_interval_tick.js
+++ b/lib/twap/events/self_interval_tick.js
@@ -32,9 +32,7 @@ const onSelfIntervalTick = async (instance = {}) => {
     debug('scheduling interval (%f s)', sliceInterval / 1000)
     const [id, t] = timeout(sliceInterval)
     await updateState(instance, { timeout: id })
-    console.log('before tick')
     await t()
-    console.log('after tick')
     await emitSelf('interval_tick')
   }
 

--- a/lib/twap/events/self_interval_tick.js
+++ b/lib/twap/events/self_interval_tick.js
@@ -22,16 +22,28 @@ const isTargetMet = require('../util/is_target_met')
 const onSelfIntervalTick = async (instance = {}) => {
   const { state = {}, h = {} } = instance
   const { orders = {}, args = {}, gid } = state
-  const { emit, debug, timeout } = h
+  const { emit, debug, timeout, updateState, emitSelf } = h
   const {
     priceTarget, tradeBeyondEnd, amount, sliceAmount, cancelDelay, submitDelay, priceDelta,
-    orderType
+    orderType, sliceInterval
   } = args
+
+  async function scheduleTick () {
+    debug('scheduling interval (%f s)', sliceInterval / 1000)
+    const [id, t] = timeout(sliceInterval)
+    await updateState(instance, { timeout: id })
+    console.log('before tick')
+    await t()
+    console.log('after tick')
+    await emitSelf('interval_tick')
+  }
 
   debug('tick')
 
   if (!tradeBeyondEnd && !_isEmpty(orders)) {
-    await emit('exec:order:cancel:all', gid, orders, cancelDelay)
+    const [, t] = timeout(cancelDelay)
+    await t()
+    await emit('exec:order:cancel:all', gid, orders, 0)
   }
 
   if (tradeBeyondEnd) {
@@ -51,7 +63,8 @@ const onSelfIntervalTick = async (instance = {}) => {
   }
 
   if (submitDelay) {
-    await timeout(submitDelay)
+    const [, t] = timeout(submitDelay)
+    await t()
   }
 
   let orderPrice
@@ -65,6 +78,7 @@ const onSelfIntervalTick = async (instance = {}) => {
 
     if (!_isFinite(orderPrice)) {
       debug('price data unavailable, awaiting next tick')
+      scheduleTick()
       return
     }
 
@@ -76,7 +90,7 @@ const onSelfIntervalTick = async (instance = {}) => {
           'target not met | price %f (target %s delta %f)',
           orderPrice, priceTarget, priceDelta
         )
-
+        scheduleTick()
         return
       }
     }
@@ -88,6 +102,8 @@ const onSelfIntervalTick = async (instance = {}) => {
   if (order) {
     await emit('exec:order:submit:all', gid, [order], 0)
   }
+
+  scheduleTick()
 }
 
 module.exports = onSelfIntervalTick

--- a/test/lib/twap/events/life_start.js
+++ b/test/lib/twap/events/life_start.js
@@ -8,8 +8,6 @@ const Config = require('../../../../lib/twap/config')
 
 describe('twap:events:life_start', () => {
   it('sets up interval & saves it on state', (done) => {
-    let interval = null
-
     onLifeStart({
       state: {
         args: {
@@ -21,20 +19,9 @@ describe('twap:events:life_start', () => {
 
       h: {
         debug: () => {},
-
-        updateState: (instance, state) => {
-          return new Promise((resolve) => {
-            assert(state.interval)
-            interval = state.interval
-            resolve()
-          }).catch(done)
-        },
-
         emitSelf: (eName) => {
           return new Promise((resolve) => {
             assert.strictEqual(eName, 'interval_tick')
-            assert(interval)
-            clearInterval(interval)
             resolve()
           }).then(done).catch(done)
         }

--- a/test/lib/twap/events/life_stop.js
+++ b/test/lib/twap/events/life_stop.js
@@ -4,13 +4,13 @@
 const onLifeStop = require('../../../../lib/twap/events/life_stop')
 
 describe('twap:events:life_stop', () => {
-  it('sets up interval & saves it on state', (done) => {
-    const interval = setInterval(() => {
-      done(new Error('interval should not have been set'))
+  it('sets up timeout & saves it on state', (done) => {
+    const timeout = setTimeout(() => {
+      done(new Error('timeout should not have been set'))
     }, 10)
 
     onLifeStop({
-      state: { interval },
+      state: { timeout },
       h: {
         updateState: () => {},
         debug: () => {}

--- a/test/lib/twap/events/self_interval_tick.js
+++ b/test/lib/twap/events/self_interval_tick.js
@@ -17,10 +17,14 @@ const args = {
   orderType: 'LIMIT'
 }
 
-const timeout = () => {
-  return new Promise((resolve) => {
-    setTimeout(resolve, 0)
+const timeout = (ms) => {
+  let id = null
+
+  const p = new Promise((resolve) => {
+    id = setTimeout(resolve, ms)
   })
+
+  return [id, () => p]
 }
 
 describe('twap:events:self_interval_tick', () => {
@@ -38,6 +42,8 @@ describe('twap:events:self_interval_tick', () => {
       },
       h: {
         timeout,
+        updateState: () => {},
+        emitSelf: () => {},
         debug: () => {},
         emit: (eventName) => {
           if (eventName === 'exec:order:submit:all') {
@@ -63,6 +69,8 @@ describe('twap:events:self_interval_tick', () => {
 
       h: {
         timeout,
+        updateState: () => {},
+        emitSelf: () => {},
         debug: (msg) => {
           if (msg === 'tick') {
             return
@@ -88,16 +96,17 @@ describe('twap:events:self_interval_tick', () => {
 
       h: {
         timeout,
+        updateState: () => {},
+        emitSelf: () => {},
         debug: () => {},
         emit: (eventName, gid, orders, delay) => {
           return new Promise((resolve) => {
             if (eventName !== 'exec:order:cancel:all') {
               return
             }
-
             assert.strictEqual(gid, 100)
             assert.deepStrictEqual(orders, { o: 42 })
-            assert.strictEqual(delay, 100)
+            assert.strictEqual(delay, 0)
             resolve()
           }).then(done).catch(done)
         }
@@ -117,6 +126,8 @@ describe('twap:events:self_interval_tick', () => {
 
       h: {
         timeout,
+        updateState: () => {},
+        emitSelf: () => {},
         debug: () => {},
         emit: (eventName, gid, orders, delay) => {
           return new Promise((resolve, reject) => {
@@ -141,6 +152,8 @@ describe('twap:events:self_interval_tick', () => {
 
       h: {
         timeout,
+        updateState: () => {},
+        emitSelf: () => {},
         debug: () => {},
         emit: (eventName, gid, orders, delay) => {
           return new Promise((resolve, reject) => {
@@ -170,6 +183,8 @@ describe('twap:events:self_interval_tick', () => {
 
       h: {
         timeout,
+        updateState: () => {},
+        emitSelf: () => {},
         debug: () => {},
         emit: (eventName, gid, orders, delay) => {
           return new Promise((resolve) => {
@@ -203,6 +218,8 @@ describe('twap:events:self_interval_tick', () => {
 
       h: {
         timeout,
+        updateState: () => {},
+        emitSelf: () => {},
         debug: () => {},
         emit: (eventName, gid, orders, delay) => {
           return new Promise((resolve) => {
@@ -236,6 +253,8 @@ describe('twap:events:self_interval_tick', () => {
 
       h: {
         timeout,
+        updateState: () => {},
+        emitSelf: () => {},
         debug: () => {},
         emit: (eventName, gid, orders, delay) => {
           return new Promise((resolve, reject) => {
@@ -265,6 +284,8 @@ describe('twap:events:self_interval_tick', () => {
 
       h: {
         timeout,
+        updateState: () => {},
+        emitSelf: () => {},
         debug: () => {},
         emit: (eventName, gid, orders, delay) => {
           return new Promise((resolve, reject) => {


### PR DESCRIPTION
when we cancel an order, we want to wait until its removed from
the book so we don't trade against our own order.

we also don't want to queue up operations.

currently a simple interval is used for scheduling a twap algo run.
i.e. every two seconds the algo starts, checks the orderbook,
cancels and submits an order. both sending and cancelling an order
is async. that means with a slow connection it can take longer
than the interval. that can lead to queing up operations.

another case is when the order book is outdated. that happens,
with a slow connection especially when the algo starts to run and
new subscription data has not arrived yet. because we were not
waiting for async cancel/submit to be finished, they woudl queue up,
whil ein the background new intervals would already kick off new runs
in parallel. that leads to an issue were the twap algo trades against
its own outdated orders in the orderbook.

the new approach waits for all operations of the current tick to
get finished, before allowing a new run, avoiding race conditions
and wrong prices