### PR TITLE
Fix 'debug's memory leak

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "bfx-hf-indicators": "^2.0.0",
     "bfx-hf-util": "^1.0.1",
     "bluebird": "^3.5.5",
-    "debug": "^4.1.1",
+    "debug": "^4.3.1",
     "flat-promise": "^1.0.2",
     "lodash": "^4.17.15"
   },


### PR DESCRIPTION
Asana ticket: https://app.asana.com/0/1125859137800433/1200252416166861/f

Debugged using the following code, which simulates continuous 'debug' initialization:
```js
setInterval(() => {
  const debug = Debug(`bfx:hf:server:ws-server:test`)

  debug('%s', 'test')
}, 16)
```

### Results

- debug@4.1.1 (master branch)

![image](https://user-images.githubusercontent.com/70510980/117036043-af2bde80-ad0d-11eb-9bc4-2b2ec9be11de.png)

- debug@4.3.1 (this PR)
![image](https://user-images.githubusercontent.com/70510980/117036063-b6eb8300-ad0d-11eb-810c-5281a82c6fe6.png)

As you can see, v4.3.1 doesn't have memory leak on initialization