### PR TITLE
Remove cancel delay iceberg

### DIFF
--- a/lib/iceberg/events/orders_order_cancel.js
+++ b/lib/iceberg/events/orders_order_cancel.js
@@ -13,13 +13,12 @@
  */
 const onOrdersOrderCancel = async (instance = {}, order) => {
   const { state = {}, h = {} } = instance
-  const { args = {}, orders = {}, gid } = state
+  const { orders = {}, gid } = state
   const { emit, debug } = h
-  const { cancelDelay } = args
 
   debug('detected atomic cancelation, stopping...')
 
-  await emit('exec:order:cancel:all', gid, orders, cancelDelay)
+  await emit('exec:order:cancel:all', gid, orders)
   return emit('exec:stop')
 }
 

--- a/lib/iceberg/index.js
+++ b/lib/iceberg/index.js
@@ -25,7 +25,6 @@ const genOrderLabel = require('./meta/gen_order_label')
  * @param {boolean} excessAsHidden - whether to submit remainder as a hidden order
  * @param {string} orderType - LIMIT or MARKET
  * @param {number} [submitDelay] - in ms, default 1500
- * @param {number} [cancelDelay] - in ms, default 5000
  * @param {boolean} [_margin] - if false, prefixes order type with EXCHANGE
  *
  * @example
@@ -37,7 +36,6 @@ const genOrderLabel = require('./meta/gen_order_label')
  *   excessAsHidden: true,
  *   orderType: 'LIMIT',
  *   submitDelay: 150,
- *   cancelDelay: 150,
  *   _margin: false,
  * })
  */

--- a/lib/iceberg/meta/get_ui_def.js
+++ b/lib/iceberg/meta/get_ui_def.js
@@ -29,7 +29,7 @@ const getUIDef = () => ({
       ['orderType', 'price'],
       ['amount', 'excessAsHidden'],
       ['sliceAmount', 'sliceAmountPerc'],
-      ['submitDelaySec', 'cancelDelaySec']
+      ['submitDelaySec', null]
     ]
   }, {
     title: '',
@@ -107,13 +107,6 @@ const getUIDef = () => ({
       label: 'Submit Delay (sec)',
       customHelp: 'Seconds to wait before submitting orders',
       default: 2
-    },
-
-    cancelDelaySec: {
-      component: 'input.number',
-      label: 'Cancel Delay (sec)',
-      customHelp: 'Seconds to wait before cancelling orders',
-      default: 1
     },
 
     lev: {

--- a/lib/iceberg/meta/process_params.js
+++ b/lib/iceberg/meta/process_params.js
@@ -28,18 +28,9 @@ const processParams = (data) => {
     delete params.lev
   }
 
-  if (params.cancelDelaySec) {
-    params.cancelDelay = params.cancelDelaySec * 1000
-    delete params.cancelDelaySec
-  }
-
   if (params.submitDelaySec) {
     params.submitDelay = params.submitDelaySec * 1000
     delete params.submitDelaySec
-  }
-
-  if (!params.cancelDelay) {
-    params.cancelDelay = 1000
   }
 
   if (!params.submitDelay) {

--- a/lib/iceberg/meta/validate_params.js
+++ b/lib/iceberg/meta/validate_params.js
@@ -18,13 +18,12 @@ const _includes = require('lodash/includes')
  * @param {boolean} args.excessAsHidden - whether to submit remainder as a hidden order
  * @param {string} args.orderType - LIMIT or MARKET
  * @param {number} [args.submitDelay] - in ms, default 1500
- * @param {number} [args.cancelDelay] - in ms, default 5000
  * @returns {string} error - null if parameters are valid, otherwise a
  *   description of which parameter is invalid.
  */
 const validateParams = (args = {}) => {
   const {
-    price, amount, sliceAmount, orderType, submitDelay, cancelDelay, lev,
+    price, amount, sliceAmount, orderType, submitDelay, lev,
     _futures
   } = args
 
@@ -32,7 +31,6 @@ const validateParams = (args = {}) => {
   if (!_isFinite(amount)) return 'Invalid amount'
   if (!_isFinite(sliceAmount)) return 'Invalid slice amount'
   if (!_isFinite(submitDelay) || submitDelay < 0) return 'Invalid submit delay'
-  if (!_isFinite(cancelDelay) || cancelDelay < 0) return 'Invalid cancel delay'
   if (!_includes(orderType, 'MARKET') && (isNaN(price) || price <= 0)) {
     return 'Invalid price'
   }

--- a/test/lib/iceberg/events/orders_order_cancel.js
+++ b/test/lib/iceberg/events/orders_order_cancel.js
@@ -14,17 +14,15 @@ describe('iceberg:events:orders_order_cancel', () => {
     onOrderCancel({
       state: {
         gid: 100,
-        args: { cancelDelay: 42 },
         orders: orderState
       },
 
       h: {
         debug: () => {},
-        emit: async (eName, gid, orders, cancelDelay) => {
+        emit: async (eName, gid, orders) => {
           if (call === 0) {
             assert.strictEqual(gid, 100)
             assert.strictEqual(eName, 'exec:order:cancel:all')
-            assert.strictEqual(cancelDelay, 42)
             assert.deepStrictEqual(orders, orderState)
             call += 1
           } else if (call === 1) {

--- a/test/lib/iceberg/events/orders_order_fill.js
+++ b/test/lib/iceberg/events/orders_order_fill.js
@@ -16,8 +16,7 @@ describe('iceberg:events:orders_order_fill', () => {
       gid: 100,
       orders: orderState,
       args: {
-        amount: 100,
-        cancelDelay: 42
+        amount: 100
       },
       remainingAmount: 100
     },
@@ -46,14 +45,13 @@ describe('iceberg:events:orders_order_fill', () => {
       ...instance,
       h: {
         ...instance.h,
-        emit: (eName, gid, orders, cancelDelay) => {
+        emit: (eName, gid, orders) => {
           if (called !== 0) return
           called += 1
 
           return new Promise((resolve) => {
             assert.strictEqual(gid, 100)
             assert.strictEqual(eName, 'exec:order:cancel:all')
-            assert.strictEqual(cancelDelay, 0)
             assert.deepStrictEqual(orders, orderState)
             resolve()
           }).then(done).catch(done)

--- a/test/lib/iceberg/index.js
+++ b/test/lib/iceberg/index.js
@@ -18,7 +18,6 @@ testAOLive({
     excessAsHidden: true,
     orderType: 'LIMIT',
     submitDelay: 0,
-    cancelDelay: 0,
     _margin: true
   },
 

--- a/test/lib/iceberg/meta/process_params.js
+++ b/test/lib/iceberg/meta/process_params.js
@@ -19,9 +19,8 @@ describe('iceberg:meta:process_params', () => {
     assert.strictEqual(params.symbol, 'tBTCUSD')
   })
 
-  it('provides defaults for cancel & submit delays', () => {
+  it('provides default for submit delay', () => {
     const params = processParams()
-    assert(_isFinite(params.cancelDelay))
     assert(_isFinite(params.submitDelay))
   })
 
@@ -33,13 +32,11 @@ describe('iceberg:meta:process_params', () => {
     assert.strictEqual(sellParams.amount, -1)
   })
 
-  it('converts cancel/submit delays from s to ms', () => {
+  it('converts submit delay from s to ms', () => {
     const params = processParams({
-      cancelDelaySec: 1,
       submitDelaySec: 1
     })
 
-    assert.strictEqual(params.cancelDelay, 1000)
     assert.strictEqual(params.submitDelay, 1000)
   })
 

--- a/test/lib/iceberg/meta/validate_params.js
+++ b/test/lib/iceberg/meta/validate_params.js
@@ -10,8 +10,7 @@ const validParams = {
   orderType: 'LIMIT',
   amount: 1,
   sliceAmount: 0.1,
-  submitDelay: 100,
-  cancelDelay: 100
+  submitDelay: 100
 }
 
 describe('iceberg:meta:validate_params', () => {
@@ -49,18 +48,6 @@ describe('iceberg:meta:validate_params', () => {
     assert(_isString(validateParams({
       ...validParams,
       submitDelay: -100
-    })))
-  })
-
-  it('returns error on invalid or negative cancel delay', () => {
-    assert(_isString(validateParams({
-      ...validParams,
-      cancelDelay: 'nope'
-    })))
-
-    assert(_isString(validateParams({
-      ...validParams,
-      cancelDelay: -100
     })))
   })
 


### PR DESCRIPTION
- remove cancel delay options from iceberg orders
- removed tests for cancelled delays 

Related PR: https://github.com/bitfinexcom/bfx-hf-algo/pull/89