### PR TITLE
ma-cross: guard against outdated data

### DIFF
--- a/lib/host/gen_helpers.js
+++ b/lib/host/gen_helpers.js
@@ -199,6 +199,17 @@ const genHelpers = (state = {}, adapter) => {
       }
     },
 
+    sendPing: async (state = {}) => {
+      const { connection } = state
+
+      logHelperCall(
+        'sending ping to get server time'
+      )
+
+      const data = await adapter.sendPing(connection)
+      return data
+    },
+
     /**
      * Submits an order after a delay, and adds it to the active order set on
      * the AO state. Emits errors if the order fails to submit; retries up to

--- a/lib/ma_crossover/events/data_managed_candles.js
+++ b/lib/ma_crossover/events/data_managed_candles.js
@@ -21,7 +21,7 @@ const _reverse = require('lodash/reverse')
  */
 const onDataManagedCandles = async (instance = {}, candles, meta) => {
   const { state = {}, h = {} } = instance
-  const { args = {}, longIndicator, shortIndicator } = state
+  const { args = {}, longIndicator, shortIndicator, ts } = state
   const { symbol, long, short } = args
   const { debug, updateState, emitSelf, emit } = h
   const { chanFilter } = meta
@@ -36,6 +36,8 @@ const onDataManagedCandles = async (instance = {}, candles, meta) => {
 
   let indicatorsUpdated = false
   const [lastCandle] = candles
+
+  const outdated = ts > lastCandle.mts
 
   if (chanTF === long.candleTimeFrame) {
     indicatorsUpdated = true
@@ -87,6 +89,11 @@ const onDataManagedCandles = async (instance = {}, candles, meta) => {
     }
 
     await updateState(instance, { lastCandleShort: lastCandle })
+  }
+
+  if (outdated) {
+    debug('outdated value, skipping execution', ts, '>', lastCandle.mts)
+    return
   }
 
   if (indicatorsUpdated) {

--- a/lib/ma_crossover/events/life_start.js
+++ b/lib/ma_crossover/events/life_start.js
@@ -14,13 +14,15 @@ const HFI = require('bfx-hf-indicators')
 const onLifeStart = async (instance = {}) => {
   const { state = {}, h = {} } = instance
   const { args = {} } = state
-  const { debug, updateState, subscribeDataChannels } = h
+  const { debug, updateState, sendPing, subscribeDataChannels } = h
   const { long, short } = args
 
   debug(
     'starting with long %s(%d) and short %s(%d)',
     long.type.toUpperCase(), long.args[0], short.type.toUpperCase(), short.args[0]
   )
+
+  const { ts } = await sendPing(state)
 
   const typeL = long.type.toUpperCase() === 'MA' ? 'SMA' : long.type.toUpperCase()
   const typeS = short.type.toUpperCase() === 'MA' ? 'SMA' : short.type.toUpperCase()
@@ -31,7 +33,7 @@ const onLifeStart = async (instance = {}) => {
   const longIndicator = new LongIndicatorClass(long.args)
   const shortIndicator = new ShortIndicatorClass(long.args)
 
-  await updateState(instance, { longIndicator, shortIndicator })
+  await updateState(instance, { longIndicator, shortIndicator, ts })
 
   subscribeDataChannels(state)
 }

--- a/lib/ma_crossover/meta/init_state.js
+++ b/lib/ma_crossover/meta/init_state.js
@@ -11,7 +11,7 @@
  * @returns {object} initialState
  */
 const initState = (args = {}) => {
-  return { args }
+  return { args, ts: null }
 }
 
 module.exports = initState

--- a/lib/ws_adapter.js
+++ b/lib/ws_adapter.js
@@ -14,8 +14,10 @@ const Watchdog = require('bfx-api-node-plugin-wd')
 const { Order } = require('bfx-api-node-models')
 const {
   subscribe, unsubscribe, findChannelId, Manager, cancelOrder: _cancelOrder, submitOrder,
-  send
+  send, ping
 } = require('bfx-api-node-core')
+
+const genCid = require('./util/gen_client_id')
 
 const HB_INTERVAL_MS = 2500
 
@@ -196,6 +198,12 @@ module.exports = class AOAdapter extends EventEmitter {
 
   orderEventsValid () {
     return !this._ignoreOrderEvents
+  }
+
+  async sendPing (connection) {
+    const { c } = connection
+
+    return await ping(c, { cid: genCid() })
   }
 
   async submitOrderWithDelay (connection, delay, order) {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   ],
   "dependencies": {
     "@bitfinex/lib-js-util-math": "git+https://github.com/bitfinexcom/lib-js-util-math.git",
-    "bfx-api-node-core": "^1.2.0",
+    "bfx-api-node-core": "^1.3.0",
     "bfx-api-node-models": "^1.1.9",
     "bfx-api-node-plugin-managed-candles": "^1.0.2",
     "bfx-api-node-plugin-managed-ob": "^1.0.2",

--- a/test/lib/ma_crossover/events/life_start.js
+++ b/test/lib/ma_crossover/events/life_start.js
@@ -21,6 +21,7 @@ const getInstance = ({
     debug: () => {},
     updateState: async () => {},
     subscribeDataChannels: async () => {},
+    sendPing: async () => { return { ts: Date.now() } },
     ...helperParams
   },
 


### PR DESCRIPTION
the ws api sends a snapshot in the beginning. it contains historic
candles from the past. additionally, when there is a lot of traffic,
the ws2 sends the last 1-3 candles that are not part of the
snapshot yet.

example, on a 5min scale candle subscription:

1. last candle in snapshot: 13:30
2. immediately sent after connect: candles for 13:35 and 13:40
3. current date time: 13:41

this issue leads to an issue where, when with those 1-3 historic
candles a ma cross happens, it is executed - but too late.

to fix this, we get the current server time on start of the algo,
and then check if the incoming data is older.

related PRs:

#128
bitfinexcom/bfx-api-node-core#18