### PR TITLE
fix algo order startup

### DIFF
--- a/lib/ao_host.js
+++ b/lib/ao_host.js
@@ -110,8 +110,11 @@ class AOHost extends AsyncEventEmitter {
 
     bindWS2Bus(this)
 
-    this.adapter.once('order:snapshot', (snapshot) => {
+    this.adapter.on('order:snapshot', (snapshot) => {
       this.orderSnapshot = snapshot
+    })
+
+    this.adapter.once('order:snapshot', (snapshot) => {
       this.emit('ready')
     })
   }

--- a/lib/ao_host.js
+++ b/lib/ao_host.js
@@ -85,6 +85,8 @@ class AOHost extends AsyncEventEmitter {
 
     this.instances = {}
 
+    this.ready = false
+
     this.onAOStart = this.onAOStart.bind(this)
     this.onAOStop = this.onAOStop.bind(this)
     this.onAOPersist = this.onAOPersist.bind(this)
@@ -114,7 +116,8 @@ class AOHost extends AsyncEventEmitter {
       this.orderSnapshot = snapshot
     })
 
-    this.adapter.once('order:snapshot', (snapshot) => {
+    this.adapter.once('order:snapshot', () => {
+      this.ready = true
       this.emit('ready')
     })
   }
@@ -461,6 +464,10 @@ class AOHost extends AsyncEventEmitter {
    * @private
    */
   async bootstrapAO (ao, instance = {}, gidCB) {
+    if (!this.ready) {
+      throw new Error('ERR_NOT_READY')
+    }
+
     const { state } = instance
     const { gid } = state
 
@@ -487,20 +494,7 @@ class AOHost extends AsyncEventEmitter {
       await declareChannels(this.instances[gid], this)
     }
 
-    // Cancel existing orders
-    if (this.orderSnapshot.gid === +gid) {
-      await this.adapter.cancelOrderWithDelay(
-        state.connection, 0, this.orderSnapshot
-      )
-    } else {
-      for (let i = 0; i < this.orderSnapshot.length; i += 1) {
-        if (this.orderSnapshot[i].gid === +gid) {
-          await this.adapter.cancelOrderWithDelay(
-            state.connection, 0, this.orderSnapshot[i]
-          )
-        }
-      }
-    }
+    await this.maybeCancelExistingOrders(state, gid)
 
     if (_isFunction(gidCB)) {
       await gidCB(gid)
@@ -509,6 +503,28 @@ class AOHost extends AsyncEventEmitter {
     await this.emit('ao:start', this.instances[gid])
 
     return gid
+  }
+
+  async maybeCancelExistingOrders (state, gid) {
+    const snapshot = this.orderSnapshot
+
+    if (snapshot.gid && snapshot.gid === +gid) {
+      await this.adapter.cancelOrderWithDelay(
+        state.connection, 0, snapshot
+      )
+      return
+    }
+
+    // snapshot is an array-like-object
+    for (let i = 0; i < snapshot.length; i += 1) {
+      const el = snapshot[i]
+
+      if (el.gid === +gid) {
+        await this.adapter.cancelOrderWithDelay(
+          state.connection, 0, el
+        )
+      }
+    }
   }
 
   /**


### PR DESCRIPTION
this PR contains two fixes:

- fix: update order snapshots not just once, small fix for the event emitter


- bootstrap: error when no snapshot is received 

when there are connection issues, no snapshot is received. in
those cases we want to refuse the start of the algo order with an
error, because we don't know what state our account is in.

this error can be handled by the spawning server, but should be
an exception. the server should run `connect` on the host and
then wait for the ready event to get emitted, before starting the
first algo order.