### PR TITLE
await delay before submitting orders before generating orders

### DIFF
--- a/lib/iceberg/events/life_stop.js
+++ b/lib/iceberg/events/life_stop.js
@@ -9,10 +9,17 @@
  * @param {AOInstance} instance - AO instance
  */
 const onLifeStop = async (instance = {}) => {
-  const { h = {} } = instance
-  const { debouncedSubmitOrders } = h
+  const { state = {}, h = {} } = instance
+  const { timeout } = state
+  const { debouncedSubmitOrders, debug, updateState } = h
 
   debouncedSubmitOrders.cancel()
+
+  if (timeout !== null) {
+    clearTimeout(timeout)
+    await updateState(instance, { timeout: null })
+    debug('cleared timeout')
+  }
 }
 
 module.exports = onLifeStop

--- a/lib/iceberg/events/orders_order_fill.js
+++ b/lib/iceberg/events/orders_order_fill.js
@@ -20,14 +20,14 @@ const onOrdersOrderFill = async (instance = {}, order) => {
   const { state = {}, h = {} } = instance
   const { args = {}, orders = {}, gid } = state
   const { emit, updateState, debug, debouncedSubmitOrders } = h
-  const { cancelDelay, amount } = args
+  const { amount } = args
   const m = amount < 0 ? -1 : 1
 
-  await emit('exec:order:cancel:all', gid, orders, cancelDelay)
+  await emit('exec:order:cancel:all', gid, orders, 0)
 
   const fillAmount = order.getLastFillAmount()
 
-  const remainingAmount = nBN(state.remainingAmount).minus(fillAmount).toNumber()
+  const remainingAmount = nBN(instance.state.remainingAmount).minus(fillAmount).toNumber()
   const absRem = m < 0 ? remainingAmount * -1 : remainingAmount
 
   order.resetFilledAmount()

--- a/lib/iceberg/events/self_submit_orders.js
+++ b/lib/iceberg/events/self_submit_orders.js
@@ -15,12 +15,13 @@ const generateOrders = require('../util/generate_orders')
  */
 const onSelfSubmitOrders = async (instance = {}) => {
   const { state = {}, h = {} } = instance
-  const { emit, timeout } = h
+  const { emit, timeout, updateState } = h
   const { args = {}, gid } = state
   const { submitDelay } = args
 
   if (submitDelay) {
-    const [, t] = timeout(submitDelay)
+    const [id, t] = timeout(submitDelay)
+    await updateState(instance, { timeout: id })
     await t()
   }
 

--- a/lib/iceberg/events/self_submit_orders.js
+++ b/lib/iceberg/events/self_submit_orders.js
@@ -15,12 +15,18 @@ const generateOrders = require('../util/generate_orders')
  */
 const onSelfSubmitOrders = async (instance = {}) => {
   const { state = {}, h = {} } = instance
-  const { emit } = h
+  const { emit, timeout } = h
   const { args = {}, gid } = state
   const { submitDelay } = args
-  const orders = generateOrders(state)
 
-  return emit('exec:order:submit:all', gid, orders, submitDelay)
+  if (submitDelay) {
+    const [, t] = timeout(submitDelay)
+    await t()
+  }
+
+  const orders = generateOrders(instance.state)
+
+  return emit('exec:order:submit:all', gid, orders, 0)
 }
 
 module.exports = onSelfSubmitOrders

--- a/test/lib/iceberg/events/orders_order_fill.js
+++ b/test/lib/iceberg/events/orders_order_fill.js
@@ -5,6 +5,10 @@ const assert = require('assert')
 const Promise = require('bluebird')
 const onOrderFill = require('../../../../lib/iceberg/events/orders_order_fill')
 
+const timeout = () => {
+  return [null, () => {}]
+}
+
 describe('iceberg:events:orders_order_fill', () => {
   const orderState = { 1: 'some_order_object' }
   const instance = {
@@ -19,6 +23,7 @@ describe('iceberg:events:orders_order_fill', () => {
     },
 
     h: {
+      timeout,
       debug: () => {},
       updateState: async () => {},
       emitSelf: async () => {},
@@ -48,7 +53,7 @@ describe('iceberg:events:orders_order_fill', () => {
           return new Promise((resolve) => {
             assert.strictEqual(gid, 100)
             assert.strictEqual(eName, 'exec:order:cancel:all')
-            assert.strictEqual(cancelDelay, 42)
+            assert.strictEqual(cancelDelay, 0)
             assert.deepStrictEqual(orders, orderState)
             resolve()
           }).then(done).catch(done)

--- a/test/lib/iceberg/events/self_submit_orders.js
+++ b/test/lib/iceberg/events/self_submit_orders.js
@@ -23,11 +23,15 @@ describe('iceberg:events:self_submit_orders', () => {
       },
 
       h: {
+        timeout: () => {
+          return [null, () => {}]
+        },
+        updateState: () => {},
         emit: (eName, gid, orders, submitDelay) => {
           return new Promise((resolve) => {
             assert.strictEqual(eName, 'exec:order:submit:all')
             assert.strictEqual(gid, 41)
-            assert.strictEqual(submitDelay, 42)
+            assert.strictEqual(submitDelay, 0)
             assert.strictEqual(orders.length, 1)
 
             const [order] = orders


### PR DESCRIPTION
Awaits for the submit delay before generating new orders and read the amounts from the latest state if the adjacent order was filled in between the submit delay await. If the submit delay is relatively a substantial number, this prevents from submitting two new orders and gets the job done in one if the adjacent order was filled in between this submit delay awaiting period.  