### PR TITLE
cancel all orders set by acc/dis algo order on life stop event

### DIFF
--- a/lib/accumulate_distribute/events/life_stop.js
+++ b/lib/accumulate_distribute/events/life_stop.js
@@ -10,12 +10,18 @@
  * @returns {Promise} p
  */
 const onLifeStop = async (instance = {}) => {
-  const { state = {} } = instance
-  const { timeout } = state
+  const { state = {}, h = {} } = instance
+  const { timeout, orders = {}, gid } = state
+  const { debug, emit } = h
 
   if (timeout) {
     clearTimeout(timeout)
+    debug('cleared timeout')
   }
+
+  debug('detected acccumulate/distribute algo cancelation, stopping...')
+
+  await emit('exec:order:cancel:all', gid, orders)
 }
 
 module.exports = onLifeStop

--- a/lib/accumulate_distribute/events/orders_order_cancel.js
+++ b/lib/accumulate_distribute/events/orders_order_cancel.js
@@ -12,17 +12,11 @@
  * @returns {Promise} p
  */
 const onOrdersOrderCancel = async (instance = {}, order) => {
-  const { state = {}, h = {} } = instance
-  const { orders = {}, gid, timeout } = state
+  const { h = {} } = instance
   const { emit, debug } = h
 
   debug('detected atomic cancelation, stopping...')
 
-  if (timeout) {
-    clearTimeout(timeout)
-  }
-
-  await emit('exec:order:cancel:all', gid, orders)
   return emit('exec:stop')
 }
 

--- a/test/lib/accumulate_distribute/events/life_stop.js
+++ b/test/lib/accumulate_distribute/events/life_stop.js
@@ -12,6 +12,8 @@ const getInstance = ({
     timeout: null,
     ...stateParams
   },
+  h: helperParams,
+  args: argParams,
   ...params
 })
 
@@ -22,10 +24,35 @@ describe('accumulate_distribute:events:life_stop', () => {
         timeout: setTimeout(() => {
           assert.ok(false, 'timeout should have been cleared')
         }, 50)
+      },
+      helperParams: {
+        updateState: () => {},
+        debug: () => {},
+        emit: () => {}
       }
     })
 
     await lifeStop(i)
     return Promise.delay(55)
+  })
+
+  it('cancels all order set by the accumulate/distribute algo', async () => {
+    let cancelledOrders = false
+
+    const i = getInstance({
+      helperParams: {
+        updateState: () => {},
+        debug: () => {},
+        emit: (eventName) => {
+          if (eventName === 'exec:order:cancel:all') {
+            cancelledOrders = true
+          }
+        }
+      }
+    })
+
+    await lifeStop(i)
+
+    assert.ok(cancelledOrders, 'did not cancel all orders set by accumulate/distribute algo')
   })
 })

--- a/test/lib/accumulate_distribute/events/orders_order_cancel.js
+++ b/test/lib/accumulate_distribute/events/orders_order_cancel.js
@@ -2,11 +2,9 @@
 'use strict'
 
 const assert = require('assert')
-const Promise = require('bluebird')
 const { Order } = require('bfx-api-node-models')
 const ordersOrderCancel = require('../../../../lib/accumulate_distribute/events/orders_order_cancel')
 
-const o = new Order()
 const getInstance = ({
   params = {}, argParams = {}, stateParams = {}, helperParams = {}
 }) => ({
@@ -25,45 +23,6 @@ const getInstance = ({
 })
 
 describe('accumulate_distribute:events:orders_order_cancel', () => {
-  it('clears the timeout if set', async () => {
-    const i = getInstance({
-      stateParams: {
-        timeout: setTimeout(() => {
-          assert.ok(false, 'timeout should have been cleared')
-        }, 50)
-      }
-    })
-
-    await ordersOrderCancel(i, o)
-    return Promise.delay(55)
-  })
-
-  it('cancels all orders', async () => {
-    let sawCancelAll = false
-    const orders = [new Order(), new Order()]
-    const i = getInstance({
-      stateParams: {
-        orders,
-        gid: 42
-      },
-
-      helperParams: {
-        emit: async (eventName, gid, receivedOrders) => {
-          if (eventName !== 'exec:order:cancel:all') {
-            return
-          }
-
-          assert.strictEqual(gid, 42, 'received wrong gid')
-          assert.strictEqual(receivedOrders, orders, 'received wrong orders')
-          sawCancelAll = true
-        }
-      }
-    })
-
-    await ordersOrderCancel(i, orders[0])
-    assert.ok(sawCancelAll, 'did not see cancel-all event')
-  })
-
   it('emits the exec:stop event', async () => {
     let sawExecStop = false
     const orders = [new Order(), new Order()]


### PR DESCRIPTION
This removes all of the respective atomic orders set by acc/dis algo when stopped by the user.

Related PR: https://github.com/bitfinexcom/bfx-hf-algo/pull/89