### PR TITLE
twap slice amount greater issue fix

### DIFF
--- a/lib/twap/meta/validate_params.js
+++ b/lib/twap/meta/validate_params.js
@@ -42,7 +42,7 @@ const validateParams = (args = {}) => {
   if (!_isFinite(sliceAmount)) err = 'invalid slice amount'
   if (!_isFinite(sliceInterval)) err = 'slice interval not a number'
   if (!_isFinite(amountDistortion)) return 'Amount distortion required'
-  if (sliceAmount > amount) return 'Slice amount cannot be greater than total amount'
+  if (Math.abs(sliceAmount) > Math.abs(amount)) return 'Slice amount cannot be greater than total amount'
   if (sliceInterval <= 0) err = 'slice interval <= 0'
   if (!_isString(priceTarget) && !_isFinite(priceTarget)) {
     err = 'invalid price target'

--- a/test/lib/twap/meta/validate_params.js
+++ b/test/lib/twap/meta/validate_params.js
@@ -121,4 +121,17 @@ describe('twap:meta:validate_params', () => {
       priceDelta: 'nope'
     })))
   })
+
+  it('returns error when slice amount is greater than total amount', () => {
+    assert(_isString(validateParams({
+      ...validParams,
+      sliceAmount: 2
+    })), 'doesn\'t return error when submitted buy order')
+
+    assert(_isString(validateParams({
+      ...validParams,
+      amount: -1,
+      sliceAmount: -2
+    })), 'doesn\'t return error when submitted sell order')
+  })
 })


### PR DESCRIPTION
1. Handles the slice amount greater check for both buy and sell orders. 
2. Added tests to verify.