### PR TITLE
add safety net if the orderbook isn't updated

### DIFF
--- a/lib/twap/events/data_managed_book.js
+++ b/lib/twap/events/data_managed_book.js
@@ -31,7 +31,8 @@ const onDataManagedBook = async (instance = {}, book, meta) => {
   debug('recv updated order book for %s', symbol)
 
   await updateState(instance, {
-    lastBook: book
+    lastBook: book,
+    isBookUpdated: true
   })
 }
 

--- a/lib/twap/events/self_interval_tick.js
+++ b/lib/twap/events/self_interval_tick.js
@@ -21,12 +21,13 @@ const isTargetMet = require('../util/is_target_met')
  */
 const onSelfIntervalTick = async (instance = {}) => {
   const { state = {}, h = {} } = instance
-  const { orders = {}, args = {}, gid, shutdown } = state
+  const { orders = {}, args = {}, gid, shutdown, isBookUpdated } = state
   const { emit, debug, timeout, updateState, emitSelf } = h
   const {
     priceTarget, tradeBeyondEnd, amount, sliceAmount, cancelDelay, submitDelay, priceDelta,
     orderType, sliceInterval
   } = args
+  const isMarketOrder = /MARKET/.test(orderType)
 
   async function scheduleTick () {
     debug('scheduling interval (%f s)', sliceInterval / 1000)
@@ -42,10 +43,18 @@ const onSelfIntervalTick = async (instance = {}) => {
     return
   }
 
-  if (!tradeBeyondEnd && !_isEmpty(orders)) {
+  if (!isMarketOrder && !isBookUpdated) {
+    scheduleTick()
+    return
+  }
+
+  if (!isMarketOrder && !tradeBeyondEnd && !_isEmpty(orders)) {
     const [, t] = timeout(cancelDelay)
     await t()
+    await updateState(instance, { isBookUpdated: false })
     await emit('exec:order:cancel:all', gid, orders, 0)
+    scheduleTick()
+    return
   }
 
   if (tradeBeyondEnd) {
@@ -71,7 +80,7 @@ const onSelfIntervalTick = async (instance = {}) => {
 
   let orderPrice
 
-  if (!/MARKET/.test(orderType)) {
+  if (!isMarketOrder) {
     if (hasTradeTarget(args)) {
       orderPrice = getTradePrice(state)
     } else if (hasOBTarget(args)) {

--- a/lib/twap/meta/init_state.js
+++ b/lib/twap/meta/init_state.js
@@ -16,7 +16,8 @@ const initState = (args = {}) => {
     timeout: null,
     remainingAmount: amount,
     args,
-    shutdown: false
+    shutdown: false,
+    isBookUpdated: false
   }
 }
 

--- a/test/lib/twap/events/self_interval_tick.js
+++ b/test/lib/twap/events/self_interval_tick.js
@@ -56,31 +56,33 @@ describe('twap:events:self_interval_tick', () => {
     assert.ok(orderSubmitted, 'did not submit order for float amounts')
   })
 
-  it('doesn\'t submit a new order if order amount exceeds in case of trading beyond end', (done) => {
-    onIntervalTick({
+  it('doesn\'t submit a new order if order amount exceeds in case of trading beyond end', async () => {
+    let orderSubmitted = false
+    const instance = {
       state: {
         gid: 100,
         orders: { o: { amount: 0.4 }, p: { amount: 0.4 } },
         args: {
           ...args,
           sliceAmount: 0.4
-        }
+        },
+        isBookUpdated: true
       },
 
       h: {
         timeout,
         updateState: () => {},
         emitSelf: () => {},
-        debug: (msg) => {
-          if (msg === 'tick') {
-            return
+        debug: () => {},
+        emit: (eventName) => {
+          if (eventName === 'exec:order:submit:all') {
+            orderSubmitted = true
           }
-          assert.strictEqual(msg, 'next tick would exceed total order amount, refusing')
-          done()
-        },
-        emit: () => {}
+        }
       }
-    })
+    }
+    await onIntervalTick(instance)
+    assert.ok(!orderSubmitted, 'should not have submitted a new order if order amount exceeds')
   })
 
   it('cancels if not trading beyond end period and there are orders', (done) => {
@@ -91,7 +93,8 @@ describe('twap:events:self_interval_tick', () => {
         args: {
           ...args,
           tradeBeyondEnd: false
-        }
+        },
+        isBookUpdated: true
       },
 
       h: {
@@ -121,7 +124,8 @@ describe('twap:events:self_interval_tick', () => {
         args: {
           ...args,
           priceCondition: Config.PRICE_COND.MATCH_MIDPOINT
-        }
+        },
+        isBookUpdated: true
       },
 
       h: {
@@ -147,7 +151,8 @@ describe('twap:events:self_interval_tick', () => {
         args: {
           ...args,
           priceCondition: Config.PRICE_COND.MATCH_LAST
-        }
+        },
+        isBookUpdated: true
       },
 
       h: {
@@ -173,7 +178,7 @@ describe('twap:events:self_interval_tick', () => {
         lastBook: {
           midPrice: () => { return 1000 }
         },
-
+        isBookUpdated: true,
         remainingAmount: 1,
         args: {
           ...args,
@@ -213,7 +218,8 @@ describe('twap:events:self_interval_tick', () => {
         args: {
           ...args,
           priceCondition: Config.PRICE_COND.MATCH_LAST
-        }
+        },
+        isBookUpdated: true
       },
 
       h: {
@@ -248,7 +254,8 @@ describe('twap:events:self_interval_tick', () => {
         args: {
           ...args,
           priceCondition: Config.PRICE_COND.MATCH_LAST
-        }
+        },
+        isBookUpdated: true
       },
 
       h: {
@@ -274,7 +281,7 @@ describe('twap:events:self_interval_tick', () => {
         lastBook: {
           midPrice: () => { return 2000 }
         },
-
+        isBookUpdated: true,
         remainingAmount: 1,
         args: {
           ...args,


### PR DESCRIPTION
The book updates asynchronously using an event emitter. So, this fix waits for the book to be updated in local after the order cancellation and then calculates the price with the new updated book.