### PR TITLE
handle symbols with colons

### DIFF
--- a/lib/accumulate_distribute/events/data_managed_candles.js
+++ b/lib/accumulate_distribute/events/data_managed_candles.js
@@ -3,6 +3,7 @@
 const _reverse = require('lodash/reverse')
 const hasIndicatorOffset = require('../util/has_indicator_offset')
 const hasIndicatorCap = require('../util/has_indicator_cap')
+const parseChannelKey = require('../../util/parse_channel_key')
 
 /**
  * If the instance has internal indicators, they are either seeded with the
@@ -26,7 +27,7 @@ const onDataManagedCandles = async (instance = {}, candles, meta) => {
   const { debug, updateState } = h
   const { chanFilter } = meta
   const { key } = chanFilter
-  const chanSymbol = key.split(':')[2]
+  const { symbol: chanSymbol } = parseChannelKey(key)
 
   if ((!hasIndicatorOffset(args) && !hasIndicatorCap(args)) || symbol !== chanSymbol) {
     return

--- a/lib/ma_crossover/events/data_managed_candles.js
+++ b/lib/ma_crossover/events/data_managed_candles.js
@@ -2,6 +2,7 @@
 
 const _isFinite = require('lodash/isFinite')
 const _reverse = require('lodash/reverse')
+const parseChannelKey = require('../../util/parse_channel_key')
 
 /**
  * If the instance has internal indicators, they are either seeded with the
@@ -26,9 +27,7 @@ const onDataManagedCandles = async (instance = {}, candles, meta) => {
   const { debug, updateState, emitSelf, emit } = h
   const { chanFilter } = meta
   const { key } = chanFilter
-  const chanDetails = key.split(':')
-  const chanTF = chanDetails[1]
-  const chanSymbol = chanDetails[2]
+  const { symbol: chanSymbol, tf: chanTF } = parseChannelKey(key)
 
   if (symbol !== chanSymbol) {
     return

--- a/lib/util/parse_channel_key.js
+++ b/lib/util/parse_channel_key.js
@@ -1,0 +1,10 @@
+const separator = ':'
+
+module.exports = (chanKey) => {
+  const [key, tf, ...symbol] = chanKey.split(separator)
+  return {
+    key,
+    tf,
+    symbol: symbol.join(separator)
+  }
+}

--- a/lib/util/parse_channel_key.js
+++ b/lib/util/parse_channel_key.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const separator = ':'
 
 module.exports = (chanKey) => {

--- a/test/lib/accumulate_distribute/index.js
+++ b/test/lib/accumulate_distribute/index.js
@@ -8,6 +8,7 @@ const { EMA } = require('bfx-hf-indicators')
 const { Config } = require('bfx-api-node-core')
 const AccumulateDistribute = require('../../../lib/accumulate_distribute')
 const testAOLive = require('../../util/test_ao_live')
+const parseChannelKey = require('../../../lib/util/parse_channel_key')
 
 const { DUST } = Config
 
@@ -119,7 +120,8 @@ testAOLive({
       let emaSeeded = false
 
       harness.once('internal:data:managedCandles', (candles, meta) => {
-        if (meta.chanFilter.key.split(':')[2] !== 'tLEOUSD') {
+        const { symbol } = parseChannelKey(meta.chanFilter.key)
+        if (symbol !== 'tLEOUSD') {
           return
         }
 

--- a/test/lib/ma_crossover/events/data_managed_candles.js
+++ b/test/lib/ma_crossover/events/data_managed_candles.js
@@ -8,7 +8,7 @@ const { Candle } = require('bfx-api-node-models')
 const dataManagedCandles = require('../../../../lib/ma_crossover/events/data_managed_candles')
 
 const CANDLE = new Candle({ open: 1, high: 1.2, low: 0.9, close: 1, volume: 100 })
-const CANDLE_KEY = 'key:1m:tLEOUSD'
+const CANDLE_KEY = 'key:1m:tTESTBTC:TESTUSD'
 const getInstance = ({
   params = {}, argParams = {}, stateParams = {}, helperParams = {}
 }) => ({
@@ -18,7 +18,7 @@ const getInstance = ({
     longIndicator: new EMA([100]),
     shortIndicator: new EMA([20]),
     args: {
-      symbol: 'tLEOUSD',
+      symbol: 'tTESTBTC:TESTUSD',
       long: { candleTimeFrame: '1m', candlePrice: 'close' },
       short: { candleTimeFrame: '1m', candlePrice: 'close' },
       ...argParams

--- a/test/lib/util/parse_channel_key.js
+++ b/test/lib/util/parse_channel_key.js
@@ -1,0 +1,25 @@
+/* eslint-env mocha */
+'use strict'
+
+const { expect } = require('chai')
+const parseChannelKey = require('../../../lib/util/parse_channel_key')
+
+describe('parseChannelKey', () => {
+  it('should parse channel key', () => {
+    const details = parseChannelKey('key:1m:LEOUSD')
+    expect(details).to.eql({
+      key: 'key',
+      tf: '1m',
+      symbol: 'LEOUSD'
+    })
+  })
+
+  it('should be able to parse symbols with colons', () => {
+    const details = parseChannelKey('key:1m:tTESTBTC:TESTUSD')
+    expect(details).to.eql({
+      key: 'key',
+      tf: '1m',
+      symbol: 'tTESTBTC:TESTUSD'
+    })
+  })
+})


### PR DESCRIPTION
for pairs like `tTESTBTC:TESTUSD` with colon, they are not recognized by ma cross and maybe also other algos

to reproduce run an algo order ma cross with `tTESTBTC:TESTUSD`