### PR TITLE
Validate params iceberg

### DIFF
--- a/lib/host/init_ao_state.js
+++ b/lib/host/init_ao_state.js
@@ -2,6 +2,7 @@
 
 const clientID = require('../util/gen_client_id')
 const _isFunction = require('lodash/isFunction')
+const _isString = require('lodash/isString')
 const AsyncEventEmitter = require('../async_event_emitter')
 
 /**
@@ -23,7 +24,7 @@ module.exports = (aoDef = {}, args = {}) => {
     const vError = validateParams(params)
 
     if (vError) {
-      throw new Error(vError)
+      throw new Error(_isString(vError) ? vError : vError.message)
     }
   }
 

--- a/lib/iceberg/meta/validate_params.js
+++ b/lib/iceberg/meta/validate_params.js
@@ -3,6 +3,7 @@
 const { Order } = require('bfx-api-node-models')
 const _isFinite = require('lodash/isFinite')
 const _includes = require('lodash/includes')
+const validationErrObj = require('../../util/validate_params_err')
 
 /**
  * Verifies that a parameters Object is valid, and all parameters are within
@@ -26,24 +27,24 @@ const validateParams = (args = {}) => {
     _futures
   } = args
 
-  if (!Order.type[orderType]) return `Invalid order type: ${orderType}`
-  if (!_isFinite(amount)) return 'Invalid amount'
-  if (!_isFinite(sliceAmount)) return 'Invalid slice amount'
+  if (!Order.type[orderType]) return validationErrObj('orderType', `Invalid order type: ${orderType}`)
+  if (!_isFinite(amount)) return validationErrObj('amount', 'Invalid amount')
+  if (!_isFinite(sliceAmount)) return validationErrObj('sliceAmount', 'Invalid slice amount')
   if (!_includes(orderType, 'MARKET') && (isNaN(price) || price <= 0)) {
-    return 'Invalid price'
+    return validationErrObj('price', 'Invalid price')
   }
 
   if (
     (amount < 0 && sliceAmount >= 0) ||
     (amount > 0 && sliceAmount <= 0)
   ) {
-    return 'Amount & slice amount must have same sign'
+    return validationErrObj('sliceAmount', 'Amount & slice amount must have same sign')
   }
 
   if (_futures) {
-    if (!_isFinite(lev)) return 'Invalid leverage'
-    if (lev < 1) return 'Leverage less than 1'
-    if (lev > 100) return 'Leverage greater than 100'
+    if (!_isFinite(lev)) return validationErrObj('lev', 'Invalid leverage')
+    if (lev < 1) return validationErrObj('lev', 'Leverage less than 1')
+    if (lev > 100) return validationErrObj('lev', 'Leverage greater than 100')
   }
 
   return null

--- a/lib/iceberg/meta/validate_params.js
+++ b/lib/iceberg/meta/validate_params.js
@@ -18,14 +18,16 @@ const validationErrObj = require('../../util/validate_params_err')
  * @param {number} [args.sliceAmountPerc] - optional, slice amount as % of total amount
  * @param {boolean} args.excessAsHidden - whether to submit remainder as a hidden order
  * @param {string} args.orderType - LIMIT or MARKET
+ * @param {object} pairConfig - config for the selected market pair
+ * @param {number} pairConfig.minSize - minimum order size for the selected market pair
+ * @param {number} pairConfig.maxSize - maximum order size for the selected market pair
+ * @param {number} pairConfig.lev - leverage allowed for the selected market pair
  * @returns {string} error - null if parameters are valid, otherwise a
  *   description of which parameter is invalid.
  */
-const validateParams = (args = {}) => {
-  const {
-    price, amount, sliceAmount, orderType, lev,
-    _futures
-  } = args
+const validateParams = (args = {}, pairConfig = {}) => {
+  const { minSize, maxSize, lev: maxLev } = pairConfig
+  const { price, amount, sliceAmount, orderType, lev, _futures } = args
 
   if (!Order.type[orderType]) return validationErrObj('orderType', `Invalid order type: ${orderType}`)
   if (!_isFinite(amount)) return validationErrObj('amount', 'Invalid amount')
@@ -41,10 +43,20 @@ const validateParams = (args = {}) => {
     return validationErrObj('sliceAmount', 'Amount & slice amount must have same sign')
   }
 
+  if (_isFinite(minSize)) {
+    if (Math.abs(amount) < minSize) return validationErrObj('amount', `Amount cannot be less than ${minSize}`)
+    if (Math.abs(sliceAmount) < minSize) return validationErrObj('sliceAmount', `Slice amount cannot be less than ${minSize}`)
+  }
+
+  if (_isFinite(maxSize)) {
+    if (Math.abs(amount) > maxSize) return validationErrObj('amount', `Amount cannot be greater than ${maxSize}`)
+    if (Math.abs(sliceAmount) > maxSize) return validationErrObj('sliceAmount', `Slice amount cannot be greater than ${maxSize}`)
+  }
+
   if (_futures) {
     if (!_isFinite(lev)) return validationErrObj('lev', 'Invalid leverage')
-    if (lev < 1) return validationErrObj('lev', 'Leverage less than 1')
-    if (lev > 100) return validationErrObj('lev', 'Leverage greater than 100')
+    if (lev < 1) return validationErrObj('lev', 'Leverage cannot be less than 1')
+    if (_isFinite(maxLev) && (lev > maxLev)) return validationErrObj('lev', `Leverage cannot be greater than ${maxLev}`)
   }
 
   return null

--- a/lib/util/validate_params_err.js
+++ b/lib/util/validate_params_err.js
@@ -1,0 +1,8 @@
+'use strict'
+
+module.exports = (field, message) => {
+  return {
+    field,
+    message
+  }
+}

--- a/test/lib/iceberg/meta/validate_params.js
+++ b/test/lib/iceberg/meta/validate_params.js
@@ -12,6 +12,12 @@ const validParams = {
   sliceAmount: 0.1
 }
 
+const pairConfig = {
+  minSize: 0.01,
+  maxSize: 20,
+  lev: 5
+}
+
 describe('iceberg:meta:validate_params', () => {
   it('returns no error on valid params', () => {
     assert.strictEqual(validateParams(validParams), null)
@@ -65,6 +71,52 @@ describe('iceberg:meta:validate_params', () => {
     })
 
     assert.deepStrictEqual(err.field, 'sliceAmount')
+    assert(_isString(err.message))
+  })
+
+  it('returns error if amount is less than the minimum order size', () => {
+    const err = validateParams({
+      ...validParams,
+      amount: 0.001
+    }, pairConfig)
+    assert.deepStrictEqual(err.field, 'amount')
+    assert(_isString(err.message))
+  })
+
+  it('returns error if slice amount is less than the minimum order size', () => {
+    const err = validateParams({
+      ...validParams,
+      sliceAmount: 0.001
+    }, pairConfig)
+    assert.deepStrictEqual(err.field, 'sliceAmount')
+    assert(_isString(err.message))
+  })
+
+  it('returns error if amount is greater than the maximum order size', () => {
+    const err = validateParams({
+      ...validParams,
+      amount: 25
+    }, pairConfig)
+    assert.deepStrictEqual(err.field, 'amount')
+    assert(_isString(err.message))
+  })
+
+  it('returns error if slice amount is greater than the maximum order size', () => {
+    const err = validateParams({
+      ...validParams,
+      sliceAmount: 25
+    }, pairConfig)
+    assert.deepStrictEqual(err.field, 'sliceAmount')
+    assert(_isString(err.message))
+  })
+
+  it('returns error if leverage is greater than the allowed leverage', () => {
+    const err = validateParams({
+      ...validParams,
+      _futures: true,
+      lev: 6
+    }, pairConfig)
+    assert.deepStrictEqual(err.field, 'lev')
     assert(_isString(err.message))
   })
 })

--- a/test/lib/iceberg/meta/validate_params.js
+++ b/test/lib/iceberg/meta/validate_params.js
@@ -18,30 +18,39 @@ describe('iceberg:meta:validate_params', () => {
   })
 
   it('returns error on invalid order type', () => {
-    assert(_isString(validateParams({
+    const err = validateParams({
       ...validParams,
       orderType: 'nope'
-    })))
+    })
+    assert.deepStrictEqual(err.field, 'orderType')
+    assert(_isString(err.message))
   })
 
   it('returns error on invalid amount', () => {
-    assert(_isString(validateParams({
+    const err = validateParams({
       ...validParams,
       amount: 'nope'
-    })))
+    })
+    assert.deepStrictEqual(err.field, 'amount')
+    assert(_isString(err.message))
   })
 
   it('returns error on invalid slice amount', () => {
-    assert(_isString(validateParams({
+    const err = validateParams({
       ...validParams,
       sliceAmount: 'nope'
-    })))
+    })
+    assert.deepStrictEqual(err.field, 'sliceAmount')
+    assert(_isString(err.message))
   })
 
   it('returns error if non-MARKET type and no price provided', () => {
     const params = { ...validParams }
     delete params.price
-    assert(_isString(validateParams(params)))
+
+    const noPriceErr = validateParams(params)
+    assert.deepStrictEqual(noPriceErr.field, 'price')
+    assert(_isString(noPriceErr.message))
 
     assert.strictEqual(validateParams({
       ...params,
@@ -50,9 +59,12 @@ describe('iceberg:meta:validate_params', () => {
   })
 
   it('returns error if amount & sliceAmount differ in sign', () => {
-    assert(_isString(validateParams({
+    const err = validateParams({
       ...validParams,
       amount: -1
-    })))
+    })
+
+    assert.deepStrictEqual(err.field, 'sliceAmount')
+    assert(_isString(err.message))
   })
 })


### PR DESCRIPTION
This PR adds the functionality to be able to fetch the error fields as well so that it's easier in the UI side to show the error message on the specific field of the algo order. It can be used by UI to check for errors before submitting the order to algo server. However, the UI if wishes to use this function, it must process params first using `processParams` function before using the `validateParams` function. 

Related PR: https://github.com/bitfinexcom/bfx-hf-server/pull/96 to not break the existing function for params validation.

Task: https://app.asana.com/0/1125859137800433/1200038332394566