### PR TITLE
[wip] submits only active orders when when cancelling all orders

### DIFF
--- a/lib/host/events/cancel_all_orders.js
+++ b/lib/host/events/cancel_all_orders.js
@@ -22,7 +22,7 @@ module.exports = async (aoHost, gid, orders) => {
 
     // Don't try to cancel market orders
     const _orders = allOrders
-      .filter(o => !/MARKET/.test(o.type) && o.id && !/CANCELED/.test(o.status))
+      .filter(o => !/MARKET/.test(o.type) && o.id && /ACTIVE/.test(o.status))
 
     let nextState = state
 


### PR DESCRIPTION
This fixes the error (Order not found) thrown when the algo server tries to submit all the orders created during the life cycle of algo for cancellation. This case occurs when a user tries to cancel an algo order. The algo server tries to cancel all the orders stored in its state based on the `id` of the order and not the `status`. 

However, if the status isn't `ACTIVE` means that the order wasn't submitted successfully in the first place.