### PR TITLE
check for the latest shutdown state in twap

### DIFF
--- a/lib/twap/events/self_interval_tick.js
+++ b/lib/twap/events/self_interval_tick.js
@@ -69,6 +69,10 @@ const onSelfIntervalTick = async (instance = {}) => {
     await t()
   }
 
+  if (instance.state.shutdown) {
+    return
+  }
+
   let orderPrice
 
   if (!/MARKET/.test(orderType)) {


### PR DESCRIPTION
check for the latest shutdown state after waiting for the submitDelay period preventing from submitting orders to be submitted if user cancelled algo order in between that time