### PR TITLE
Remove cancel delay acc dis

### DIFF
--- a/lib/accumulate_distribute/events/orders_order_cancel.js
+++ b/lib/accumulate_distribute/events/orders_order_cancel.js
@@ -13,9 +13,8 @@
  */
 const onOrdersOrderCancel = async (instance = {}, order) => {
   const { state = {}, h = {} } = instance
-  const { args = {}, orders = {}, gid, timeout } = state
+  const { orders = {}, gid, timeout } = state
   const { emit, debug } = h
-  const { cancelDelay } = args
 
   debug('detected atomic cancelation, stopping...')
 
@@ -23,7 +22,7 @@ const onOrdersOrderCancel = async (instance = {}, order) => {
     clearTimeout(timeout)
   }
 
-  await emit('exec:order:cancel:all', gid, orders, cancelDelay)
+  await emit('exec:order:cancel:all', gid, orders)
   return emit('exec:stop')
 }
 

--- a/lib/accumulate_distribute/events/self_interval_tick.js
+++ b/lib/accumulate_distribute/events/self_interval_tick.js
@@ -27,7 +27,7 @@ const onSelfIntervalTick = async (instance = {}) => {
   const { state = {}, h = {} } = instance
   const { orders = {}, args = {}, gid, ordersBehind, orderAmounts, currentOrder } = state
   const { emit, emitSelf, debug, updateState } = h
-  const { awaitFill, cancelDelay } = args
+  const { awaitFill } = args
 
   await scheduleTick.tick(instance)
 
@@ -40,7 +40,7 @@ const onSelfIntervalTick = async (instance = {}) => {
     debug('now behind with %d orders', nextOrdersBehind)
 
     if (!awaitFill) { // cancel current order if not awaiting fill
-      await emit('exec:order:cancel:all', gid, orders, cancelDelay)
+      await emit('exec:order:cancel:all', gid, orders)
     } else {
       debug('awaiting fill...')
       return // await order fill, then rely on ordersBehind

--- a/lib/accumulate_distribute/index.js
+++ b/lib/accumulate_distribute/index.js
@@ -62,7 +62,6 @@ const unserialize = require('./meta/unserialize')
  *   capType: 'bid',
  *   capDelta: 10,
  *   submitDelay: 150,
- *   cancelDelay: 150,
  *   catchUp: true, // if true & behind, ignore slice interval (after prev fill)
  *   awaitFill: true, // await current slice fill before continuing to next slice
  *   _margin: false,

--- a/lib/accumulate_distribute/meta/get_ui_def.js
+++ b/lib/accumulate_distribute/meta/get_ui_def.js
@@ -126,7 +126,7 @@ const getUIDef = () => ({
   }, {
     name: 'actions',
     rows: [
-      ['submitDelay', 'cancelDelay'],
+      ['submitDelay', null],
       ['action', null]
     ]
   }],
@@ -454,13 +454,6 @@ const getUIDef = () => ({
       label: 'Submit Delay (sec)',
       customHelp: 'Seconds to wait before submitting orders',
       default: 2
-    },
-
-    cancelDelay: {
-      component: 'input.number',
-      label: 'Cancel Delay (sec)',
-      customHelp: 'Seconds to wait before cancelling orders',
-      default: 1
     },
 
     lev: {

--- a/lib/accumulate_distribute/meta/process_params.js
+++ b/lib/accumulate_distribute/meta/process_params.js
@@ -26,10 +26,6 @@ const processParams = (data) => {
     delete params.lev
   }
 
-  if (!_isFinite(params.cancelDelay)) {
-    params.cancelDelay = 1500
-  }
-
   if (!_isFinite(params.submitDelay)) {
     params.submitDelay = 5000
   }

--- a/lib/accumulate_distribute/meta/validate_params.js
+++ b/lib/accumulate_distribute/meta/validate_params.js
@@ -42,7 +42,7 @@ const ORDER_TYPES = ['MARKET', 'LIMIT', 'RELATIVE']
  */
 const validateParams = (args = {}) => {
   const {
-    limitPrice, amount, sliceAmount, orderType, submitDelay, cancelDelay,
+    limitPrice, amount, sliceAmount, orderType, submitDelay,
     intervalDistortion, amountDistortion, sliceInterval, relativeOffset,
     relativeCap, catchUp, awaitFill, lev, _futures
   } = args
@@ -51,7 +51,6 @@ const validateParams = (args = {}) => {
   if (!_isFinite(amount)) return 'Invalid amount'
   if (!_isFinite(sliceAmount)) return 'Invalid slice amount'
   if (!_isFinite(submitDelay) || submitDelay < 0) return 'Invalid submit delay'
-  if (!_isFinite(cancelDelay) || cancelDelay < 0) return 'Invalid cancel delay'
   if (!_isBoolean(catchUp)) return 'Bool catch up flag required'
   if (!_isBoolean(awaitFill)) return 'Bool await fill flag required'
   if (!_isFinite(sliceInterval) || sliceInterval <= 0) return 'Invalid slice interval'

--- a/test/lib/accumulate_distribute/events/orders_order_cancel.js
+++ b/test/lib/accumulate_distribute/events/orders_order_cancel.js
@@ -42,21 +42,19 @@ describe('accumulate_distribute:events:orders_order_cancel', () => {
     let sawCancelAll = false
     const orders = [new Order(), new Order()]
     const i = getInstance({
-      argParams: { cancelDelay: 100 },
       stateParams: {
         orders,
         gid: 42
       },
 
       helperParams: {
-        emit: async (eventName, gid, receivedOrders, delay) => {
+        emit: async (eventName, gid, receivedOrders) => {
           if (eventName !== 'exec:order:cancel:all') {
             return
           }
 
           assert.strictEqual(gid, 42, 'received wrong gid')
           assert.strictEqual(receivedOrders, orders, 'received wrong orders')
-          assert.strictEqual(delay, 100, 'received wrong delay')
           sawCancelAll = true
         }
       }
@@ -70,7 +68,6 @@ describe('accumulate_distribute:events:orders_order_cancel', () => {
     let sawExecStop = false
     const orders = [new Order(), new Order()]
     const i = getInstance({
-      argParams: { cancelDelay: 100 },
       stateParams: {
         orders,
         gid: 42

--- a/test/lib/accumulate_distribute/events/self_interval_tick.js
+++ b/test/lib/accumulate_distribute/events/self_interval_tick.js
@@ -17,7 +17,6 @@ const getInstance = ({
     currentOrder: 7,
     args: {
       awaitFill: false,
-      cancelDelay: 100,
       ...argParams
     },
     ...stateParams

--- a/test/lib/accumulate_distribute/events/self_submit_order.js
+++ b/test/lib/accumulate_distribute/events/self_submit_order.js
@@ -13,7 +13,6 @@ const getInstance = ({
   state: {
     gid: 42,
     args: {
-      cancelDelay: 100,
       ...argParams
     },
     ...stateParams

--- a/test/lib/accumulate_distribute/index.js
+++ b/test/lib/accumulate_distribute/index.js
@@ -23,7 +23,6 @@ testAOLive({
     sliceAmount: -6,
     sliceInterval: 1000,
     submitDelay: 0,
-    cancelDelay: 0,
     _margin: true,
     _futures: false,
 

--- a/test/lib/accumulate_distribute/meta/process_params.js
+++ b/test/lib/accumulate_distribute/meta/process_params.js
@@ -9,7 +9,6 @@ const args = {
   _symbol: 'tBTCUSD',
   _futures: true,
   lev: 3.3,
-  cancelDelay: 1500,
   submitDelay: 5000,
   sliceIntervalSec: 1,
   amountDistortion: 2,
@@ -43,13 +42,11 @@ describe('accumulate_distribute:meta:process_params', () => {
   it('provides sane defaults', () => {
     const params = processParams({
       ...args,
-      cancelDelay: null,
       submitDelay: null,
       amountDistortion: null,
       intervalDistortion: null
     })
 
-    assert.strictEqual(params.cancelDelay, 1500, 'incorrect cancel delay')
     assert.strictEqual(params.submitDelay, 5000, 'incorrect submit delay')
     assert.strictEqual(params.amountDistortion, 0, 'incorrect amount distortion')
     assert.strictEqual(params.intervalDistortion, 0, 'incorrect interval distortion')

--- a/test/lib/accumulate_distribute/meta/validate_params.js
+++ b/test/lib/accumulate_distribute/meta/validate_params.js
@@ -11,7 +11,6 @@ const params = {
   sliceAmount: 1,
   orderType: 'LIMIT',
   submitDelay: 0,
-  cancelDelay: 0,
   intervalDistortion: 0,
   amountDistortion: 0,
   sliceInterval: 1000,
@@ -46,7 +45,6 @@ describe('accumulate_distribute:meta:unserialize', () => {
     assert.ok(!_isEmpty(validateParams({ ...params, lev: 101 })))
     assert.ok(!_isEmpty(validateParams({ ...params, sliceAmount: 'not' })))
     assert.ok(!_isEmpty(validateParams({ ...params, submitDelay: 'testing' })))
-    assert.ok(!_isEmpty(validateParams({ ...params, cancelDelay: 'every' })))
     assert.ok(!_isEmpty(validateParams({ ...params, catchUp: 'day' })))
     assert.ok(!_isEmpty(validateParams({ ...params, awaitFill: 'and' })))
     assert.ok(!_isEmpty(validateParams({ ...params, sliceInterval: 'it' })))


### PR DESCRIPTION
- remove cancel delay options from accumulate/distribute orders
- removed tests for cancelled delays

Related PR: https://github.com/bitfinexcom/bfx-hf-algo/pull/89