### PR TITLE
Remove cancel delays from ping pong orders

### DIFF
--- a/lib/ping_pong/events/life_stop.js
+++ b/lib/ping_pong/events/life_stop.js
@@ -11,11 +11,10 @@
  */
 const onLifeStop = async (instance = {}) => {
   const { state = {}, h = {} } = instance
-  const { args = {}, orders = {}, gid } = state
+  const { orders = {}, gid } = state
   const { emit } = h
-  const { cancelDelay } = args
 
-  return emit('exec:order:cancel:all', gid, orders, cancelDelay)
+  return emit('exec:order:cancel:all', gid, orders)
 }
 
 module.exports = onLifeStop

--- a/lib/ping_pong/events/orders_order_cancel.js
+++ b/lib/ping_pong/events/orders_order_cancel.js
@@ -13,13 +13,12 @@
  */
 const onOrdersOrderCancel = async (instance = {}, order) => {
   const { state = {}, h = {} } = instance
-  const { args = {}, orders = {}, gid } = state
+  const { orders = {}, gid } = state
   const { emit, debug } = h
-  const { cancelDelay } = args
 
   debug('detected atomic cancelation, stopping...')
 
-  await emit('exec:order:cancel:all', gid, orders, cancelDelay)
+  await emit('exec:order:cancel:all', gid, orders)
   await emit('exec:stop')
 }
 

--- a/lib/ping_pong/index.js
+++ b/lib/ping_pong/index.js
@@ -35,7 +35,6 @@ const genOrderLabel = require('./meta/gen_order_label')
  *   pingMaxPrice: 6700,
  *   pongDistance: 300,
  *   submitDelay: 150,
- *   cancelDelay: 150,
  *   _margin: false,
  * })
  */

--- a/lib/ping_pong/meta/get_ui_def.js
+++ b/lib/ping_pong/meta/get_ui_def.js
@@ -37,7 +37,7 @@ const getUIDef = () => ({
     rows: [
       ['action', null],
       ['amount', 'orderCount'],
-      ['submitDelaySec', 'cancelDelaySec']
+      ['submitDelaySec', null]
     ]
   }, {
     title: '',
@@ -103,13 +103,6 @@ const getUIDef = () => ({
       label: 'Submit Delay (sec)',
       customHelp: 'Seconds to wait before submitting orders',
       default: 1
-    },
-
-    cancelDelaySec: {
-      component: 'input.number',
-      label: 'Cancel Delay (sec)',
-      customHelp: 'Seconds to wait before cancelling orders',
-      default: 0
     },
 
     endless: {

--- a/lib/ping_pong/meta/process_params.js
+++ b/lib/ping_pong/meta/process_params.js
@@ -24,18 +24,9 @@ const processParams = (data) => {
     delete params.lev
   }
 
-  if (_isFinite(params.cancelDelaySec)) {
-    params.cancelDelay = params.cancelDelaySec * 1000
-    delete params.cancelDelaySec
-  }
-
   if (_isFinite(params.submitDelaySec)) {
     params.submitDelay = params.submitDelaySec * 1000
     delete params.submitDelaySec
-  }
-
-  if (!_isFinite(params.cancelDelay)) {
-    params.cancelDelay = 1000
   }
 
   if (!_isFinite(params.submitDelay)) {

--- a/test/lib/ping_pong/index.js
+++ b/test/lib/ping_pong/index.js
@@ -21,7 +21,6 @@ testAOLive({
     amount: 6,
     orderCount: 4,
     submitDelaySec: 0,
-    cancelDelaySec: 0,
 
     pingMinPrice: 0.4,
     pingMaxPrice: 0.6,


### PR DESCRIPTION
Remove the cancel delay options from ping pong orders.
Related PR: https://github.com/bitfinexcom/bfx-hf-algo/pull/89