### PR TITLE
use manual data-channel-subscriptions

### DIFF
--- a/lib/accumulate_distribute/events/life_start.js
+++ b/lib/accumulate_distribute/events/life_start.js
@@ -23,7 +23,7 @@ const hasIndicatorCap = require('../util/has_indicator_cap')
 const onLifeStart = async (instance = {}) => {
   const { state = {}, h = {} } = instance
   const { args = {}, orderAmounts, remainingAmount } = state
-  const { debug, updateState } = h
+  const { debug, updateState, subscribeDataChannels } = h
   const { amount, relativeCap, relativeOffset } = args
 
   debug(
@@ -51,6 +51,8 @@ const onLifeStart = async (instance = {}) => {
 
     await updateState(instance, { capIndicator })
   }
+
+  subscribeDataChannels(state)
 
   await scheduleTick.tick(instance)
 }

--- a/lib/ao_host.js
+++ b/lib/ao_host.js
@@ -577,7 +577,7 @@ class AOHost extends AsyncEventEmitter {
    * @private
    */
   async onAOStart (instance = {}) {
-    const { channels = [], gid, connection } = instance.state
+    const { gid } = instance.state
 
     await withAOUpdate(this, gid, (instance = {}) => {
       const { state = {} } = instance
@@ -587,14 +587,6 @@ class AOHost extends AsyncEventEmitter {
         active: true
       }
     })
-
-    if (!_isEmpty(channels)) {
-      channels.forEach(ch => {
-        debug('subscribing to channel %j [AO gid %d]', ch, gid)
-
-        this.adapter.subscribe(connection, ch.channel, ch.filter)
-      })
-    }
 
     /**
      * Triggered when an algorithmic order begins execution.

--- a/lib/host/gen_helpers.js
+++ b/lib/host/gen_helpers.js
@@ -146,6 +146,17 @@ const genHelpers = (state = {}, adapter) => {
       await state.ev.emit('notify', gid, level, message)
     },
 
+    subscribeDataChannels: (state = {}) => {
+      const { channels = [], gid, connection } = state
+
+      channels.forEach((ch) => {
+        debug('subscribing to channel %j [AO gid %d]', ch, gid)
+
+        // TODO: optional await
+        adapter.subscribe(connection, ch.channel, ch.filter)
+      })
+    },
+
     /**
      * Cancels the provided order instantly, and removes it from the active
      * order set.

--- a/lib/ma_crossover/events/life_start.js
+++ b/lib/ma_crossover/events/life_start.js
@@ -14,7 +14,7 @@ const HFI = require('bfx-hf-indicators')
 const onLifeStart = async (instance = {}) => {
   const { state = {}, h = {} } = instance
   const { args = {} } = state
-  const { debug, updateState } = h
+  const { debug, updateState, subscribeDataChannels } = h
   const { long, short } = args
 
   debug(
@@ -32,6 +32,8 @@ const onLifeStart = async (instance = {}) => {
   const shortIndicator = new ShortIndicatorClass(long.args)
 
   await updateState(instance, { longIndicator, shortIndicator })
+
+  subscribeDataChannels(state)
 }
 
 module.exports = onLifeStart

--- a/lib/twap/events/life_start.js
+++ b/lib/twap/events/life_start.js
@@ -16,7 +16,7 @@ const onLifeStart = async (instance = {}) => {
   const { state = {}, h = {} } = instance
   const { args = {} } = state
   const { priceTarget, priceCondition, orderType } = args
-  const { debug, emitSelf } = h
+  const { debug, emitSelf, subscribeDataChannels } = h
 
   if (!/MARKET/.test(orderType)) {
     if (_isFinite(priceTarget) && _isString(priceCondition)) {
@@ -28,6 +28,10 @@ const onLifeStart = async (instance = {}) => {
       return
     }
   }
+
+  // TODO: use await here once awaitable feature is added
+  // so first tick can operate on data already
+  subscribeDataChannels(state)
 
   emitSelf('interval_tick') // no await, don't delay
 }

--- a/test/lib/accumulate_distribute/events/life_start.js
+++ b/test/lib/accumulate_distribute/events/life_start.js
@@ -23,6 +23,7 @@ const getInstance = ({
     updateState: async () => {},
     scheduleTick: async () => {},
     notifyUI: async () => {},
+    subscribeDataChannels: () => {},
     ...helperParams
   },
 

--- a/test/lib/ma_crossover/events/life_start.js
+++ b/test/lib/ma_crossover/events/life_start.js
@@ -20,6 +20,7 @@ const getInstance = ({
   h: {
     debug: () => {},
     updateState: async () => {},
+    subscribeDataChannels: async () => {},
     ...helperParams
   },
 

--- a/test/lib/twap/events/life_start.js
+++ b/test/lib/twap/events/life_start.js
@@ -19,6 +19,7 @@ describe('twap:events:life_start', () => {
 
       h: {
         debug: () => {},
+        subscribeDataChannels: async () => {},
         emitSelf: (eName) => {
           return new Promise((resolve) => {
             assert.strictEqual(eName, 'interval_tick')


### PR DESCRIPTION
the current automagic does automatically subscribe to required
channels like candles and trades before each `life_start` run.

in `life_start` initialisations are done for acc/dis and ma cross.

through the automatic subscribe of data channels, it can happen
that data event hooks are called before `life_start` finished.
in those cases the algo order crashes. one solution is to run all
subscriptions after `life_start`, but this does not fit for all
algo orders, twap requires data already present at the time
`life_start` finishes.

this PR makes the data subscriptions manual, so a developer has to
decide for each algo order what the best behaviour is. in the
future we can make the subscriptions optionally awaitable so we
can make sure that subscriptions happened reliably at the current
point in time, which supports with developing better algo orders.