### PR TITLE
debug added properly while subscribing to data channels

### DIFF
--- a/lib/host/gen_helpers.js
+++ b/lib/host/gen_helpers.js
@@ -184,7 +184,7 @@ const genHelpers = (state = {}, adapter) => {
 
       return Promise.all(
         channels.map(({ channel, filter: payload }) => {
-          debug('subscribing to channel %j (filter: %) [AO gid %d]', channel, payload, gid)
+          debug('subscribing to channel %j (filter: %O) [AO gid %s]', channel, payload, gid)
 
           adapter.subscribe(connection, channel, payload)
 


### PR DESCRIPTION
Adding the missing params in debug while logging the subscribing channel info.