### PR TITLE
issue fix for the sliced order amounts not being distorted

### DIFF
--- a/lib/accumulate_distribute/util/gen_order_amounts.js
+++ b/lib/accumulate_distribute/util/gen_order_amounts.js
@@ -26,7 +26,7 @@ const generateOrderAmounts = (args = {}) => {
 
     while (Math.abs(amount - totalAmount) > DUST) {
       const m = Math.random() > 0.5 ? 1 : -1
-      const orderAmount = Math.min(sliceAmount, sliceAmount * (1 + (Math.random() * amountDistortion * m)))
+      const orderAmount = sliceAmount * (1 + (Math.random() * amountDistortion * m))
       const remAmount = amount - totalAmount
       const cappedOrderAmount = +prepareAmount(remAmount < 0
         ? Math.max(remAmount, orderAmount)


### PR DESCRIPTION
This PR fixes the issue of not distorting some of the sliced order amounts. The order amount is always distorted and minimum value between the remaining and distorted amount is taken in the last iteration while generating order amounts. 

Task: https://app.asana.com/0/1125859137800433/1200207564508439