### PR TITLE
storage: apply changes to receive algo order data

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,17 +23,17 @@ const {
   AOHost, PingPong, Iceberg, TWAP, AccumulateDistribute, MACrossover
 } = require('bfx-hf-algo')
 
-const HFDB = require('bfx-hf-models')	
-const HFDBLowDBAdapter = require('bfx-hf-models-adapter-lowdb')	
-const {	
-  schema: HFDBBitfinexSchema	
+const HFDB = require('bfx-hf-models')
+const HFDBLowDBAdapter = require('bfx-hf-models-adapter-lowdb')
+const {
+  schema: HFDBBitfinexSchema
 } = require('bfx-hf-ext-plugin-bitfinex')
 
-const algoDB = new HFDB({	
-  schema: HFDBBitfinexSchema,	
-  adapter: HFDBLowDBAdapter({	
-    dbPath: path.join(__dirname, '..', 'db', 'example.json')	
-  })	
+const algoDB = new HFDB({
+  schema: HFDBBitfinexSchema,
+  adapter: HFDBLowDBAdapter({
+    dbPath: path.join(__dirname, '..', 'db', 'example.json')
+  })
 })
 
 const host = new AOHost({
@@ -45,22 +45,8 @@ const host = new AOHost({
   }
 })
 
-host.on('ao:start', (instance) => {
-  const { state = {} } = instance
-  const { id, gid } = state
-  console.log('started AO %s [gid %s]', id, gid)
-})
-
-host.on('ao:stop', (instance) => {
-  const { state = {} } = instance
-  const { id, gid } = state
-  console.log('stopped AO %s [gid %s]', id, gid)
-})
-
-host.on('ao:persist:db:update', async(updateOpts) => {
-  const { AlgoOrder } = algoDB  //algoDB is the low-adapter DB for algo
-  await AlgoOrder.set(updateOpts)
-  console.log('ao instance updated %s', updateOpts.gid)
+host.on('ao:state:update', async (updateOpts) => {
+  // send ui updates
 })
 
 host.on('auth:error', (packet) => {
@@ -72,9 +58,8 @@ host.on('error', (err) => {
 })
 
 host.once('ready', async () => {
-
   // Start an Iceberg order instance
-  const gid = await host.startAO('bfx-iceberg', {
+  const [serialized] = await host.startAO('bfx-iceberg', {
     symbol: 'tBTCUSD',
     price: 21000,
     amount: -0.5,

--- a/examples/ao_host.js
+++ b/examples/ao_host.js
@@ -17,7 +17,7 @@ const {
   schema: HFDBBitfinexSchema
 } = require('bfx-hf-ext-plugin-bitfinex')
 
-const algoDB = new HFDB({
+const { AlgoOrder } = new HFDB({
   schema: HFDBBitfinexSchema,
   adapter: HFDBLowDBAdapter({
     dbPath: path.join(__dirname, '..', 'db', 'example.json')
@@ -41,22 +41,9 @@ const host = new AOHost({
   wsSettings
 })
 
-host.on('ao:start', (instance) => {
-  const { state = {} } = instance
-  const { id, gid } = state
-  debug('started AO %s [gid %s]', id, gid)
-})
-
-host.on('ao:stop', (instance) => {
-  const { state = {} } = instance
-  const { id, gid } = state
-  debug('stopped AO %s [gid %s]', id, gid)
-})
-
-host.on('ao:persist:db:update', async (updateOpts) => {
-  const { AlgoOrder } = algoDB
-  await AlgoOrder.set(updateOpts)
+host.on('ao:state:update', async (updateOpts) => {
   debug('ao instance updated %s', updateOpts.gid)
+  console.log(updateOpts)
 })
 
 host.on('auth:error', (packet) => {
@@ -68,7 +55,7 @@ host.on('error', (err) => {
 })
 
 host.once('ready', async () => {
-  const gid = await host.startAO('bfx-accumulate_distribute', {
+  const [serialized] = await host.startAO('bfx-accumulate_distribute', {
     symbol: 'tBTCUSD',
     amount: -0.2,
     sliceAmount: -0.1,
@@ -85,7 +72,8 @@ host.once('ready', async () => {
     _margin: false
   })
 
-  debug('started AO %s', gid)
+  debug('started AO %s', serialized.gid)
+  await AlgoOrder.set(serialized)
 })
 
 host.connect()

--- a/lib/ao_host.js
+++ b/lib/ao_host.js
@@ -89,9 +89,8 @@ class AOHost extends AsyncEventEmitter {
 
     this.ready = false
 
-    this.onAOStart = this.onAOStart.bind(this)
-    this.onAOStop = this.onAOStop.bind(this)
     this.onAOPersist = this.onAOPersist.bind(this)
+
     this.loadAO = this.loadAO.bind(this)
     this.triggerAOEvent = this.triggerAOEvent.bind(this)
     this.triggerGlobalEvent = this.triggerGlobalEvent.bind(this)
@@ -108,8 +107,6 @@ class AOHost extends AsyncEventEmitter {
     this.adapter.on('meta:reload', this.onMetaReload.bind(this))
     this.adapter.on('meta:connection:update', this.onMetaConnectionUpdate.bind(this))
 
-    this.on('ao:start', this.onAOStart)
-    this.on('ao:stop', this.onAOStop)
     this.on('ao:persist', this.onAOPersist)
 
     bindWS2Bus(this)
@@ -439,10 +436,8 @@ class AOHost extends AsyncEventEmitter {
    *
    * @param {string} id - algo order definition ID, i.e. bfx-iceberg
    * @param {object} args - algo order arguments/parameters
-   * @param {Function} [gidCB] - callback to acquire GID prior to ao:start
-   * @returns {string} gid - instance GID
    */
-  async startAO (id, args = {}, gidCB) {
+  async startAO (id, args = {}) {
     const ao = this.getAO(id)
 
     if (!ao) {
@@ -451,7 +446,7 @@ class AOHost extends AsyncEventEmitter {
 
     const inst = initAO(this.adapter, ao, args)
 
-    return this.bootstrapAO(ao, inst, gidCB)
+    return this.bootstrapAO(ao, inst)
   }
 
   /**
@@ -462,11 +457,9 @@ class AOHost extends AsyncEventEmitter {
    *
    * @param {object} ao - base algo order definition
    * @param {object} instance - new algo order to be started
-   * @param {Function} [gidCB] - callback to acquire GID prior to ao:start
-   * @returns {string} gid - new instance GID
    * @private
    */
-  async bootstrapAO (ao, instance = {}, gidCB) {
+  async bootstrapAO (ao, instance = {}) {
     if (!this.ready) {
       throw new Error('ERR_NOT_READY')
     }
@@ -501,13 +494,8 @@ class AOHost extends AsyncEventEmitter {
 
     await this.maybeCancelExistingOrders(state, gid)
 
-    if (_isFunction(gidCB)) {
-      await gidCB(gid)
-    }
-
-    await this.emit('ao:start', this.instances[gid])
-
-    return gid
+    const data = await this._startAlgo(this.instances[gid])
+    return data
   }
 
   async maybeCancelExistingOrders (state, gid) {
@@ -530,6 +518,14 @@ class AOHost extends AsyncEventEmitter {
         )
       }
     }
+  }
+
+  getSerializedAlgos () {
+    const data = this.getAOInstances().map((instance) => {
+      return this.getSerializedAO(instance)
+    })
+
+    return data
   }
 
   /**
@@ -577,18 +573,15 @@ class AOHost extends AsyncEventEmitter {
    * to required channels, and triggers the life.start event.
    *
    * @param {object} instance - algo order instance that has started
-   * @private
    */
-  async onAOStart (instance = {}) {
-    const { gid } = instance.state
+  async _startAlgo (instance = {}) {
+    const { gid, name, label, args } = instance.state
 
     await withAOUpdate(this, gid, (instance = {}) => {
       const { state = {} } = instance
+      state.active = true
 
-      return {
-        ...state,
-        active: true
-      }
+      return false
     })
 
     /**
@@ -597,7 +590,11 @@ class AOHost extends AsyncEventEmitter {
      * @event AOHost~lifeStart
      */
     await this.triggerAOEvent(instance, 'life', 'start')
-    await this.emit('ao:persist', gid)
+
+    return [
+      this.getSerializedAO(instance),
+      { gid, name, label, args }
+    ]
   }
 
   /**
@@ -608,19 +605,20 @@ class AOHost extends AsyncEventEmitter {
    * @param {object} opts - options if required for algo order
    * @private
    */
-  async onAOStop (instance = {}, opts = {}) {
+  async _stopAlgo (instance = {}, opts = {}) {
     const { h } = instance
-    const { channels = [], gid, connection, ev, algoLogStream } = instance.state
+    const {
+      channels = [], gid, connection, ev, algoLogStream,
+      name, label, args
+    } = instance.state
 
     h.close()
 
     await withAOUpdate(this, gid, (instance = {}) => {
       const { state = {} } = instance
+      state.active = false
 
-      return {
-        ...state,
-        active: false
-      }
+      return false
     })
 
     if (!_isEmpty(channels)) {
@@ -636,7 +634,7 @@ class AOHost extends AsyncEventEmitter {
      * @event AOHost~lifeStop
      */
     await this.triggerAOEvent(instance, 'life', 'stop', opts)
-    await this.emit('ao:persist', gid)
+    const serialized = this.getSerializedAO(instance)
 
     if (algoLogStream) {
       debug('closing log stream for [AO gid %d]', gid)
@@ -646,10 +644,15 @@ class AOHost extends AsyncEventEmitter {
     ev.removeAllListeners()
 
     delete this.instances[gid]
+
+    return [
+      serialized,
+      { gid, name, label, args }
+    ]
   }
 
   /**
-   * Serializes & saves an algo order instance state to the DB
+   * Serializes emits an event for UI updates
    *
    * @param {string} gid - GID of algo order instance to persist
    * @private
@@ -661,30 +664,24 @@ class AOHost extends AsyncEventEmitter {
       return
     }
 
-    const { state = {} } = instance
-    const { id } = state
-    const ao = this.getAO(id)
+    const serialized = this.getSerializedAO(instance)
+    await this.emit('ao:state:update', serialized)
+  }
 
-    if (!ao) {
-      throw new Error(`can\t persist unknown ao: ${id}`)
-    }
+  getSerializedAO (instance) {
+    const { state = {} } = instance
+    const { id, gid } = state
+    const ao = this.getAO(id)
 
     const { meta = {} } = ao
     const { serialize } = meta
 
-    if (!serialize) {
-      debug('can\t save AO %s [%s] due to missing serialize method', gid, id)
-      return
-    }
-
-    await this.emit('ao:persist:db:update', {
+    return {
       gid,
       algoID: id,
       state: JSON.stringify(serialize(state)),
       active: state.active
-    })
-
-    debug('saved AO %s', gid)
+    }
   }
 
   /**

--- a/lib/ao_host.js
+++ b/lib/ao_host.js
@@ -540,7 +540,8 @@ class AOHost extends AsyncEventEmitter {
       throw new Error(`unknown AO: ${gid}`)
     }
 
-    await this.emit('ao:stop', instance)
+    const res = await this._stopAlgo(instance)
+    return res
   }
 
   /**

--- a/lib/ao_host.js
+++ b/lib/ao_host.js
@@ -583,6 +583,7 @@ class AOHost extends AsyncEventEmitter {
      * @event AOHost~lifeStart
      */
     await this.triggerAOEvent(instance, 'life', 'start')
+    await this.emit('ao:persist', gid)
 
     return [
       this.getSerializedAO(instance),
@@ -622,6 +623,8 @@ class AOHost extends AsyncEventEmitter {
      * @event AOHost~lifeStop
      */
     await this.triggerAOEvent(instance, 'life', 'stop', opts)
+    await this.emit('ao:persist', gid)
+
     const serialized = this.getSerializedAO(instance)
 
     if (algoLogStream) {

--- a/lib/ao_host.js
+++ b/lib/ao_host.js
@@ -425,9 +425,7 @@ class AOHost extends AsyncEventEmitter {
      * @property {module:Helpers} h - helpers bound to the instance
      */
     const inst = { state, h }
-
-    await this.bootstrapAO(ao, inst)
-    return this.emit('ao:loaded', gid)
+    return this.bootstrapAO(ao, inst)
   }
 
   /**

--- a/lib/ao_host.js
+++ b/lib/ao_host.js
@@ -18,7 +18,6 @@ const onUpdateState = require('./host/events/update_state')
 const onAssignChannel = require('./host/events/assign_channel')
 const onNotify = require('./host/events/notify')
 const onStop = require('./host/events/stop')
-const withAOUpdate = require('./host/with_ao_update')
 const bindWS2Bus = require('./host/ws2/bind_bus')
 const initAO = require('./host/init_ao')
 const genHelpers = require('./host/gen_helpers')
@@ -576,12 +575,7 @@ class AOHost extends AsyncEventEmitter {
   async _startAlgo (instance = {}) {
     const { gid, name, label, args } = instance.state
 
-    await withAOUpdate(this, gid, (instance = {}) => {
-      const { state = {} } = instance
-      state.active = true
-
-      return false
-    })
+    instance.state.active = true
 
     /**
      * Triggered when an algorithmic order begins execution.
@@ -613,12 +607,7 @@ class AOHost extends AsyncEventEmitter {
 
     h.close()
 
-    await withAOUpdate(this, gid, (instance = {}) => {
-      const { state = {} } = instance
-      state.active = false
-
-      return false
-    })
+    instance.state.active = false
 
     if (!_isEmpty(channels)) {
       channels.forEach(ch => {

--- a/lib/host/events/stop.js
+++ b/lib/host/events/stop.js
@@ -26,7 +26,7 @@ module.exports = async (aoHost, gid, onCleanup, opts) => {
   }
 
   // Let the host teardown (unsubs from channels, persists, etc)
-  await aoHost.emit('ao:stop', inst, opts)
+  await aoHost._stopAlgo(inst, opts)
 
   // implode
   delete aoHost.instances[gid]

--- a/test/lib/host/events/stop.js
+++ b/test/lib/host/events/stop.js
@@ -24,7 +24,8 @@ describe('host:events:stop', () => {
       emit: async () => {},
       instances: {
         a: { state: { ev } }
-      }
+      },
+      _stopAlgo: () => {}
     }, 'a')
 
     ev.emit('test')
@@ -37,22 +38,19 @@ describe('host:events:stop', () => {
       emit: async () => {},
       instances: {
         a: { state: { ev } }
-      }
+      },
+      _stopAlgo: () => {}
     }, 'a', done)
   })
 
-  it('emits ao:stop event on host', (done) => {
+  it('calls _stopAlgo on host', (done) => {
     const ev = new AsyncEventEmitter()
 
     stop({
-      emit: async (eventName) => {
-        if (eventName === 'ao:stop') {
-          done()
-        }
-      },
       instances: {
         a: { state: { ev } }
-      }
+      },
+      _stopAlgo: () => { done() }
     }, 'a')
   })
 
@@ -62,6 +60,7 @@ describe('host:events:stop', () => {
 
     await stop({
       instances,
+      _stopAlgo: () => {},
       emit: async (eventName) => {}
     }, 'a')
 


### PR DESCRIPTION
to support worker threads and in general better support for
hosted environments with many clients, storage won't be done
every few seconds any more, like currently the case

on start the state is stored, and on shutdown. this reduces the
db writes a lot (a twap with a 2 secod interval currently writes
every 2 seconds). it also brings flexibility by loosening the
coupling to the hf-models and database adapters, which we won't
use for the hosted version.

the event `ao:persist:db:update` is kept and can get used for
detailed UI updates on algo order details in the future