### PR TITLE
fix memleak on closing algo orders

### DIFF
--- a/lib/ao_host.js
+++ b/lib/ao_host.js
@@ -615,9 +615,11 @@ class AOHost extends AsyncEventEmitter {
    */
   async onAOStop (instance = {}, opts = {}) {
     const { h } = instance
-    const { channels = [], gid, connection } = instance.state
+    const { channels = [], gid, connection, ev } = instance.state
 
     h.clearAllTimeouts()
+
+    ev.removeAllListeners()
 
     await withAOUpdate(this, gid, (instance = {}) => {
       const { state = {} } = instance
@@ -642,6 +644,8 @@ class AOHost extends AsyncEventEmitter {
      */
     await this.triggerAOEvent(instance, 'life', 'stop', opts)
     await this.emit('ao:persist', gid)
+
+    delete this.instances[gid]
   }
 
   /**


### PR DESCRIPTION
when an algo order was stopped, events were still listened for,
triggering event updates.

to reproduce:
1. start a twap, delay 0s
2. stop it
3. start another one, delay 0s
4. stop it
5. start another one set delay to 5s

you have 3 save events for 3 algo orders in the log when order
book updates arrive for the last algo order.