### PR TITLE
cancels all orders set by ping pong algo on life_stop event

### DIFF
--- a/lib/ping_pong/events/life_stop.js
+++ b/lib/ping_pong/events/life_stop.js
@@ -12,7 +12,9 @@
 const onLifeStop = async (instance = {}) => {
   const { state = {}, h = {} } = instance
   const { orders = {}, gid } = state
-  const { emit } = h
+  const { emit, debug } = h
+
+  debug('detected ping/pong algo cancelation, stopping...')
 
   return emit('exec:order:cancel:all', gid, orders)
 }

--- a/lib/ping_pong/events/orders_order_cancel.js
+++ b/lib/ping_pong/events/orders_order_cancel.js
@@ -12,13 +12,11 @@
  * @returns {Promise} p - resolves on completion
  */
 const onOrdersOrderCancel = async (instance = {}, order) => {
-  const { state = {}, h = {} } = instance
-  const { orders = {}, gid } = state
+  const { h = {} } = instance
   const { emit, debug } = h
 
   debug('detected atomic cancelation, stopping...')
 
-  await emit('exec:order:cancel:all', gid, orders)
   await emit('exec:stop')
 }
 

--- a/test/lib/ping_pong/events/life_stop.js
+++ b/test/lib/ping_pong/events/life_stop.js
@@ -1,0 +1,25 @@
+/* eslint-env mocha */
+'use strict'
+
+const assert = require('assert')
+const onLifeStop = require('../../../../lib/ping_pong/events/life_stop')
+
+describe('ping_pong:events:life_stop', () => {
+  it('cancels all orders when ping pong algo stopped', async () => {
+    let cancelledOrders = false
+
+    await onLifeStop({
+      h: {
+        updateState: () => {},
+        debug: () => {},
+        emit: (eventName) => {
+          if (eventName === 'exec:order:cancel:all') {
+            cancelledOrders = true
+          }
+        }
+      }
+    })
+
+    assert.ok(cancelledOrders, 'did not cancel all orders set by ping pong algo')
+  })
+})

--- a/test/lib/ping_pong/events/orders_order_cancel.js
+++ b/test/lib/ping_pong/events/orders_order_cancel.js
@@ -1,0 +1,25 @@
+/* eslint-env mocha */
+'use strict'
+
+const assert = require('assert')
+const onOrdersCancel = require('../../../../lib/ping_pong/events/orders_order_cancel')
+
+describe('ping_pong:events:life_stop', () => {
+  it('emits exec:stop', async () => {
+    let sawExecStop = false
+
+    await onOrdersCancel({
+      h: {
+        updateState: () => {},
+        debug: () => {},
+        emit: (eventName) => {
+          if (eventName === 'exec:stop') {
+            sawExecStop = true
+          }
+        }
+      }
+    })
+
+    assert.ok(sawExecStop, 'did not see exec:stop event')
+  })
+})


### PR DESCRIPTION
This removes all of the respective atomic orders set by ping pong algo when stopped by the user.

Related PR: https://github.com/bitfinexcom/bfx-hf-algo/pull/89