### PR TITLE
cancels all orders set by ma crossover algo on life_stop event

### DIFF
--- a/lib/ao_host.js
+++ b/lib/ao_host.js
@@ -608,9 +608,10 @@ class AOHost extends AsyncEventEmitter {
    * from channels, emits the life.stop event, and saves the AO instance.
    *
    * @param {object} instance - algo order instance to operate on
+   * @param {object} opts - options if required for algo order
    * @private
    */
-  async onAOStop (instance = {}) {
+  async onAOStop (instance = {}, opts = {}) {
     const { h } = instance
     const { channels = [], gid, connection } = instance.state
 
@@ -637,7 +638,7 @@ class AOHost extends AsyncEventEmitter {
      *
      * @event AOHost~lifeStop
      */
-    await this.triggerAOEvent(instance, 'life', 'stop')
+    await this.triggerAOEvent(instance, 'life', 'stop', opts)
     await this.emit('ao:persist', gid)
   }
 

--- a/lib/host/events/stop.js
+++ b/lib/host/events/stop.js
@@ -8,8 +8,9 @@ const _isFunction = require('lodash/isFunction')
  * @param {object} aoHost - algo host
  * @param {string} gid - AO instance GID to operate on
  * @param {Function?} onCleanup - called before the instance is destroyed
+ * @param {object} opts - extra options required for stopping algo host
  */
-module.exports = async (aoHost, gid, onCleanup) => {
+module.exports = async (aoHost, gid, onCleanup, opts) => {
   const inst = aoHost.instances[gid]
 
   if (!inst) { // instance may have already stopped
@@ -25,7 +26,7 @@ module.exports = async (aoHost, gid, onCleanup) => {
   }
 
   // Let the host teardown (unsubs from channels, persists, etc)
-  await aoHost.emit('ao:stop', inst)
+  await aoHost.emit('ao:stop', inst, opts)
 
   // implode
   delete aoHost.instances[gid]

--- a/lib/ma_crossover/events/data_managed_candles.js
+++ b/lib/ma_crossover/events/data_managed_candles.js
@@ -97,7 +97,7 @@ const onDataManagedCandles = async (instance = {}, candles, meta) => {
       shortIndicator.crossed(longV)
     )) {
       await emitSelf('submit_order')
-      await emit('exec:stop')
+      await emit('exec:stop', null, { keepOrdersOpen: true })
     }
   }
 }

--- a/lib/ma_crossover/events/life_stop.js
+++ b/lib/ma_crossover/events/life_stop.js
@@ -8,6 +8,14 @@
  * @param {AOInstance} instance - AO instance
  * @returns {Promise} p - resolves on completion
  */
-const onLifeStop = async (instance = {}) => {}
+const onLifeStop = async (instance = {}) => {
+  const { state = {}, h = {} } = instance
+  const { orders = {}, gid } = state
+  const { emit, debug } = h
+
+  debug('detected ma crossover algo cancelation, stopping...')
+
+  await emit('exec:order:cancel:all', gid, orders)
+}
 
 module.exports = onLifeStop

--- a/lib/ma_crossover/events/life_stop.js
+++ b/lib/ma_crossover/events/life_stop.js
@@ -6,14 +6,21 @@
  * @memberOf module:MACrossover
  * @listens AOHost~lifeStop
  * @param {AOInstance} instance - AO instance
+ * @param {object} opts - options if required for algo order
  * @returns {Promise} p - resolves on completion
  */
-const onLifeStop = async (instance = {}) => {
+const onLifeStop = async (instance = {}, opts = {}) => {
   const { state = {}, h = {} } = instance
   const { orders = {}, gid } = state
   const { emit, debug } = h
+  const { keepOrdersOpen = false } = opts
 
   debug('detected ma crossover algo cancelation, stopping...')
+
+  if (keepOrdersOpen) {
+    debug('keeping ma crossover algo orders [gid %s] open...', gid)
+    return
+  }
 
   await emit('exec:order:cancel:all', gid, orders)
 }

--- a/lib/ma_crossover/events/orders_order_cancel.js
+++ b/lib/ma_crossover/events/orders_order_cancel.js
@@ -17,7 +17,7 @@ const onOrdersOrderCancel = async (instance = {}, order) => {
 
   debug('detected atomic cancelation, stopping...')
 
-  return emit('exec:stop')
+  return emit('exec:stop', null, { keepOrdersOpen: false })
 }
 
 module.exports = onOrdersOrderCancel

--- a/lib/ma_crossover/events/orders_order_cancel.js
+++ b/lib/ma_crossover/events/orders_order_cancel.js
@@ -12,13 +12,11 @@
  * @returns {Promise} p - resolves on completion
  */
 const onOrdersOrderCancel = async (instance = {}, order) => {
-  const { state = {}, h = {} } = instance
-  const { orders = {}, gid } = state
+  const { h = {} } = instance
   const { emit, debug } = h
 
   debug('detected atomic cancelation, stopping...')
 
-  await emit('exec:order:cancel:all', gid, orders)
   return emit('exec:stop')
 }
 

--- a/test/lib/ma_crossover/events/life_stop.js
+++ b/test/lib/ma_crossover/events/life_stop.js
@@ -1,0 +1,25 @@
+/* eslint-env mocha */
+'use strict'
+
+const assert = require('assert')
+const onLifeStop = require('../../../../lib/ma_crossover/events/life_stop')
+
+describe('ma_crossover:events:life_stop', () => {
+  it('cancels all orders when ma crossover algo stopped', async () => {
+    let cancelledOrders = false
+
+    await onLifeStop({
+      h: {
+        updateState: () => {},
+        debug: () => {},
+        emit: (eventName) => {
+          if (eventName === 'exec:order:cancel:all') {
+            cancelledOrders = true
+          }
+        }
+      }
+    })
+
+    assert.ok(cancelledOrders, 'did not cancel all orders set by ma crossover algo')
+  })
+})

--- a/test/lib/ma_crossover/events/life_stop.js
+++ b/test/lib/ma_crossover/events/life_stop.js
@@ -22,4 +22,22 @@ describe('ma_crossover:events:life_stop', () => {
 
     assert.ok(cancelledOrders, 'did not cancel all orders set by ma crossover algo')
   })
+
+  it('does not cancel order when ma crossover algo stopped when option is passed to keep orders alive', async () => {
+    let cancelledOrders = false
+
+    await onLifeStop({
+      h: {
+        updateState: () => {},
+        debug: () => {},
+        emit: (eventName) => {
+          if (eventName === 'exec:order:cancel:all') {
+            cancelledOrders = true
+          }
+        }
+      }
+    }, { keepOrdersOpen: true })
+
+    assert.deepStrictEqual(cancelledOrders, false, 'shouldn\'t have cancelled orders set by ma crossover algo')
+  })
 })

--- a/test/lib/ma_crossover/events/orders_order_cancel.js
+++ b/test/lib/ma_crossover/events/orders_order_cancel.js
@@ -24,33 +24,19 @@ const getInstance = ({
 })
 
 describe('ma_crossover:events:orders_order_cancel', () => {
-  it('cancels all orders', (done) => {
-    const i = getInstance({
-      helperParams: {
-        emit: async (eventName, gid, orders) => {
-          if (eventName !== 'exec:order:cancel:all') return
-
-          assert.strictEqual(gid, 42)
-          assert.deepStrictEqual(orders, {})
-          done()
-        }
-      }
-    })
-
-    ordersOrderCancel(i, {})
-  })
-
-  it('emits exec:stop', (done) => {
+  it('emits exec:stop', async () => {
+    let sawExecStop = false
     const i = getInstance({
       helperParams: {
         emit: async (eventName) => {
           if (eventName === 'exec:stop') {
-            done()
+            sawExecStop = true
           }
         }
       }
     })
 
-    ordersOrderCancel(i, {})
+    await ordersOrderCancel(i, {})
+    assert.ok(sawExecStop, 'did not see exec:stop event')
   })
 })


### PR DESCRIPTION
This removes all of the respective atomic orders set by ma crossover algo when stopped by the user.

Related PR: https://github.com/bitfinexcom/bfx-hf-algo/pull/89