### PR TITLE
Remove cancel delay ococo

### DIFF
--- a/lib/ococo/events/orders_order_cancel.js
+++ b/lib/ococo/events/orders_order_cancel.js
@@ -12,13 +12,12 @@
  */
 const onOrdersOrderCancel = async (instance = {}, order) => {
   const { state = {}, h = {} } = instance
-  const { args = {}, orders = {}, gid } = state
+  const { orders = {}, gid } = state
   const { emit, debug } = h
-  const { cancelDelay } = args
 
   debug('detected atomic cancelation, stopping...')
 
-  await emit('exec:order:cancel:all', gid, orders, cancelDelay)
+  await emit('exec:order:cancel:all', gid, orders)
   await emit('exec:stop')
 }
 

--- a/lib/ococo/index.js
+++ b/lib/ococo/index.js
@@ -32,7 +32,6 @@ const unserialize = require('./meta/unserialize')
  * @param {number} ocoAmount - oco order amount
  * @param {string} ocoAction - oco order direction, Buy or Sell
  * @param {number} submitDelaySec - submit delay in seconds
- * @param {number} cancelDelaySec - cancel delay in seconds
  * @param {number} lev - leverage for relevant markets
  *
  * @example
@@ -47,7 +46,6 @@ const unserialize = require('./meta/unserialize')
  *   ocoAmount: 30,
  *   ocoAction: 'Buy',
  *   submitDelaySec: 0,
- *   cancelDelaySec: 0,
  *   margin: true
  * })
  */

--- a/lib/ococo/meta/get_ui_def.js
+++ b/lib/ococo/meta/get_ui_def.js
@@ -47,7 +47,7 @@ const getUIDef = () => ({
     fixed: true,
 
     rows: [
-      ['submitDelaySec', 'cancelDelaySec']
+      ['submitDelaySec']
     ]
   }, {
     title: '',
@@ -68,13 +68,6 @@ const getUIDef = () => ({
       label: 'Submit Delay (sec)',
       customHelp: 'Seconds to wait before submitting orders',
       default: 1
-    },
-
-    cancelDelaySec: {
-      component: 'input.number',
-      label: 'Cancel Delay (sec)',
-      customHelp: 'Seconds to wait before cancelling orders',
-      default: 0
     },
 
     orderType: {

--- a/lib/ococo/meta/process_params.js
+++ b/lib/ococo/meta/process_params.js
@@ -24,18 +24,9 @@ const processParams = (data) => {
     delete params.lev
   }
 
-  if (params.cancelDelaySec) {
-    params.cancelDelay = params.cancelDelaySec * 1000
-    delete params.cancelDelaySec
-  }
-
   if (params.submitDelaySec) {
     params.submitDelay = params.submitDelaySec * 1000
     delete params.submitDelaySec
-  }
-
-  if (!_isFinite(params.cancelDelay)) {
-    params.cancelDelay = 1000
   }
 
   if (!_isFinite(params.submitDelay)) {

--- a/lib/ococo/meta/validate_params.js
+++ b/lib/ococo/meta/validate_params.js
@@ -23,20 +23,18 @@ const ORDER_TYPES = ['MARKET', 'LIMIT']
  * @param {number} args.ocoAmount - oco order amount
  * @param {string} args.ocoAction - oco order direction, Buy or Sell
  * @param {number} args.submitDelaySec - submit delay in seconds
- * @param {number} args.cancelDelaySec - cancel delay in seconds
  * @returns {string} error - null if parameters are valid, otherwise a
  *   description of which parameter is invalid.
  */
 const validateParams = (args = {}) => {
   const {
-    orderPrice, amount, orderType, submitDelay, cancelDelay, limitPrice,
+    orderPrice, amount, orderType, submitDelay, limitPrice,
     stopPrice, ocoAmount, lev, _futures, action, ocoAction
   } = args
 
   if (!_includes(ORDER_TYPES, orderType)) return `Invalid order type: ${orderType}`
   if (!_isFinite(amount)) return 'Invalid amount'
   if (!_isFinite(submitDelay) || submitDelay < 0) return 'Invalid submit delay'
-  if (!_isFinite(cancelDelay) || cancelDelay < 0) return 'Invalid cancel delay'
   if (orderType === 'LIMIT' && !_isFinite(orderPrice)) {
     return 'Limit price required for LIMIT order type'
   }

--- a/test/lib/ococo/index.js
+++ b/test/lib/ococo/index.js
@@ -25,7 +25,6 @@ testAOLive({
     ocoAmount: 6,
     ocoAction: 'Buy',
 
-    cancelDelaySec: 0,
     submitDelaySec: 0
   },
 

--- a/test/lib/ococo/meta/process_params.js
+++ b/test/lib/ococo/meta/process_params.js
@@ -8,7 +8,6 @@ const params = {
   _symbol: 'tLEOUSD',
   _future: false,
 
-  cancelDelaySec: 1,
   submitDelaySec: 1,
   action: 'Sell',
   ocoAction: 'Sell',
@@ -22,9 +21,7 @@ describe('ococo:meta:process_params', () => {
   it('process params correctly', () => {
     assert.strictEqual(processParams(params).symbol, 'tLEOUSD')
     assert.ok(!processParams(params).lev)
-    assert.strictEqual(processParams(params).cancelDelay, 1000)
     assert.strictEqual(processParams(params).submitDelay, 1000)
-    assert.strictEqual(processParams({ ...params, cancelDelaySec: null }).cancelDelay, 1000)
     assert.strictEqual(processParams({ ...params, submitDelaySec: null }).submitDelay, 2000)
     assert.strictEqual(processParams({ ...params, action: 'Buy' }).amount, 6)
     assert.strictEqual(processParams({ ...params, ocoAction: 'Buy' }).ocoAmount, 6)

--- a/test/lib/ococo/meta/validate_params.js
+++ b/test/lib/ococo/meta/validate_params.js
@@ -10,7 +10,6 @@ const params = {
   orderPrice: 1,
   amount: 6,
   submitDelay: 0,
-  cancelDelay: 0,
 
   limitPrice: 6,
   stopPrice: 6,
@@ -29,8 +28,6 @@ describe('ococo:meta:unserialize', () => {
     assert.ok(!_isEmpty(validateParams({ ...params, amount: '' })))
     assert.ok(!_isEmpty(validateParams({ ...params, submitDelay: '' })))
     assert.ok(!_isEmpty(validateParams({ ...params, submitDelay: -1 })))
-    assert.ok(!_isEmpty(validateParams({ ...params, cancelDelay: '' })))
-    assert.ok(!_isEmpty(validateParams({ ...params, cancelDelay: -1 })))
     assert.ok(!_isEmpty(validateParams({ ...params, limitPrice: '' })))
     assert.ok(!_isEmpty(validateParams({ ...params, stopPrice: '' })))
     assert.ok(!_isEmpty(validateParams({ ...params, ocoAmount: '' })))


### PR DESCRIPTION
- remove cancel delay options from oco algo
- removed tests for cancelled delays

Related PR: https://github.com/bitfinexcom/bfx-hf-algo/pull/89