### PR TITLE
order not found issue fix

### DIFF
--- a/lib/host/events/cancel_all_orders.js
+++ b/lib/host/events/cancel_all_orders.js
@@ -23,7 +23,7 @@ module.exports = async (aoHost, gid, orders, delay) => {
 
     // Don't try to cancel market orders
     const _orders = allOrders
-      .filter(o => !/MARKET/.test(o.type) && o.id)
+      .filter(o => !/MARKET/.test(o.type) && o.id && !/CANCELED/.test(o.status))
 
     let nextState = state
 


### PR DESCRIPTION
This fixes the error (`Order not found`) thrown when the algo server tries to cancel the already cancelled orders. This case occurs when a user tries to cancel an atomic order. The algo server when processing `order.close` event tries to cancel all the orders stored in its state based on the `id` of the order and not the `status` .