### PR TITLE
invalid slice amount error check issue fix

### DIFF
--- a/lib/accumulate_distribute/meta/validate_params.js
+++ b/lib/accumulate_distribute/meta/validate_params.js
@@ -49,7 +49,7 @@ const validateParams = (args = {}) => {
 
   if (!_includes(ORDER_TYPES, orderType)) return `Invalid order type: ${orderType}`
   if (!_isFinite(amount) || amount === 0) return 'Invalid amount'
-  if (!_isFinite(sliceAmount) || amount === 0) return 'Invalid slice amount'
+  if (!_isFinite(sliceAmount) || sliceAmount === 0) return 'Invalid slice amount'
   if (!_isBoolean(catchUp)) return 'Bool catch up flag required'
   if (!_isBoolean(awaitFill)) return 'Bool await fill flag required'
   if (!_isFinite(sliceInterval) || sliceInterval <= 0) return 'Invalid slice interval'


### PR DESCRIPTION
In accumulate/distribute algo, the validation was done for the `amount` value and not the `sliceAmount`. This PR fixes that.