### PR TITLE
allow cancelling orders before removing all listeners

### DIFF
--- a/lib/ao_host.js
+++ b/lib/ao_host.js
@@ -619,8 +619,6 @@ class AOHost extends AsyncEventEmitter {
 
     h.clearAllTimeouts()
 
-    ev.removeAllListeners()
-
     await withAOUpdate(this, gid, (instance = {}) => {
       const { state = {} } = instance
 
@@ -644,6 +642,8 @@ class AOHost extends AsyncEventEmitter {
      */
     await this.triggerAOEvent(instance, 'life', 'stop', opts)
     await this.emit('ao:persist', gid)
+
+    ev.removeAllListeners()
 
     delete this.instances[gid]
   }


### PR DESCRIPTION
- remove remaining cancel order listeners on algo stop
- fix for not removing all listeners before cancelling existing orders set by algo