### PR TITLE
handle exceptions while cancelling orders

### DIFF
--- a/lib/host/gen_helpers.js
+++ b/lib/host/gen_helpers.js
@@ -166,7 +166,17 @@ const genHelpers = (state = {}, adapter) => {
       } = orders
 
       // NOTE: No await, in order to update cancelled order set immediately
-      adapter.cancelOrder(connection, order)
+      adapter.cancelOrder(connection, order).then((order) => { // eslint-disable-line
+        debug(
+          'order successfully cancelled (id: %s, cid: %s): %s %f @ %f',
+          order.id, order.cid, order.type, order.amountOrig, order.price
+        )
+      }).catch(async (notification) => {
+        debug(
+          'received error while canceling order(id: %s, cid: %s): %s %f @ %f [ERROR: %O]',
+          order.id, order.cid, order.type, order.amountOrig, order.price, notification
+        )
+      })
 
       return {
         ...state,

--- a/lib/host/gen_helpers.js
+++ b/lib/host/gen_helpers.js
@@ -171,7 +171,7 @@ const genHelpers = (state = {}, adapter) => {
           'order successfully cancelled (id: %s, cid: %s): %s %f @ %f',
           order.id, order.cid, order.type, order.amountOrig, order.price
         )
-      }).catch(async (notification) => {
+      }).catch((notification) => {
         debug(
           'received error while canceling order(id: %s, cid: %s): %s %f @ %f [ERROR: %O]',
           order.id, order.cid, order.type, order.amountOrig, order.price, notification

--- a/test/lib/host/gen_helpers.js
+++ b/test/lib/host/gen_helpers.js
@@ -108,7 +108,7 @@ describe('genHelpers', () => {
       let adapterFuncCalled = false
 
       const h = H(state, {
-        cancelOrder: (c, order) => {
+        cancelOrder: async (c, order) => {
           adapterFuncCalled = true
 
           assert.strictEqual(c, 'conn', 'connection not passed to adapter')
@@ -134,7 +134,9 @@ describe('genHelpers', () => {
         cancelledOrders: {}
       }
 
-      const h = H(state, { cancelOrder: () => {} })
+      const h = H(state, {
+        cancelOrder: async () => {}
+      })
       const patchedState = await h.cancelOrder(state, o)
 
       assert.ok(_isObject(patchedState), 'patched state not an object')


### PR DESCRIPTION
This fixes the error (`Order not found`) thrown when the algo server tries to submit all the orders created during the life cycle of algo for cancellation. A catch block is added while cancelling orders to log errors and not throw ugly rejection errors.