### PR TITLE
Remove cancel delay ma crossover

### DIFF
--- a/lib/ma_crossover/events/orders_order_cancel.js
+++ b/lib/ma_crossover/events/orders_order_cancel.js
@@ -13,13 +13,12 @@
  */
 const onOrdersOrderCancel = async (instance = {}, order) => {
   const { state = {}, h = {} } = instance
-  const { args = {}, orders = {}, gid } = state
+  const { orders = {}, gid } = state
   const { emit, debug } = h
-  const { cancelDelay } = args
 
   debug('detected atomic cancelation, stopping...')
 
-  await emit('exec:order:cancel:all', gid, orders, cancelDelay)
+  await emit('exec:order:cancel:all', gid, orders)
   return emit('exec:stop')
 }
 

--- a/lib/ma_crossover/meta/get_ui_def.js
+++ b/lib/ma_crossover/meta/get_ui_def.js
@@ -99,7 +99,7 @@ const getUIDef = ({ timeframes }) => {
     }, {
       name: 'actions',
       rows: [
-        ['submitDelay', 'cancelDelay'],
+        ['submitDelay', null],
         ['action', null]
       ]
     }],
@@ -309,13 +309,6 @@ const getUIDef = ({ timeframes }) => {
         label: 'Submit Delay (sec)',
         customHelp: 'Seconds to wait before submitting orders',
         default: 2
-      },
-
-      cancelDelay: {
-        component: 'input.number',
-        label: 'Cancel Delay (sec)',
-        customHelp: 'Seconds to wait before cancelling orders',
-        default: 1
       },
 
       action: {

--- a/lib/ma_crossover/meta/process_params.js
+++ b/lib/ma_crossover/meta/process_params.js
@@ -22,10 +22,6 @@ const processParams = (data) => {
     delete params.lev
   }
 
-  if (!params.cancelDelay) {
-    params.cancelDelay = 1500
-  }
-
   if (!params.submitDelay) {
     params.submitDelay = 5000
   }

--- a/lib/ma_crossover/meta/validate_params.js
+++ b/lib/ma_crossover/meta/validate_params.js
@@ -36,14 +36,13 @@ const ORDER_TYPES = ['MARKET', 'LIMIT']
  */
 const validateParams = (args = {}) => {
   const {
-    orderPrice, amount, orderType, submitDelay, cancelDelay, long, short, lev,
+    orderPrice, amount, orderType, submitDelay, long, short, lev,
     _futures
   } = args
 
   if (!_includes(ORDER_TYPES, orderType)) return `Invalid order type: ${orderType}`
   if (!_isFinite(amount)) return 'Invalid amount'
   if (!_isFinite(submitDelay) || submitDelay < 0) return 'Invalid submit delay'
-  if (!_isFinite(cancelDelay) || cancelDelay < 0) return 'Invalid cancel delay'
   if (orderType === 'LIMIT' && !_isFinite(orderPrice)) {
     return 'Limit price required for LIMIT order type'
   }

--- a/test/lib/ma_crossover/events/orders_order_cancel.js
+++ b/test/lib/ma_crossover/events/orders_order_cancel.js
@@ -10,10 +10,7 @@ const getInstance = ({
   state: {
     gid: 42,
     orders: {},
-    args: {
-      cancelDelay: 100,
-      ...argParams
-    },
+    args: argParams,
     ...stateParams
   },
 
@@ -30,12 +27,11 @@ describe('ma_crossover:events:orders_order_cancel', () => {
   it('cancels all orders', (done) => {
     const i = getInstance({
       helperParams: {
-        emit: async (eventName, gid, orders, cancelDelay) => {
+        emit: async (eventName, gid, orders) => {
           if (eventName !== 'exec:order:cancel:all') return
 
           assert.strictEqual(gid, 42)
           assert.deepStrictEqual(orders, {})
-          assert.strictEqual(cancelDelay, 100)
           done()
         }
       }
@@ -47,7 +43,7 @@ describe('ma_crossover:events:orders_order_cancel', () => {
   it('emits exec:stop', (done) => {
     const i = getInstance({
       helperParams: {
-        emit: async (eventName, gid, orders, cancelDelay) => {
+        emit: async (eventName) => {
           if (eventName === 'exec:stop') {
             done()
           }

--- a/test/lib/ma_crossover/index.js
+++ b/test/lib/ma_crossover/index.js
@@ -19,7 +19,6 @@ testAOLive({
     amount: 6,
 
     submitDelay: 0,
-    cancelDelay: 0,
 
     longType: 'EMA',
     longEMAPrice: 'close',

--- a/test/lib/ma_crossover/meta/validate_params.js
+++ b/test/lib/ma_crossover/meta/validate_params.js
@@ -10,7 +10,6 @@ const params = {
   orderType: 'LIMIT',
   amount: 1,
   submitDelay: 10,
-  cancelDelay: 10,
   _futures: false,
   lev: 3.3,
 
@@ -35,8 +34,6 @@ describe('ma_crossover:meta:unserialize', () => {
     assert.ok(!_isEmpty(validateParams({ ...params, amount: '' })))
     assert.ok(!_isEmpty(validateParams({ ...params, submitDelay: '' })))
     assert.ok(!_isEmpty(validateParams({ ...params, submitDelay: -1 })))
-    assert.ok(!_isEmpty(validateParams({ ...params, cancelDelay: '' })))
-    assert.ok(!_isEmpty(validateParams({ ...params, cancelDelay: -1 })))
     assert.ok(!_isEmpty(validateParams({ ...params, orderPrice: '' })))
 
     assert.ok(!_isEmpty(validateParams({ ...params, long: '' })))


### PR DESCRIPTION
- remove cancel delay options from ma crossover orders
- removed tests for cancelled delays

Related PR: https://github.com/bitfinexcom/bfx-hf-algo/pull/89