### PR TITLE
Add safety net twap not skip current tick

### DIFF
--- a/lib/twap/events/data_managed_book.js
+++ b/lib/twap/events/data_managed_book.js
@@ -31,7 +31,8 @@ const onDataManagedBook = async (instance = {}, book, meta) => {
   debug('recv updated order book for %s', symbol)
 
   await updateState(instance, {
-    lastBook: book
+    lastBook: book,
+    isBookUpdated: true
   })
 }
 

--- a/lib/twap/events/self_interval_tick.js
+++ b/lib/twap/events/self_interval_tick.js
@@ -99,6 +99,7 @@ const onSelfIntervalTick = async (instance = {}) => {
 
   const order = generateOrder(state, orderPrice)
   if (order) {
+    await updateState(instance, { isBookUpdated: false })
     await emit('exec:order:submit:all', gid, [order], 0)
   }
 

--- a/lib/twap/events/self_interval_tick.js
+++ b/lib/twap/events/self_interval_tick.js
@@ -9,6 +9,7 @@ const generateOrder = require('../util/generate_order')
 const getOBPrice = require('../util/get_ob_price')
 const getTradePrice = require('../util/get_trade_price')
 const isTargetMet = require('../util/is_target_met')
+const scheduleTick = require('../util/schedule_tick')
 
 /**
  * Submits the next slice order if the price condition/target is met.
@@ -22,20 +23,12 @@ const isTargetMet = require('../util/is_target_met')
 const onSelfIntervalTick = async (instance = {}) => {
   const { state = {}, h = {} } = instance
   const { orders = {}, args = {}, gid, shutdown, isBookUpdated } = state
-  const { emit, debug, timeout, updateState, emitSelf } = h
+  const { emit, debug, updateState } = h
   const {
     priceTarget, tradeBeyondEnd, amount, sliceAmount, priceDelta,
-    orderType, sliceInterval
+    orderType
   } = args
   const isMarketOrder = /MARKET/.test(orderType)
-
-  async function scheduleTick () {
-    debug('scheduling interval (%f s)', sliceInterval / 1000)
-    const [id, t] = timeout(sliceInterval)
-    await updateState(instance, { timeout: id })
-    await t()
-    await emitSelf('interval_tick')
-  }
 
   debug('tick')
 
@@ -44,7 +37,7 @@ const onSelfIntervalTick = async (instance = {}) => {
   }
 
   if (!isMarketOrder && !isBookUpdated) {
-    scheduleTick()
+    scheduleTick.tick(instance)
     return
   }
 
@@ -84,7 +77,7 @@ const onSelfIntervalTick = async (instance = {}) => {
 
     if (!_isFinite(orderPrice)) {
       debug('price data unavailable, awaiting next tick')
-      scheduleTick()
+      scheduleTick.tick(instance)
       return
     }
 
@@ -96,7 +89,7 @@ const onSelfIntervalTick = async (instance = {}) => {
           'target not met | price %f (target %s delta %f)',
           orderPrice, priceTarget, priceDelta
         )
-        scheduleTick()
+        scheduleTick.tick(instance)
         return
       }
     }
@@ -109,7 +102,7 @@ const onSelfIntervalTick = async (instance = {}) => {
     await emit('exec:order:submit:all', gid, [order], 0)
   }
 
-  scheduleTick()
+  scheduleTick.tick(instance)
 }
 
 module.exports = onSelfIntervalTick

--- a/lib/twap/events/self_interval_tick.js
+++ b/lib/twap/events/self_interval_tick.js
@@ -77,9 +77,9 @@ const onSelfIntervalTick = async (instance = {}) => {
 
   if (!isMarketOrder) {
     if (hasTradeTarget(args)) {
-      orderPrice = getTradePrice(state)
+      orderPrice = getTradePrice(instance.state)
     } else if (hasOBTarget(args)) {
-      orderPrice = getOBPrice(state)
+      orderPrice = getOBPrice(instance.state)
     }
 
     if (!_isFinite(orderPrice)) {

--- a/lib/twap/events/self_interval_tick.js
+++ b/lib/twap/events/self_interval_tick.js
@@ -21,12 +21,13 @@ const isTargetMet = require('../util/is_target_met')
  */
 const onSelfIntervalTick = async (instance = {}) => {
   const { state = {}, h = {} } = instance
-  const { orders = {}, args = {}, gid, shutdown } = state
+  const { orders = {}, args = {}, gid, shutdown, isBookUpdated } = state
   const { emit, debug, timeout, updateState, emitSelf } = h
   const {
     priceTarget, tradeBeyondEnd, amount, sliceAmount, priceDelta,
     orderType, sliceInterval
   } = args
+  const isMarketOrder = /MARKET/.test(orderType)
 
   async function scheduleTick () {
     debug('scheduling interval (%f s)', sliceInterval / 1000)
@@ -42,7 +43,13 @@ const onSelfIntervalTick = async (instance = {}) => {
     return
   }
 
-  if (!tradeBeyondEnd && !_isEmpty(orders)) {
+  if (!isMarketOrder && !isBookUpdated) {
+    scheduleTick()
+    return
+  }
+
+  if (!isMarketOrder && !tradeBeyondEnd && !_isEmpty(orders)) {
+    await updateState(instance, { isBookUpdated: false })
     await emit('exec:order:cancel:all', gid, orders)
   }
 
@@ -68,7 +75,7 @@ const onSelfIntervalTick = async (instance = {}) => {
 
   let orderPrice
 
-  if (!/MARKET/.test(orderType)) {
+  if (!isMarketOrder) {
     if (hasTradeTarget(args)) {
       orderPrice = getTradePrice(state)
     } else if (hasOBTarget(args)) {

--- a/lib/twap/meta/init_state.js
+++ b/lib/twap/meta/init_state.js
@@ -16,7 +16,8 @@ const initState = (args = {}) => {
     timeout: null,
     remainingAmount: amount,
     args,
-    shutdown: false
+    shutdown: false,
+    isBookUpdated: false
   }
 }
 

--- a/lib/twap/util/get_ob_price.js
+++ b/lib/twap/util/get_ob_price.js
@@ -12,11 +12,11 @@ const Config = require('../config')
  * @returns {number} obPrice
  */
 const getOBPrice = (state = {}) => {
-  const { args = {}, lastBook } = state
+  const { args = {}, lastBook, isBookUpdated } = state
   const { amount, priceTarget, priceCondition } = args
   let price = null
 
-  if (!lastBook) {
+  if (!lastBook || !isBookUpdated) {
     return null
   }
 

--- a/lib/twap/util/schedule_tick.js
+++ b/lib/twap/util/schedule_tick.js
@@ -1,0 +1,18 @@
+'use strict'
+
+const scheduleTick = async (instance) => {
+  const { state = {}, h = {} } = instance
+  const { args = {} } = state
+  const { debug, timeout, updateState, emitSelf } = h
+  const { sliceInterval } = args
+
+  debug('scheduling interval (%f s)', sliceInterval / 1000)
+  const [id, t] = timeout(sliceInterval)
+  await updateState(instance, { timeout: id })
+  await t()
+  await emitSelf('interval_tick')
+}
+
+module.exports = {
+  tick: scheduleTick
+}

--- a/test/lib/twap/events/self_interval_tick.js
+++ b/test/lib/twap/events/self_interval_tick.js
@@ -54,31 +54,33 @@ describe('twap:events:self_interval_tick', () => {
     assert.ok(orderSubmitted, 'did not submit order for float amounts')
   })
 
-  it('doesn\'t submit a new order if order amount exceeds in case of trading beyond end', (done) => {
-    onIntervalTick({
+  it('doesn\'t submit a new order if order amount exceeds in case of trading beyond end', async () => {
+    let orderSubmitted = false
+    const instance = {
       state: {
         gid: 100,
         orders: { o: { amount: 0.4 }, p: { amount: 0.4 } },
         args: {
           ...args,
           sliceAmount: 0.4
-        }
+        },
+        isBookUpdated: true
       },
 
       h: {
         timeout,
         updateState: () => {},
         emitSelf: () => {},
-        debug: (msg) => {
-          if (msg === 'tick') {
-            return
+        debug: () => {},
+        emit: (eventName) => {
+          if (eventName === 'exec:order:submit:all') {
+            orderSubmitted = true
           }
-          assert.strictEqual(msg, 'next tick would exceed total order amount, refusing')
-          done()
-        },
-        emit: () => {}
+        }
       }
-    })
+    }
+    await onIntervalTick(instance)
+    assert.ok(!orderSubmitted, 'should not have submitted a new order if order amount exceeds')
   })
 
   it('cancels if not trading beyond end period and there are orders', (done) => {
@@ -89,7 +91,8 @@ describe('twap:events:self_interval_tick', () => {
         args: {
           ...args,
           tradeBeyondEnd: false
-        }
+        },
+        isBookUpdated: true
       },
 
       h: {
@@ -118,7 +121,8 @@ describe('twap:events:self_interval_tick', () => {
         args: {
           ...args,
           priceCondition: Config.PRICE_COND.MATCH_MIDPOINT
-        }
+        },
+        isBookUpdated: true
       },
 
       h: {
@@ -144,7 +148,8 @@ describe('twap:events:self_interval_tick', () => {
         args: {
           ...args,
           priceCondition: Config.PRICE_COND.MATCH_LAST
-        }
+        },
+        isBookUpdated: true
       },
 
       h: {
@@ -170,7 +175,7 @@ describe('twap:events:self_interval_tick', () => {
         lastBook: {
           midPrice: () => { return 1000 }
         },
-
+        isBookUpdated: true,
         remainingAmount: 1,
         args: {
           ...args,
@@ -210,7 +215,8 @@ describe('twap:events:self_interval_tick', () => {
         args: {
           ...args,
           priceCondition: Config.PRICE_COND.MATCH_LAST
-        }
+        },
+        isBookUpdated: true
       },
 
       h: {
@@ -245,7 +251,8 @@ describe('twap:events:self_interval_tick', () => {
         args: {
           ...args,
           priceCondition: Config.PRICE_COND.MATCH_LAST
-        }
+        },
+        isBookUpdated: true
       },
 
       h: {
@@ -271,7 +278,7 @@ describe('twap:events:self_interval_tick', () => {
         lastBook: {
           midPrice: () => { return 2000 }
         },
-
+        isBookUpdated: true,
         remainingAmount: 1,
         args: {
           ...args,

--- a/test/lib/twap/events/self_interval_tick.js
+++ b/test/lib/twap/events/self_interval_tick.js
@@ -1,304 +1,243 @@
 /* eslint-env mocha */
 'use strict'
 
+const sinon = require('sinon')
 const assert = require('assert')
-const Promise = require('bluebird')
 const _isObject = require('lodash/isObject')
+const scheduleTick = require('../../../../lib/twap/util/schedule_tick')
 const onIntervalTick = require('../../../../lib/twap/events/self_interval_tick')
 const Config = require('../../../../lib/twap/config')
 
-const args = {
-  priceTarget: 1000,
-  tradeBeyondEnd: true,
-  sliceAmount: 0.1,
-  amount: 1,
-  orderType: 'LIMIT'
-}
-
-const timeout = (ms) => {
-  let id = null
-
-  const p = new Promise((resolve) => {
-    id = setTimeout(resolve, ms)
-  })
-
-  return [id, () => p]
-}
+const getInstance = ({
+  params = {}, argParams = {}, stateParams = {}, helperParams = {}
+}) => ({
+  state: {
+    gid: 100,
+    isBookUpdated: true,
+    remainingAmount: 1,
+    orders: { o: { amount: 0.1 }, p: { amount: 0.1 } },
+    args: {
+      priceTarget: 1000,
+      tradeBeyondEnd: true,
+      cancelDelay: 100,
+      submitDelay: 200,
+      sliceAmount: 0.1,
+      amount: 1,
+      orderType: 'LIMIT',
+      priceCondition: Config.PRICE_COND.MATCH_MIDPOINT,
+      ...argParams
+    },
+    ...stateParams
+  },
+  h: {
+    timeout: () => {
+      return [null, () => {}]
+    },
+    debug: () => {},
+    updateState: () => {},
+    emitSelf: () => {},
+    emit: () => {},
+    ...helperParams
+  },
+  ...params
+})
 
 describe('twap:events:self_interval_tick', () => {
+  it('calls schedule tick function when book isn\'t updated', async () => {
+    const stubbedScheduler = sinon.stub(scheduleTick, 'tick').resolves()
+    const instance = getInstance({
+      stateParams: {
+        isBookUpdated: false
+      }
+    })
+    await onIntervalTick(instance)
+    assert.ok(stubbedScheduler.calledOnceWithExactly(instance), 'schedule tick not called when book not updated')
+  })
+
   it('submits order for float order amount', async () => {
     let orderSubmitted = false
-    const instance = {
-      state: {
-        gid: 100,
-        orders: { o: { amount: 0.1 }, p: { amount: 0.1 } },
-        args: {
-          ...args,
-          amount: 0.3,
-          orderType: 'MARKET'
-        }
+    const instance = getInstance({
+      argParams: {
+        amount: 0.3,
+        orderType: 'MARKET'
       },
-      h: {
-        timeout,
-        updateState: () => {},
-        emitSelf: () => {},
-        debug: () => {},
+      helperParams: {
         emit: (eventName) => {
           if (eventName === 'exec:order:submit:all') {
             orderSubmitted = true
           }
         }
       }
-    }
+    })
     await onIntervalTick(instance)
     assert.ok(orderSubmitted, 'did not submit order for float amounts')
   })
 
   it('doesn\'t submit a new order if order amount exceeds in case of trading beyond end', async () => {
     let orderSubmitted = false
-    const instance = {
-      state: {
-        gid: 100,
-        orders: { o: { amount: 0.4 }, p: { amount: 0.4 } },
-        args: {
-          ...args,
-          sliceAmount: 0.4
-        },
+    const instance = getInstance({
+      stateParams: {
+        orders: { o: { amount: 0.1 }, p: { amount: 0.1 } },
         isBookUpdated: true
       },
-
-      h: {
-        timeout,
-        updateState: () => {},
-        emitSelf: () => {},
-        debug: () => {},
+      argParams: {
+        sliceAmount: 0.4
+      },
+      helperParams: {
         emit: (eventName) => {
           if (eventName === 'exec:order:submit:all') {
             orderSubmitted = true
           }
         }
       }
-    }
+    })
     await onIntervalTick(instance)
     assert.ok(!orderSubmitted, 'should not have submitted a new order if order amount exceeds')
   })
 
-  it('cancels if not trading beyond end period and there are orders', (done) => {
-    onIntervalTick({
-      state: {
-        gid: 100,
-        orders: { o: 42 },
-        args: {
-          ...args,
-          tradeBeyondEnd: false
-        },
-        isBookUpdated: true
+  it('cancels if not trading beyond end period and there are orders', async () => {
+    const instance = getInstance({
+      stateParams: {
+        orders: { o: 42 }
       },
-
-      h: {
-        timeout,
-        updateState: () => {},
-        emitSelf: () => {},
-        debug: () => {},
+      argParams: {
+        tradeBeyondEnd: false
+      },
+      helperParams: {
         emit: (eventName, gid, orders, delay) => {
-          return new Promise((resolve) => {
-            if (eventName !== 'exec:order:cancel:all') {
-              return
-            }
-            assert.strictEqual(gid, 100)
-            assert.deepStrictEqual(orders, { o: 42 })
-            resolve()
-          }).then(done).catch(done)
+          if (eventName !== 'exec:order:cancel:all') {
+            return
+          }
+          assert.strictEqual(gid, 100)
+          assert.deepStrictEqual(orders, { o: 42 })
         }
       }
     })
+    await onIntervalTick(instance)
   })
 
-  it('does not submit orders if book price data needed & unavailable', (done) => {
-    onIntervalTick({
-      state: {
-        gid: 100,
-        args: {
-          ...args,
-          priceCondition: Config.PRICE_COND.MATCH_MIDPOINT
-        },
-        isBookUpdated: true
-      },
-
-      h: {
-        timeout,
-        updateState: () => {},
-        emitSelf: () => {},
-        debug: () => {},
-        emit: (eventName, gid, orders, delay) => {
-          return new Promise((resolve, reject) => {
-            reject(new Error('should not have submitted orders'))
-          }).catch(done)
+  it('does not submit orders if book price data needed & unavailable', async () => {
+    let orderSubmitted = false
+    const instance = getInstance({
+      helperParams: {
+        emit: (eventName) => {
+          if (eventName === 'exec:order:submit:all') {
+            orderSubmitted = true
+          }
         }
       }
     })
-
-    done()
+    await onIntervalTick(instance)
+    assert.deepStrictEqual(orderSubmitted, false, 'should not have submitted orders')
   })
 
-  it('does not submit orders if trade price data needed & unavailable', (done) => {
-    onIntervalTick({
-      state: {
-        gid: 100,
-        args: {
-          ...args,
-          priceCondition: Config.PRICE_COND.MATCH_LAST
-        },
-        isBookUpdated: true
+  it('does not submit orders if trade price data needed & unavailable', async () => {
+    let orderSubmitted = false
+    const instance = getInstance({
+      argParams: {
+        priceCondition: Config.PRICE_COND.MATCH_LAST
       },
-
-      h: {
-        timeout,
-        updateState: () => {},
-        emitSelf: () => {},
-        debug: () => {},
-        emit: (eventName, gid, orders, delay) => {
-          return new Promise((resolve, reject) => {
-            reject(new Error('should not have submitted orders'))
-          }).catch(done)
+      helperParams: {
+        emit: (eventName) => {
+          if (eventName === 'exec:order:submit:all') {
+            orderSubmitted = true
+          }
         }
       }
     })
-
-    done()
+    await onIntervalTick(instance)
+    assert.deepStrictEqual(orderSubmitted, false, 'should not have submitted orders')
   })
 
-  it('submits order if book price data needed, available, and matched', (done) => {
-    onIntervalTick({
-      state: {
-        gid: 100,
+  it('submits order if book price data needed, available, and matched', async () => {
+    const instance = getInstance({
+      stateParams: {
         lastBook: {
           midPrice: () => { return 1000 }
-        },
-        isBookUpdated: true,
-        remainingAmount: 1,
-        args: {
-          ...args,
-          priceCondition: Config.PRICE_COND.MATCH_MIDPOINT
         }
       },
+      argParams: {
+      },
+      helperParams: {
+        emit: (eventName, gid, orders) => {
+          assert.strictEqual(eventName, 'exec:order:submit:all')
+          assert.strictEqual(gid, 100)
+          assert.strictEqual(orders.length, 1)
 
-      h: {
-        timeout,
-        updateState: () => {},
-        emitSelf: () => {},
-        debug: () => {},
-        emit: (eventName, gid, orders, delay) => {
-          return new Promise((resolve) => {
-            assert.strictEqual(eventName, 'exec:order:submit:all')
-            assert.strictEqual(gid, 100)
-            assert.strictEqual(orders.length, 1)
-
-            const [order] = orders
-            assert(_isObject(order))
-            assert.strictEqual(order.price, args.priceTarget)
-            assert.strictEqual(order.amount, args.sliceAmount)
-            assert.strictEqual(order.type, 'LIMIT')
-            resolve()
-          }).then(done).catch(done)
+          const [order] = orders
+          assert(_isObject(order))
+          assert.strictEqual(order.price, 1000)
+          assert.strictEqual(order.amount, 0.1)
+          assert.strictEqual(order.type, 'LIMIT')
         }
       }
     })
+    await onIntervalTick(instance)
   })
 
-  it('submits order if trade price data needed, available, and matched', (done) => {
-    onIntervalTick({
-      state: {
-        gid: 100,
-        lastTrade: { price: 1000 },
-        remainingAmount: 1,
-        args: {
-          ...args,
-          priceCondition: Config.PRICE_COND.MATCH_LAST
-        },
-        isBookUpdated: true
+  it('submits order if trade price data needed, available, and matched', async () => {
+    const instance = getInstance({
+      stateParams: {
+        lastTrade: { price: 1000 }
       },
+      argParams: {
+        priceCondition: Config.PRICE_COND.MATCH_LAST
+      },
+      helperParams: {
+        emit: (eventName, gid, orders) => {
+          assert.strictEqual(eventName, 'exec:order:submit:all')
+          assert.strictEqual(gid, 100)
+          assert.strictEqual(orders.length, 1)
 
-      h: {
-        timeout,
-        updateState: () => {},
-        emitSelf: () => {},
-        debug: () => {},
-        emit: (eventName, gid, orders, delay) => {
-          return new Promise((resolve) => {
-            assert.strictEqual(eventName, 'exec:order:submit:all')
-            assert.strictEqual(gid, 100)
-            assert.strictEqual(orders.length, 1)
-
-            const [order] = orders
-            assert(_isObject(order))
-            assert.strictEqual(order.price, args.priceTarget)
-            assert.strictEqual(order.amount, args.sliceAmount)
-            assert.strictEqual(order.type, 'LIMIT')
-            resolve()
-          }).then(done).catch(done)
+          const [order] = orders
+          assert(_isObject(order))
+          assert.strictEqual(order.price, 1000)
+          assert.strictEqual(order.amount, 0.1)
+          assert.strictEqual(order.type, 'LIMIT')
         }
       }
     })
+    await onIntervalTick(instance)
   })
 
-  it('does not submit order if trade price data needed, available, but not matched', (done) => {
-    onIntervalTick({
-      state: {
-        gid: 100,
-        lastTrade: { price: 2000 },
-        remainingAmount: 1,
-        args: {
-          ...args,
-          priceCondition: Config.PRICE_COND.MATCH_LAST
-        },
-        isBookUpdated: true
+  it('does not submit order if trade price data needed, available, but not matched', async () => {
+    let orderSubmitted = false
+    const instance = getInstance({
+      stateParams: {
+        lastTrade: { price: 2000 }
       },
-
-      h: {
-        timeout,
-        updateState: () => {},
-        emitSelf: () => {},
-        debug: () => {},
-        emit: (eventName, gid, orders, delay) => {
-          return new Promise((resolve, reject) => {
-            reject(new Error('should not have submitted orders'))
-          }).catch(done)
+      argParams: {
+        priceCondition: Config.PRICE_COND.MATCH_LAST
+      },
+      helperParams: {
+        emit: (eventName) => {
+          if (eventName === 'exec:order:submit:all') {
+            orderSubmitted = true
+          }
         }
       }
     })
-
-    done()
+    await onIntervalTick(instance)
+    assert.deepStrictEqual(orderSubmitted, false, 'should not have submitted orders')
   })
 
-  it('does not submit order if book price data needed, available, but not matched', (done) => {
-    onIntervalTick({
-      state: {
-        gid: 100,
+  it('does not submit order if book price data needed, available, but not matched', async () => {
+    let orderSubmitted = false
+    const instance = getInstance({
+      stateParams: {
         lastBook: {
           midPrice: () => { return 2000 }
-        },
-        isBookUpdated: true,
-        remainingAmount: 1,
-        args: {
-          ...args,
-          priceCondition: Config.PRICE_COND.MATCH_MIDPOINT
         }
       },
-
-      h: {
-        timeout,
-        updateState: () => {},
-        emitSelf: () => {},
-        debug: () => {},
-        emit: (eventName, gid, orders, delay) => {
-          return new Promise((resolve, reject) => {
-            reject(new Error('should not have submitted orders'))
-          }).catch(done)
+      helperParams: {
+        emit: (eventName) => {
+          if (eventName === 'exec:order:submit:all') {
+            orderSubmitted = true
+          }
         }
       }
     })
-
-    done()
+    await onIntervalTick(instance)
+    assert.deepStrictEqual(orderSubmitted, false, 'should not have submitted orders')
   })
 })

--- a/test/lib/twap/util/schedule_tick.js
+++ b/test/lib/twap/util/schedule_tick.js
@@ -1,0 +1,27 @@
+/* eslint-env mocha */
+'use strict'
+
+const assert = require('assert')
+const { tick } = require('../../../../lib/twap/util/schedule_tick')
+
+describe('twap:util:schedule_tick', () => {
+  it('schedules interval tick', async () => {
+    let selfEmitsIntervalTick = false
+    const instance = {
+      h: {
+        timeout: () => {
+          return [null, () => {}]
+        },
+        debug: () => {},
+        updateState: () => {},
+        emitSelf: (eventName) => {
+          if (eventName === 'interval_tick') {
+            selfEmitsIntervalTick = true
+          }
+        }
+      }
+    }
+    await tick(instance)
+    assert.ok(selfEmitsIntervalTick, 'should have self emitted interval tick')
+  })
+})


### PR DESCRIPTION
The book updates asynchronously using an event emitter. So, this fix waits for the book to be updated in local after the order cancellation and then calculates the price with the new updated book without skipping the current tick.