### PR TITLE
Submit active orders for cancellations

### DIFF
--- a/lib/host/events/cancel_all_orders.js
+++ b/lib/host/events/cancel_all_orders.js
@@ -2,6 +2,7 @@
 
 const _isObject = require('lodash/isObject')
 const withAOUpdate = require('../with_ao_update')
+const excludeOrderStatus = ['CANCELED', 'EXECUTED']
 
 /**
  * Cancels all provided orders, and removes them from the AO
@@ -20,9 +21,11 @@ module.exports = async (aoHost, gid, orders) => {
       ? Object.values(orders)
       : orders
 
+    const excludeOrderStatusRegex = new RegExp(excludeOrderStatus.join('|'))
+
     // Don't try to cancel market orders
     const _orders = allOrders
-      .filter(o => !/MARKET/.test(o.type) && o.id && !/CANCELED/.test(o.status))
+      .filter(o => !/MARKET/.test(o.type) && o.id && !excludeOrderStatusRegex.test(o.status))
 
     let nextState = state
 


### PR DESCRIPTION
If the status isn't `ACTIVE` means that the order wasn't submitted successfully in the first place and is not required to be cancelled.