### PR TITLE
not accepting order amount if it isn't a number and equals 0

### DIFF
--- a/lib/ma_crossover/meta/validate_params.js
+++ b/lib/ma_crossover/meta/validate_params.js
@@ -41,7 +41,7 @@ const validateParams = (args = {}) => {
   } = args
 
   if (!_includes(ORDER_TYPES, orderType)) return `Invalid order type: ${orderType}`
-  if (!_isFinite(amount)) return 'Invalid amount'
+  if (!_isFinite(amount) || amount === 0) return 'Invalid amount'
   if (orderType === 'LIMIT' && !_isFinite(orderPrice)) {
     return 'Limit price required for LIMIT order type'
   }

--- a/test/lib/ma_crossover/meta/validate_params.js
+++ b/test/lib/ma_crossover/meta/validate_params.js
@@ -31,6 +31,7 @@ describe('ma_crossover:meta:unserialize', () => {
   it('validates', () => {
     assert.ok(!_isEmpty(validateParams({ ...params, orderType: '' })))
     assert.ok(!_isEmpty(validateParams({ ...params, amount: '' })))
+    assert.ok(!_isEmpty(validateParams({ ...params, amount: 0 })))
     assert.ok(!_isEmpty(validateParams({ ...params, orderPrice: '' })))
 
     assert.ok(!_isEmpty(validateParams({ ...params, long: '' })))


### PR DESCRIPTION
Checks for the value of order amount to be finite and not equals to 0 in ma crossover algo.