### PR TITLE
ma crossover: fix cid, use cid helper

### DIFF
--- a/lib/ma_crossover/util/generate_order.js
+++ b/lib/ma_crossover/util/generate_order.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { Order } = require('bfx-api-node-models')
-const { nonce } = require('bfx-api-node-util')
+const genCID = require('../../util/gen_client_id')
 
 /**
  * Generates the atomic order as configured in the execution parameters
@@ -31,7 +31,7 @@ const generateOrder = (instance = {}) => {
   if (orderType === 'MARKET') {
     return new Order({
       ...sharedOrderParams,
-      cid: nonce(),
+      cid: genCID(),
       type: _margin || _futures ? 'MARKET' : 'EXCHANGE MARKET',
       meta: { _HF: 1 }
     })
@@ -39,7 +39,7 @@ const generateOrder = (instance = {}) => {
     return new Order({
       ...sharedOrderParams,
       price: +orderPrice,
-      cid: nonce(),
+      cid: genCID(),
       type: _margin || _futures ? 'LIMIT' : 'EXCHANGE LIMIT',
       meta: { _HF: 1 }
     })


### PR DESCRIPTION
nonce generation was creating a nonce far too big:

https://github.com/bitfinexcom/bfx-api-node-util/blob/c7fab825b0f4bdf306a5286acd566a5a0936eb0c/lib/nonce.js#L6

error:

```
  bfx:hf:algo:bfx-ma_crossover:1616505422483 cid: invalid +43ms
```