### PR TITLE
Remove cancel delay options from twap

### DIFF
--- a/lib/twap/events/life_stop.js
+++ b/lib/twap/events/life_stop.js
@@ -22,7 +22,7 @@ const onLifeStop = async (instance = {}) => {
     debug('cleared interval/timeout')
   }
 
-  await emit('exec:order:cancel:all', gid, orders, 0)
+  await emit('exec:order:cancel:all', gid, orders)
 }
 
 module.exports = onLifeStop

--- a/lib/twap/events/orders_order_cancel.js
+++ b/lib/twap/events/orders_order_cancel.js
@@ -14,14 +14,11 @@
  * @returns {Promise} p - resolves on completion
  */
 const onOrdersOrderCancel = async (instance = {}, order) => {
-  const { state = {}, h = {} } = instance
-  const { args = {}, orders = {}, gid } = state
+  const { h = {} } = instance
   const { emit, debug } = h
-  const { cancelDelay } = args
 
   debug('detected atomic cancelation, stopping...')
 
-  await emit('exec:order:cancel:all', gid, orders, cancelDelay)
   await emit('exec:stop')
 }
 

--- a/lib/twap/events/self_interval_tick.js
+++ b/lib/twap/events/self_interval_tick.js
@@ -24,7 +24,7 @@ const onSelfIntervalTick = async (instance = {}) => {
   const { orders = {}, args = {}, gid, shutdown } = state
   const { emit, debug, timeout, updateState, emitSelf } = h
   const {
-    priceTarget, tradeBeyondEnd, amount, sliceAmount, cancelDelay, submitDelay, priceDelta,
+    priceTarget, tradeBeyondEnd, amount, sliceAmount, submitDelay, priceDelta,
     orderType, sliceInterval
   } = args
 
@@ -43,9 +43,7 @@ const onSelfIntervalTick = async (instance = {}) => {
   }
 
   if (!tradeBeyondEnd && !_isEmpty(orders)) {
-    const [, t] = timeout(cancelDelay)
-    await t()
-    await emit('exec:order:cancel:all', gid, orders, 0)
+    await emit('exec:order:cancel:all', gid, orders)
   }
 
   if (tradeBeyondEnd) {

--- a/lib/twap/index.js
+++ b/lib/twap/index.js
@@ -33,7 +33,6 @@ const config = require('./config')
  * @param {string} orderType - LIMIT or MARKET
  * @param {boolean} _margin - if false, order type is prefixed with EXCHANGE
  * @param {number} [submitDelay] - in ms, defaults to 1500
- * @param {number} [cancelDelay] - in ms, defaults to 5000
  *
  * @example
  * await host.startAO('bfx-twap', {
@@ -48,7 +47,6 @@ const config = require('./config')
  *   tradeBeyondEnd: false,
  *   orderType: 'LIMIT',
  *   submitDelay: 150,
- *   cancelDelay: 150,
  *   _margin: false
  * })
  */

--- a/lib/twap/meta/get_ui_def.js
+++ b/lib/twap/meta/get_ui_def.js
@@ -36,8 +36,7 @@ const getUIDef = () => ({
     rows: [
       ['orderType', 'amount'],
       ['sliceAmount', 'amountDistortion'],
-      ['sliceInterval', 'submitDelaySec'],
-      ['cancelDelaySec']
+      ['sliceInterval', 'submitDelaySec']
     ]
   }, {
     title: '',
@@ -73,13 +72,6 @@ const getUIDef = () => ({
       label: 'Submit Delay (sec)',
       customHelp: 'Seconds to wait before submitting orders',
       default: 2
-    },
-
-    cancelDelaySec: {
-      component: 'input.number',
-      label: 'Cancel Delay (sec)',
-      customHelp: 'Seconds to wait before cancelling orders',
-      default: 1
     },
 
     tradeBeyondEnd: {

--- a/lib/twap/meta/process_params.js
+++ b/lib/twap/meta/process_params.js
@@ -33,18 +33,9 @@ const processParams = (data) => {
     delete params._symbol
   }
 
-  if (_isFinite(params.cancelDelaySec)) {
-    params.cancelDelay = params.cancelDelaySec * 1000
-    delete params.cancelDelaySec
-  }
-
   if (_isFinite(params.submitDelaySec)) {
     params.submitDelay = params.submitDelaySec * 1000
     delete params.submitDelaySec
-  }
-
-  if (!_isFinite(params.cancelDelay)) {
-    params.cancelDelay = 1000
   }
 
   if (!_isFinite(params.submitDelay)) {

--- a/lib/twap/meta/validate_params.js
+++ b/lib/twap/meta/validate_params.js
@@ -23,20 +23,18 @@ const Config = require('../config')
  * @param {boolean} args.tradeBeyondEnd - if true, slices are not cancelled after their interval expires
  * @param {string} args.orderType - LIMIT or MARKET
  * @param {number} [args.submitDelay] - in ms, defaults to 1500
- * @param {number} [args.cancelDelay] - in ms, defaults to 5000
  * @returns {string} error - null if parameters are valid, otherwise a
  *   description of which parameter is invalid.
  */
 const validateParams = (args = {}) => {
   const {
     orderType, amount, sliceAmount, sliceInterval, amountDistortion, priceTarget, priceCondition,
-    cancelDelay, submitDelay, priceDelta, lev, _futures
+    submitDelay, priceDelta, lev, _futures
   } = args
 
   let err = null
 
   if (!Order.type[orderType]) err = 'invalid order type'
-  if (!_isFinite(cancelDelay) || cancelDelay < 0) err = 'invalid cancel delay'
   if (!_isFinite(submitDelay) || submitDelay < 0) err = 'invalid submit delay'
   if (!_isFinite(amount)) err = 'invalid amount'
   if (!_isFinite(sliceAmount)) err = 'invalid slice amount'

--- a/test/lib/twap/events/life_stop.js
+++ b/test/lib/twap/events/life_stop.js
@@ -1,23 +1,25 @@
 /* eslint-env mocha */
 'use strict'
 
-const onLifeStop = require('../../../../lib/twap/events/life_stop')
+const assert = require('assert')
+const onLifeStop = require('../../../../lib/ping_pong/events/life_stop')
 
 describe('twap:events:life_stop', () => {
-  it('sets up timeout & saves it on state', (done) => {
-    const timeout = setTimeout(() => {
-      done(new Error('timeout should not have been set'))
-    }, 10)
+  it('cancels all orders when twap algo stopped', async () => {
+    let cancelledOrders = false
 
-    onLifeStop({
-      state: { timeout },
+    await onLifeStop({
       h: {
         updateState: () => {},
         debug: () => {},
-        emit: () => {}
+        emit: (eventName) => {
+          if (eventName === 'exec:order:cancel:all') {
+            cancelledOrders = true
+          }
+        }
       }
     })
 
-    setTimeout(done, 50)
+    assert.ok(cancelledOrders, 'did not cancel all orders set by twap algo')
   })
 })

--- a/test/lib/twap/events/orders_order_cancel.js
+++ b/test/lib/twap/events/orders_order_cancel.js
@@ -6,33 +6,12 @@ const onOrderCancel = require('../../../../lib/twap/events/orders_order_cancel')
 
 describe('twap:events:orders_order_cancel', () => {
   it('submits all known orders for cancellation & stops operation', (done) => {
-    let call = 0
-    const orderState = {
-      1: 'some_order_object'
-    }
-
     onOrderCancel({
-      state: {
-        gid: 100,
-        args: { cancelDelay: 42 },
-        orders: orderState
-      },
-
       h: {
         debug: () => {},
-        emit: async (eName, gid, orders, cancelDelay) => {
-          if (call === 0) {
-            assert.strictEqual(gid, 100)
-            assert.strictEqual(eName, 'exec:order:cancel:all')
-            assert.strictEqual(cancelDelay, 42)
-            assert.deepStrictEqual(orders, orderState)
-            call += 1
-          } else if (call === 1) {
-            assert.strictEqual(eName, 'exec:stop')
-            done()
-          } else {
-            done(new Error('too many events emitted'))
-          }
+        emit: async (eName) => {
+          assert.strictEqual(eName, 'exec:stop')
+          done()
         }
       }
     })

--- a/test/lib/twap/events/orders_order_fill.js
+++ b/test/lib/twap/events/orders_order_fill.js
@@ -12,8 +12,7 @@ describe('twap:events:orders_order_fill', () => {
       gid: 100,
       orders: orderState,
       args: {
-        amount: 100,
-        cancelDelay: 42
+        amount: 100
       }
     },
 

--- a/test/lib/twap/events/self_interval_tick.js
+++ b/test/lib/twap/events/self_interval_tick.js
@@ -10,7 +10,6 @@ const Config = require('../../../../lib/twap/config')
 const args = {
   priceTarget: 1000,
   tradeBeyondEnd: true,
-  cancelDelay: 100,
   submitDelay: 200,
   sliceAmount: 0.1,
   amount: 1,
@@ -106,7 +105,6 @@ describe('twap:events:self_interval_tick', () => {
             }
             assert.strictEqual(gid, 100)
             assert.deepStrictEqual(orders, { o: 42 })
-            assert.strictEqual(delay, 0)
             resolve()
           }).then(done).catch(done)
         }

--- a/test/lib/twap/index.js
+++ b/test/lib/twap/index.js
@@ -21,7 +21,6 @@ testAOLive({
     sliceAmount: -6,
     sliceInterval: 200,
     submitDelaySec: 0,
-    cancelDelaySec: 0,
 
     priceTarget: 'OB_SIDE',
     priceDelta: 0,

--- a/test/lib/twap/meta/process_params.js
+++ b/test/lib/twap/meta/process_params.js
@@ -19,9 +19,8 @@ describe('twap:meta:process_params', () => {
     assert.strictEqual(params.symbol, 'tBTCUSD')
   })
 
-  it('provides defaults for cancel & submit delays', () => {
+  it('provides defaults for submit delay', () => {
     const params = processParams()
-    assert(_isFinite(params.cancelDelay))
     assert(_isFinite(params.submitDelay))
   })
 

--- a/test/lib/twap/meta/validate_params.js
+++ b/test/lib/twap/meta/validate_params.js
@@ -12,7 +12,6 @@ const validParams = {
   amountDistortion: 0.2,
   sliceInterval: 1,
   submitDelay: 100,
-  cancelDelay: 100,
   priceTarget: 1000,
   priceCondition: 'MATCH_LAST'
 }
@@ -64,18 +63,6 @@ describe('twap:meta:validate_params', () => {
     assert(_isString(validateParams({
       ...validParams,
       submitDelay: -100
-    })))
-  })
-
-  it('returns error on invalid or negative cancel delay', () => {
-    assert(_isString(validateParams({
-      ...validParams,
-      cancelDelay: 'nope'
-    })))
-
-    assert(_isString(validateParams({
-      ...validParams,
-      cancelDelay: -100
     })))
   })
 


### PR DESCRIPTION
- remove cancel delay options from twap orders
- handle cancel all orders on `stop` event
- remove cancelling all orders from `orders_cancel` event
- removed tests for cancelled delays

Related PR: https://github.com/bitfinexcom/bfx-hf-algo/pull/89