### PR TITLE
listen to correct event to start strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ host.on('ao:persist:db:update', async(updateOpts) => {
   console.log('ao instance updated %s', updateOpts.gid)
 })
 
-host.on('ws2:auth:error', (packet) => {
+host.on('auth:error', (packet) => {
   console.log('error authenticating: %j', packet)
 })
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ host.on('error', (err) => {
   console.log('error: %s', err)
 })
 
-host.once('ws2:auth:success', async () => {
+host.once('ready', async () => {
 
   // Start an Iceberg order instance
   const gid = await host.startAO('bfx-iceberg', {

--- a/examples/ao_host.js
+++ b/examples/ao_host.js
@@ -59,7 +59,7 @@ host.on('ao:persist:db:update', async (updateOpts) => {
   debug('ao instance updated %s', updateOpts.gid)
 })
 
-host.on('ws2:auth:error', (packet) => {
+host.on('auth:error', (packet) => {
   debug('error authenticating: %j', packet)
 })
 

--- a/examples/ao_host.js
+++ b/examples/ao_host.js
@@ -67,7 +67,7 @@ host.on('error', (err) => {
   debug('error: %s', err)
 })
 
-host.once('ws2:auth:success', async () => {
+host.once('ready', async () => {
   const gid = await host.startAO('bfx-accumulate_distribute', {
     symbol: 'tBTCUSD',
     amount: -0.2,


### PR DESCRIPTION
In the example provided the current auth:success event is never called, we can use the `ready` instead