### PR TITLE
cancels all orders set by iceberg algo on life stop event

### DIFF
--- a/lib/iceberg/events/life_stop.js
+++ b/lib/iceberg/events/life_stop.js
@@ -10,16 +10,20 @@
  */
 const onLifeStop = async (instance = {}) => {
   const { state = {}, h = {} } = instance
-  const { timeout } = state
-  const { debouncedSubmitOrders, debug, updateState } = h
+  const { orders = {}, gid, timeout } = state
+  const { debouncedSubmitOrders, emit, debug, updateState } = h
 
   debouncedSubmitOrders.cancel()
+
+  debug('detected iceberg algo cancelation, stopping...')
 
   if (timeout !== null) {
     clearTimeout(timeout)
     await updateState(instance, { timeout: null })
     debug('cleared timeout')
   }
+
+  await emit('exec:order:cancel:all', gid, orders)
 }
 
 module.exports = onLifeStop

--- a/lib/iceberg/events/orders_order_cancel.js
+++ b/lib/iceberg/events/orders_order_cancel.js
@@ -12,14 +12,12 @@
  * @return {Promise} p - resolves on completion
  */
 const onOrdersOrderCancel = async (instance = {}, order) => {
-  const { state = {}, h = {} } = instance
-  const { orders = {}, gid } = state
+  const { h = {} } = instance
   const { emit, debug } = h
 
   debug('detected atomic cancelation, stopping...')
 
-  await emit('exec:order:cancel:all', gid, orders)
-  return emit('exec:stop')
+  await emit('exec:stop')
 }
 
 module.exports = onOrdersOrderCancel

--- a/test/lib/iceberg/events/life_stop.js
+++ b/test/lib/iceberg/events/life_stop.js
@@ -1,0 +1,45 @@
+/* eslint-env mocha */
+'use strict'
+
+const assert = require('assert')
+const onLifeStop = require('../../../../lib/iceberg/events/life_stop')
+
+describe('iceberg:events:life_stop', () => {
+  it('cancels the debounce set to manage orders when received simultaneously', async () => {
+    let debounceCancelled = false
+    await onLifeStop({
+      h: {
+        updateState: () => {},
+        debug: () => {},
+        emit: () => {},
+        debouncedSubmitOrders: {
+          cancel: () => {
+            debounceCancelled = true
+          }
+        }
+      }
+    })
+    assert.ok(debounceCancelled, 'did not cancel the debounce method set on startup')
+  })
+
+  it('cancels all orders when iceberg algo stopped', async () => {
+    let cancelledOrders = false
+
+    await onLifeStop({
+      h: {
+        updateState: () => {},
+        debug: () => {},
+        debouncedSubmitOrders: {
+          cancel: () => {}
+        },
+        emit: (eventName) => {
+          if (eventName === 'exec:order:cancel:all') {
+            cancelledOrders = true
+          }
+        }
+      }
+    })
+
+    assert.ok(cancelledOrders, 'did not cancel all orders set by iceberg algo')
+  })
+})

--- a/test/lib/iceberg/events/orders_order_cancel.js
+++ b/test/lib/iceberg/events/orders_order_cancel.js
@@ -6,31 +6,12 @@ const onOrderCancel = require('../../../../lib/iceberg/events/orders_order_cance
 
 describe('iceberg:events:orders_order_cancel', () => {
   it('submits all known orders for cancellation & stops operation', (done) => {
-    let call = 0
-    const orderState = {
-      1: 'some_order_object'
-    }
-
     onOrderCancel({
-      state: {
-        gid: 100,
-        orders: orderState
-      },
-
       h: {
         debug: () => {},
-        emit: async (eName, gid, orders) => {
-          if (call === 0) {
-            assert.strictEqual(gid, 100)
-            assert.strictEqual(eName, 'exec:order:cancel:all')
-            assert.deepStrictEqual(orders, orderState)
-            call += 1
-          } else if (call === 1) {
-            assert.strictEqual(eName, 'exec:stop')
-            done()
-          } else {
-            done(new Error('too many events emitted'))
-          }
+        emit: async (eName) => {
+          assert.strictEqual(eName, 'exec:stop')
+          done()
         }
       }
     })


### PR DESCRIPTION
This removes all of the respective atomic orders set by iceberg algo when stopped by the user.

Related PR: https://github.com/bitfinexcom/bfx-hf-algo/pull/89