### PR TITLE
Explictly handle subscription timeouts

### DIFF
--- a/lib/accumulate_distribute/events/life_start.js
+++ b/lib/accumulate_distribute/events/life_start.js
@@ -53,6 +53,7 @@ const onLifeStart = async (instance = {}) => {
   }
 
   subscribeDataChannels(state)
+    .catch(e => debug('failed to subscribe to data channels: %s', e.message))
 
   await scheduleTick.tick(instance)
 }

--- a/lib/ma_crossover/events/life_start.js
+++ b/lib/ma_crossover/events/life_start.js
@@ -36,6 +36,7 @@ const onLifeStart = async (instance = {}) => {
   await updateState(instance, { longIndicator, shortIndicator, ts })
 
   subscribeDataChannels(state)
+    .catch(e => debug('failed to subscribe to data channels: %s', e.message))
 }
 
 module.exports = onLifeStart

--- a/lib/twap/events/life_start.js
+++ b/lib/twap/events/life_start.js
@@ -29,9 +29,12 @@ const onLifeStart = async (instance = {}) => {
     }
   }
 
-  await subscribeDataChannels(state, { timeout: 30 * 1000 })
-
-  emitSelf('interval_tick') // no await, don't delay
+  try {
+    await subscribeDataChannels(state, { timeout: 30 * 1000 })
+    emitSelf('interval_tick') // no await, don't delay
+  } catch (e) {
+    debug('failed to subscribe to data channels: %s', e.message)
+  }
 }
 
 module.exports = onLifeStart

--- a/test/lib/accumulate_distribute/events/life_start.js
+++ b/test/lib/accumulate_distribute/events/life_start.js
@@ -23,7 +23,7 @@ const getInstance = ({
     updateState: async () => {},
     scheduleTick: async () => {},
     notifyUI: async () => {},
-    subscribeDataChannels: () => {},
+    subscribeDataChannels: () => Promise.resolve(),
     ...helperParams
   },
 


### PR DESCRIPTION
Timeouts can cause an unhandled rejection in a promise and crash the whole process