### PR TITLE
Indicator class not a constructor issue fix

### DIFF
--- a/lib/accumulate_distribute/events/life_start.js
+++ b/lib/accumulate_distribute/events/life_start.js
@@ -44,7 +44,7 @@ const onLifeStart = async (instance = {}) => {
   }
 
   if (hasIndicatorCap(args)) {
-    const IndicatorClass = HFI[relativeOffset.type === 'ma' ? 'SMA' : 'EMA']
+    const IndicatorClass = HFI[relativeCap.type === 'ma' ? 'SMA' : 'EMA']
     const capIndicator = new IndicatorClass(relativeCap.args)
 
     debug('initialized cap indicator %s %j', relativeCap.type, relativeCap.args)

--- a/lib/accumulate_distribute/events/life_start.js
+++ b/lib/accumulate_distribute/events/life_start.js
@@ -32,7 +32,7 @@ const onLifeStart = async (instance = {}) => {
   )
 
   if (hasIndicatorOffset(args)) {
-    const IndicatorClass = HFI[`${relativeOffset.type === 'ma' ? 'sma' : relativeOffset.type}`.toUpperCase()]
+    const IndicatorClass = HFI[relativeOffset.type === 'ma' ? 'SMA' : 'EMA']
     const offsetIndicator = new IndicatorClass(relativeOffset.args)
 
     debug(
@@ -44,7 +44,7 @@ const onLifeStart = async (instance = {}) => {
   }
 
   if (hasIndicatorCap(args)) {
-    const IndicatorClass = HFI[`${relativeCap.type === 'ma' ? 'sma' : relativeCap.type}`.toUpperCase()]
+    const IndicatorClass = HFI[relativeOffset.type === 'ma' ? 'SMA' : 'EMA']
     const capIndicator = new IndicatorClass(relativeCap.args)
 
     debug('initialized cap indicator %s %j', relativeCap.type, relativeCap.args)

--- a/lib/accumulate_distribute/events/life_start.js
+++ b/lib/accumulate_distribute/events/life_start.js
@@ -32,7 +32,7 @@ const onLifeStart = async (instance = {}) => {
   )
 
   if (hasIndicatorOffset(args)) {
-    const IndicatorClass = HFI[relativeOffset.type.toUpperCase()]
+    const IndicatorClass = HFI[`${relativeOffset.type === 'ma' ? 'sma' : relativeOffset.type}`.toUpperCase()]
     const offsetIndicator = new IndicatorClass(relativeOffset.args)
 
     debug(
@@ -44,7 +44,7 @@ const onLifeStart = async (instance = {}) => {
   }
 
   if (hasIndicatorCap(args)) {
-    const IndicatorClass = HFI[relativeCap.type.toUpperCase()]
+    const IndicatorClass = HFI[`${relativeCap.type === 'ma' ? 'sma' : relativeCap.type}`.toUpperCase()]
     const capIndicator = new IndicatorClass(relativeCap.args)
 
     debug('initialized cap indicator %s %j', relativeCap.type, relativeCap.args)


### PR DESCRIPTION
The issue is originated while fetching the MA indicator class when the relativeCap or relativeOffset type is selected as Moving Average(MA). And since we have `SMA`  indicator available, acc/dist algo throws an error saying `Indicator class is not a constructor` resulting in failure to start the algo.

This fix here is by explicitly fetching the SMA or EMA indicator since `hasIndicatorOffset` and `hasIndicatorCap` only returns true if the given type is either 'ma' or 'ema'.

Task: https://app.asana.com/0/1125859137800433/1200358390931756 