### PR TITLE
twap: fix delay on order submit

### DIFF
--- a/lib/twap/events/life_start.js
+++ b/lib/twap/events/life_start.js
@@ -29,7 +29,7 @@ const onLifeStart = async (instance = {}) => {
     }
   }
 
-  await emitSelf('interval_tick')
+  emitSelf('interval_tick') // no await, don't delay
 }
 
 module.exports = onLifeStart


### PR DESCRIPTION
chained events behave synchronous, so we can't "wait" for the
first interval to "finish"