### PR TITLE
improve twap stop events

### DIFF
--- a/lib/accumulate_distribute/meta/gen_preview.js
+++ b/lib/accumulate_distribute/meta/gen_preview.js
@@ -25,7 +25,7 @@ const genPreview = (args = {}) => {
   const orderAmounts = genOrderAmounts(args)
   const orders = []
 
-  orderAmounts.map((amount, i) => {
+  orderAmounts.forEach((amount, i) => {
     if (orderType === 'MARKET') {
       orders.push(new Order({
         symbol,

--- a/lib/ping_pong/events/orders_order_fill.js
+++ b/lib/ping_pong/events/orders_order_fill.js
@@ -61,9 +61,9 @@ const onOrdersOrderFill = async (instance = {}, order) => {
       const nextPingPongTable = !endless
         ? pingPongTable
         : {
-          ...pingPongTable,
-          [pingPrice]: price
-        }
+            ...pingPongTable,
+            [pingPrice]: price
+          }
 
       await updateState(instance, {
         activePongs: nextActivePongs,

--- a/lib/twap/events/life_stop.js
+++ b/lib/twap/events/life_stop.js
@@ -11,14 +11,18 @@
  */
 const onLifeStop = async (instance = {}) => {
   const { state = {}, h = {} } = instance
-  const { timeout } = state
-  const { debug, updateState } = h
+  const { timeout, gid, orders } = state
+  const { debug, updateState, emit } = h
+
+  await updateState(instance, { shutdown: true })
 
   if (timeout !== null) {
     clearTimeout(timeout)
     await updateState(instance, { timeout: null })
     debug('cleared interval/timeout')
   }
+
+  await emit('exec:order:cancel:all', gid, orders, 0)
 }
 
 module.exports = onLifeStop

--- a/lib/twap/events/self_interval_tick.js
+++ b/lib/twap/events/self_interval_tick.js
@@ -21,7 +21,7 @@ const isTargetMet = require('../util/is_target_met')
  */
 const onSelfIntervalTick = async (instance = {}) => {
   const { state = {}, h = {} } = instance
-  const { orders = {}, args = {}, gid } = state
+  const { orders = {}, args = {}, gid, shutdown } = state
   const { emit, debug, timeout, updateState, emitSelf } = h
   const {
     priceTarget, tradeBeyondEnd, amount, sliceAmount, cancelDelay, submitDelay, priceDelta,
@@ -37,6 +37,10 @@ const onSelfIntervalTick = async (instance = {}) => {
   }
 
   debug('tick')
+
+  if (shutdown) {
+    return
+  }
 
   if (!tradeBeyondEnd && !_isEmpty(orders)) {
     const [, t] = timeout(cancelDelay)

--- a/lib/twap/meta/init_state.js
+++ b/lib/twap/meta/init_state.js
@@ -13,9 +13,10 @@ const initState = (args = {}) => {
   const { amount } = args
 
   return {
-    interval: null,
+    timeout: null,
     remainingAmount: amount,
-    args
+    args,
+    shutdown: false
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -49,8 +49,8 @@
     "p-iteration": "^1.1.7"
   },
   "devDependencies": {
-    "bfx-hf-models": "^2.1.0",
     "bfx-hf-ext-plugin-bitfinex": "^1.0.5",
+    "bfx-hf-models": "^2.1.0",
     "bfx-hf-models-adapter-lowdb": "^1.0.0",
     "chai": "^4.2.0",
     "docdash": "^1.2.0",
@@ -58,7 +58,7 @@
     "jsdoc": "^3.6.3",
     "mocha": "^7.1.0",
     "sinon": "^9.0.0",
-    "standard": "^14.2.0"
+    "standard": "^16.0.3"
   },
   "standard": {
     "ignore": [

--- a/test/lib/iceberg/events/orders_order_fill.js
+++ b/test/lib/iceberg/events/orders_order_fill.js
@@ -14,7 +14,8 @@ describe('iceberg:events:orders_order_fill', () => {
       args: {
         amount: 100,
         cancelDelay: 42
-      }
+      },
+      remainingAmount: 100
     },
 
     h: {

--- a/test/lib/twap/events/life_stop.js
+++ b/test/lib/twap/events/life_stop.js
@@ -13,7 +13,8 @@ describe('twap:events:life_stop', () => {
       state: { timeout },
       h: {
         updateState: () => {},
-        debug: () => {}
+        debug: () => {},
+        emit: () => {}
       }
     })
 

--- a/test/lib/twap/meta/init_state.js
+++ b/test/lib/twap/meta/init_state.js
@@ -15,9 +15,4 @@ describe('twap:meta:init_state', () => {
     const state = initState(args)
     assert.deepStrictEqual(state.args, args)
   })
-
-  it('seeds null interval', () => {
-    const state = initState({ amount: 42 })
-    assert.strictEqual(state.interval, null)
-  })
 })


### PR DESCRIPTION
 - put algo in "shutdown" mode on stop, so no new orders can get
   submitted

 - cancel all open orders based on `gid` when stopping, closing
   open atmoic orders from the algo