### PR TITLE
Acc dist moving averge typo and issue fixes

### DIFF
--- a/lib/accumulate_distribute/events/data_managed_candles.js
+++ b/lib/accumulate_distribute/events/data_managed_candles.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const _reverse = require('lodash/reverse')
+const _last = require('lodash/last')
 const hasIndicatorOffset = require('../util/has_indicator_offset')
 const hasIndicatorCap = require('../util/has_indicator_cap')
 const parseChannelKey = require('../../util/parse_channel_key')
@@ -27,59 +27,78 @@ const onDataManagedCandles = async (instance = {}, candles, meta) => {
   const { debug, updateState } = h
   const { chanFilter } = meta
   const { key } = chanFilter
-  const { symbol: chanSymbol } = parseChannelKey(key)
+  const { symbol: chanSymbol, tf: chanTF } = parseChannelKey(key)
 
-  if ((!hasIndicatorOffset(args) && !hasIndicatorCap(args)) || symbol !== chanSymbol) {
+  const hasOffsetIndicator = hasIndicatorOffset(args)
+  const hasCapIndicator = hasIndicatorCap(args)
+
+  if ((!hasOffsetIndicator && !hasCapIndicator) || symbol !== chanSymbol) {
     return
   }
 
-  const [lastCandle] = candles
+  const lastCandleUpdateOpts = {}
+  let updateLastCandleOffset = true
+  let updateLastCandleCap = true
 
-  // Both indicators start with 0 length
-  if ((capIndicator && capIndicator.l() === 0) || (offsetIndicator && offsetIndicator.l() === 0)) {
-    debug('seeding indicators with %d candle prices', candles.length)
+  let [lastCandle] = candles
 
-    const orderedCandles = _reverse(candles)
-    orderedCandles.forEach((candle) => {
-      if (hasIndicatorCap(args)) {
-        capIndicator.add(candle[relativeCap.candlePrice])
-      }
+  if (hasOffsetIndicator && chanTF === relativeOffset.candleTimeFrame) {
+    if (!offsetIndicator.isSeeded()) {
+      debug('seeding relative offset indicator with %d candle prices', candles.length)
 
-      if (hasIndicatorOffset(args)) {
+      candles.forEach((candle) => {
         offsetIndicator.add(candle[relativeOffset.candlePrice])
-      }
-    })
-  } else { // add new data point/update data point
-    if (hasIndicatorOffset(args)) {
+      })
+      lastCandle = _last(candles)
+    } else {
       const price = lastCandle[relativeOffset.candlePrice]
+      debug('updating relative offset indicator with candle price %f(%s)', price, chanSymbol)
 
-      debug('updating relative offset indicator with candle price %f', price)
-
-      if (!state.lastCandle) {
+      if (!state.lastCandleOffset) {
         offsetIndicator.add(price)
-      } else if (state.lastCandle.mts === lastCandle.mts) {
+      } else if (state.lastCandleOffset.mts === lastCandle.mts) {
         offsetIndicator.update(price)
+      } else if (state.lastCandleOffset.mts > lastCandle.mts) {
+        updateLastCandleOffset = false // do nothing
       } else {
         offsetIndicator.add(price)
       }
     }
-
-    if (hasIndicatorCap(args)) {
-      const price = lastCandle[relativeCap.candlePrice]
-
-      debug('updating relative cap indicator with candle price %f', price)
-
-      if (!state.lastCandle) {
-        capIndicator.add(price)
-      } else if (state.lastCandle.mts === lastCandle.mts) {
-        capIndicator.update(price)
-      } else {
-        capIndicator.add(price)
-      }
+    if (updateLastCandleOffset) {
+      lastCandleUpdateOpts.lastCandleOffset = lastCandle
     }
   }
 
-  await updateState(instance, { candles })
+  if (hasCapIndicator && chanTF === relativeCap.candleTimeFrame) {
+    if (!capIndicator.isSeeded()) {
+      debug('seeding relative cap indicator with %d candle prices', candles.length)
+
+      candles.forEach((candle) => {
+        capIndicator.add(candle[relativeCap.candlePrice])
+      })
+      lastCandle = _last(candles)
+    } else {
+      const price = lastCandle[relativeCap.candlePrice]
+      debug('updating relative cap indicator with candle price %f(%s)', price, chanSymbol)
+
+      if (!state.lastCandleCap) {
+        capIndicator.add(price)
+      } else if (state.lastCandleCap.mts === lastCandle.mts) {
+        capIndicator.update(price)
+      } else if (state.lastCandleCap.mts > lastCandle.mts) {
+        updateLastCandleCap = false // do nothing
+      } else {
+        capIndicator.add(price)
+      }
+    }
+    if (updateLastCandleCap) {
+      lastCandleUpdateOpts.lastCandleCap = lastCandle
+    }
+  }
+
+  if (updateLastCandleOffset || updateLastCandleCap) {
+    await updateState(instance, { ...lastCandleUpdateOpts })
+  }
 }
 
 module.exports = onDataManagedCandles

--- a/lib/accumulate_distribute/index.js
+++ b/lib/accumulate_distribute/index.js
@@ -35,17 +35,17 @@ const unserialize = require('./meta/unserialize')
  * @param {boolean} catchUp - if true, interval will be ignored if behind with filling slices
  * @param {boolean} awaitFill - if true, slice orders will be kept open until filled
  * @param {object} [relativeOffset] - price reference for RELATIVE orders
- * @param {string} [relativeOffset.type] - ask, bid, mid, last, ma, or ema
+ * @param {string} [relativeOffset.type] - ask, bid, mid, last, sma, or ema
  * @param {number} [relativeOffset.delta] - offset distance from price reference
- * @param {number[]} [relativeOffset.args] - MA or EMA indicator arguments [period]
- * @param {string} [relativeOffset.candlePrice] - 'open', 'high', 'low', 'close' for MA or EMA indicators
- * @param {string} [relativeOffset.candleTimeFrame] - '1m', '5m', '1D', etc, for MA or EMA indicators
+ * @param {number[]} [relativeOffset.args] - SMA or EMA indicator arguments [period]
+ * @param {string} [relativeOffset.candlePrice] - 'open', 'high', 'low', 'close' for SMA or EMA indicators
+ * @param {string} [relativeOffset.candleTimeFrame] - '1m', '5m', '1D', etc, for SMA or EMA indicators
  * @param {object} [relativeCap] - maximum price reference for RELATIVE orders
- * @param {string} [relativeCap.type] - ask, bid, mid, last, ma, or ema
+ * @param {string} [relativeCap.type] - ask, bid, mid, last, sma, or ema
  * @param {number} [relativeCap.delta] - cap distance from price reference
- * @param {number[]} [relativeCap.args] - MA or EMA indicator arguments [period]
- * @param {string} [relativeCap.candlePrice] - 'open', 'high', 'low', 'close' for MA or EMA indicators
- * @param {string} [relativeCap.candleTimeFrame] - '1m', '5m', '1D', etc, for MA or EMA indicators
+ * @param {number[]} [relativeCap.args] - SMA or EMA indicator arguments [period]
+ * @param {string} [relativeCap.candlePrice] - 'open', 'high', 'low', 'close' for SMA or EMA indicators
+ * @param {string} [relativeCap.candleTimeFrame] - '1m', '5m', '1D', etc, for SMA or EMA indicators
  * @param {boolean} _margin - if false, order type is prefixed with EXCHANGE
  *
  * @example

--- a/lib/accumulate_distribute/meta/get_ui_def.js
+++ b/lib/accumulate_distribute/meta/get_ui_def.js
@@ -54,16 +54,16 @@ const getUIDef = () => ({
       ['offsetType', 'offsetDelta']
     ]
   }, {
-    name: 'offsetIndicatorMA',
-    title: 'Price Offset MA',
+    name: 'offsetIndicatorSMA',
+    title: 'Price Offset SMA',
     fixed: true,
     visible: {
       orderType: { eq: 'RELATIVE' },
-      offsetType: { eq: 'MA' }
+      offsetType: { eq: 'SMA' }
     },
     rows: [
-      ['offsetIndicatorPeriodMA', 'offsetIndicatorPriceMA'],
-      [null, 'offsetIndicatorTFMA']
+      ['offsetIndicatorPeriodSMA', 'offsetIndicatorPriceSMA'],
+      [null, 'offsetIndicatorTFSMA']
     ]
   }, {
     name: 'offsetIndicatorEMA',
@@ -89,16 +89,16 @@ const getUIDef = () => ({
       ['capType', 'capDelta']
     ]
   }, {
-    title: 'Price Cap MA',
-    name: 'capIndicatorMA',
+    title: 'Price Cap SMA',
+    name: 'capIndicatorSMA',
     fixed: true,
     visible: {
       orderType: { eq: 'RELATIVE' },
-      capType: { eq: 'MA' }
+      capType: { eq: 'SMA' }
     },
     rows: [
-      ['capIndicatorPeriodMA', 'capIndicatorPriceMA'],
-      [null, 'capIndicatorTFMA']
+      ['capIndicatorPeriodSMA', 'capIndicatorPriceSMA'],
+      [null, 'capIndicatorTFSMA']
     ]
   }, {
     title: 'Price Cap EMA',
@@ -215,7 +215,7 @@ const getUIDef = () => ({
         ASK: 'Top Ask',
         MID: 'Book Mid Price',
         TRADE: 'Last Trade Price',
-        MA: 'Moving Average',
+        SMA: 'Simple Moving Average',
         EMA: 'Exp Moving Average'
       }
     },
@@ -227,18 +227,18 @@ const getUIDef = () => ({
       default: 0
     },
 
-    offsetIndicatorPeriodMA: {
+    offsetIndicatorPeriodSMA: {
       component: 'input.number',
-      label: 'MA Period',
-      customHelp: 'Period for moving average indicator',
+      label: 'SMA Period',
+      customHelp: 'Period for simple moving average indicator',
       visible: {
-        offsetType: { eq: 'MA' }
+        offsetType: { eq: 'SMA' }
       }
     },
 
-    offsetIndicatorPriceMA: {
+    offsetIndicatorPriceSMA: {
       component: 'input.dropdown',
-      label: 'MA Candle Price',
+      label: 'SMA Candle Price',
       default: 'CLOSE',
       options: {
         OPEN: 'Open',
@@ -248,7 +248,7 @@ const getUIDef = () => ({
       },
 
       visible: {
-        offsetType: { eq: 'MA' }
+        offsetType: { eq: 'SMA' }
       }
     },
 
@@ -277,9 +277,9 @@ const getUIDef = () => ({
       }
     },
 
-    offsetIndicatorTFMA: {
+    offsetIndicatorTFSMA: {
       component: 'input.dropdown',
-      label: 'MA Candle Time Frame',
+      label: 'SMA Candle Time Frame',
       default: 'ONE_HOUR',
       options: {
         ONE_MINUTE: '1m',
@@ -297,7 +297,7 @@ const getUIDef = () => ({
       },
 
       visible: {
-        offsetType: { eq: 'MA' }
+        offsetType: { eq: 'SMA' }
       }
     },
 
@@ -336,7 +336,7 @@ const getUIDef = () => ({
         ASK: 'Top Ask',
         MID: 'Book Mid Price',
         TRADE: 'Last Trade Price',
-        MA: 'Moving Average',
+        SMA: 'Simple Moving Average',
         EMA: 'Exp Moving Average',
         NONE: 'None'
       }
@@ -353,18 +353,18 @@ const getUIDef = () => ({
       }
     },
 
-    capIndicatorPeriodMA: {
+    capIndicatorPeriodSMA: {
       component: 'input.number',
-      label: 'MA Period',
+      label: 'SMA Period',
       customHelp: 'Period for moving average indicator',
       visible: {
-        capType: { eq: 'MA' }
+        capType: { eq: 'SMA' }
       }
     },
 
-    capIndicatorPriceMA: {
+    capIndicatorPriceSMA: {
       component: 'input.dropdown',
-      label: 'MA Candle Price',
+      label: 'SMA Candle Price',
       default: 'CLOSE',
       options: {
         OPEN: 'Open',
@@ -373,7 +373,7 @@ const getUIDef = () => ({
         CLOSE: 'Close'
       },
       visible: {
-        capType: { eq: 'MA' }
+        capType: { eq: 'SMA' }
       }
     },
 
@@ -401,9 +401,9 @@ const getUIDef = () => ({
       }
     },
 
-    capIndicatorTFMA: {
+    capIndicatorTFSMA: {
       component: 'input.dropdown',
-      label: 'MA Candle Time Frame',
+      label: 'SMA Candle Time Frame',
       default: 'ONE_HOUR',
       options: {
         ONE_MINUTE: '1m',
@@ -420,7 +420,7 @@ const getUIDef = () => ({
         ONE_MONTH: '1M'
       },
       visible: {
-        capType: { eq: 'MA' }
+        capType: { eq: 'SMA' }
       }
     },
 

--- a/lib/accumulate_distribute/meta/process_params.js
+++ b/lib/accumulate_distribute/meta/process_params.js
@@ -49,20 +49,20 @@ const processParams = (data) => {
       delta: +params.capDelta
     }
 
-    if (params.offsetType === 'MA') {
-      params.relativeOffset.candlePrice = params.offsetIndicatorPriceMA.toLowerCase()
-      params.relativeOffset.candleTimeFrame = TIME_FRAMES[params.offsetIndicatorTFMA]
-      params.relativeOffset.args = [+params.offsetIndicatorPeriodMA]
+    if (params.offsetType === 'SMA') {
+      params.relativeOffset.candlePrice = params.offsetIndicatorPriceSMA.toLowerCase()
+      params.relativeOffset.candleTimeFrame = TIME_FRAMES[params.offsetIndicatorTFSMA]
+      params.relativeOffset.args = [+params.offsetIndicatorPeriodSMA]
     } else if (params.offsetType === 'EMA') {
       params.relativeOffset.candlePrice = params.offsetIndicatorPriceEMA.toLowerCase()
       params.relativeOffset.candleTimeFrame = TIME_FRAMES[params.offsetIndicatorTFEMA]
       params.relativeOffset.args = [+params.offsetIndicatorPeriodEMA]
     }
 
-    if (params.capType === 'MA') {
-      params.relativeCap.candlePrice = params.capIndicatorPriceMA.toLowerCase()
-      params.relativeCap.candleTimeFrame = TIME_FRAMES[params.capIndicatorTFMA]
-      params.relativeCap.args = [+params.capIndicatorPeriodMA]
+    if (params.capType === 'SMA') {
+      params.relativeCap.candlePrice = params.capIndicatorPriceSMA.toLowerCase()
+      params.relativeCap.candleTimeFrame = TIME_FRAMES[params.capIndicatorTFSMA]
+      params.relativeCap.args = [+params.capIndicatorPeriodSMA]
     } else if (params.capType === 'EMA') {
       params.relativeCap.candlePrice = params.capIndicatorPriceEMA.toLowerCase()
       params.relativeCap.candleTimeFrame = TIME_FRAMES[params.capIndicatorTFEMA]

--- a/lib/accumulate_distribute/meta/validate_params.js
+++ b/lib/accumulate_distribute/meta/validate_params.js
@@ -27,13 +27,13 @@ const ORDER_TYPES = ['MARKET', 'LIMIT', 'RELATIVE']
  * @param {boolean} args.catchUp - if true, interval will be ignored if behind with filling slices
  * @param {boolean} args.awaitFill - if true, slice orders will be kept open until filled
  * @param {object} [args.relativeOffset] - price reference for RELATIVE orders
- * @param {string} [args.relativeOffset.type] - ask, bid, mid, last, ma, or ema
+ * @param {string} [args.relativeOffset.type] - ask, bid, mid, last, sma, or ema
  * @param {number} [args.relativeOffset.delta] - offset distance from price reference
- * @param {number[]} [args.relativeOffset.args] - MA or EMA indicator arguments [period]
- * @param {string} [args.relativeOffset.candlePrice] - 'open', 'high', 'low', 'close' for MA or EMA indicators
- * @param {string} [args.relativeOffset.candleTimeFrame] - '1m', '5m', '1D', etc, for MA or EMA indicators
+ * @param {number[]} [args.relativeOffset.args] - SMA or EMA indicator arguments [period]
+ * @param {string} [args.relativeOffset.candlePrice] - 'open', 'high', 'low', 'close' for SMA or EMA indicators
+ * @param {string} [args.relativeOffset.candleTimeFrame] - '1m', '5m', '1D', etc, for SMA or EMA indicators
  * @param {object} [args.relativeCap] - maximum price reference for RELATIVE orders
- * @param {string} [args.relativeCap.type] - ask, bid, mid, last, ma, or ema
+ * @param {string} [args.relativeCap.type] - ask, bid, mid, last, sma, or ema
  * @param {number} [args.relativeCap.delta] - cap distance from price reference
  * @param {number[]} [args.relativeCap.args] - MA or EMA indicator arguments [period]
  * @param {string} [args.relativeCap.candlePrice] - 'open', 'high', 'low', 'close' for MA or EMA indicators
@@ -82,7 +82,7 @@ const validateParams = (args = {}, pairConfig = {}) => {
       return validationErrObj('capDelta', 'Invalid relative cap delta')
     }
 
-    if ((relativeCap.type === 'ma') || (relativeCap.type === 'ema')) {
+    if ((relativeCap.type === 'sma') || (relativeCap.type === 'ema')) {
       const { args = [], type } = relativeCap
       const capitalizedType = type.toUpperCase()
 
@@ -109,7 +109,7 @@ const validateParams = (args = {}, pairConfig = {}) => {
       return validationErrObj('offsetDelta', 'Invalid relative offset delta')
     }
 
-    if ((relativeOffset.type === 'ma') || (relativeOffset.type === 'ema')) {
+    if ((relativeOffset.type === 'sma') || (relativeOffset.type === 'ema')) {
       const { args = [], type } = relativeOffset
       const capitalizedType = type.toUpperCase()
 

--- a/lib/accumulate_distribute/util/generate_order.js
+++ b/lib/accumulate_distribute/util/generate_order.js
@@ -95,7 +95,7 @@ const generateOrder = (instance = {}) => {
       break
     }
 
-    case 'ma': {
+    case 'sma': {
       if (offsetIndicator.l() === 0) return null
       offsetPrice = offsetIndicator.v() // guaranteed seeded
       break
@@ -148,7 +148,7 @@ const generateOrder = (instance = {}) => {
         break
       }
 
-      case 'ma': {
+      case 'sma': {
         if (capIndicator.l() === 0) return null
         priceCap = capIndicator.v()
         break

--- a/lib/accumulate_distribute/util/has_indicator_cap.js
+++ b/lib/accumulate_distribute/util/has_indicator_cap.js
@@ -12,7 +12,7 @@ const hasIndicatorCap = (args = {}) => {
   const { relativeCap = {} } = args
   const { type } = relativeCap
 
-  return (type === 'ma' || type === 'ema')
+  return (type === 'sma' || type === 'ema')
 }
 
 module.exports = hasIndicatorCap

--- a/lib/accumulate_distribute/util/has_indicator_offset.js
+++ b/lib/accumulate_distribute/util/has_indicator_offset.js
@@ -12,7 +12,7 @@ const hasIndicatorOffset = (args = {}) => {
   const { relativeOffset = {} } = args
   const { type } = relativeOffset
 
-  return (type === 'ma' || type === 'ema')
+  return (type === 'sma' || type === 'ema')
 }
 
 module.exports = hasIndicatorOffset

--- a/test/lib/accumulate_distribute/events/data_managed_candles.js
+++ b/test/lib/accumulate_distribute/events/data_managed_candles.js
@@ -23,8 +23,8 @@ const getInstance = ({
     offsetIndicator: new EMA([10]),
     capIndicator: new EMA([10]),
     args: {
-      relativeOffset: { type: 'ema' },
-      relativeCap: { type: 'ema' },
+      relativeOffset: { type: 'ema', candleTimeFrame: '1m' },
+      relativeCap: { type: 'ema', candleTimeFrame: '1m' },
       ...argParams
     },
     ...stateParams
@@ -66,12 +66,12 @@ describe('accumulate_distribute:events:data_managed_candles', () => {
       argParams: { symbol: 'tBTCUSD' },
       stateParams: {
         offsetIndicator: {
-          l: () => candlesAddedToOffsetIndicator,
+          isSeeded: () => candlesAddedToOffsetIndicator !== 0,
           add: (c) => { candlesAddedToOffsetIndicator++ }
         },
 
         capIndicator: {
-          l: () => candlesAddedToCapIndicator,
+          isSeeded: () => candlesAddedToCapIndicator !== 0,
           add: (c) => { candlesAddedToCapIndicator++ }
         }
       },
@@ -101,15 +101,15 @@ describe('accumulate_distribute:events:data_managed_candles', () => {
     const i = getInstance({
       argParams: {
         symbol: 'tBTCUSD',
-        relativeCap: { type: 'ema', candlePrice: 'high' },
+        relativeCap: { type: 'ema', candleTimeFrame: '1m', candlePrice: 'high' },
         relativeOffset: {}
       },
 
       stateParams: {
-        lastCandle: { mts: 0 },
+        lastCandleCap: { mts: 0 },
         offsetIndicator: null,
         capIndicator: {
-          l: () => 1,
+          isSeeded: () => true,
           update: (price) => {
             assert.strictEqual(price, 42, 'got wrong candle')
             capCandleUpdated = true
@@ -140,15 +140,15 @@ describe('accumulate_distribute:events:data_managed_candles', () => {
     const i = getInstance({
       argParams: {
         symbol: 'tBTCUSD',
-        relativeOffset: { type: 'ema', candlePrice: 'high' },
+        relativeOffset: { type: 'ema', candleTimeFrame: '1m', candlePrice: 'high' },
         relativeCap: {}
       },
 
       stateParams: {
-        lastCandle: { mts: 0 },
+        lastCandleOffset: { mts: 0 },
         capIndicator: null,
         offsetIndicator: {
-          l: () => 1,
+          isSeeded: () => true,
           update: (price) => {
             assert.strictEqual(price, 42, 'got wrong candle')
             offsetCandleUpdated = true

--- a/test/lib/accumulate_distribute/meta/declare_channels.js
+++ b/test/lib/accumulate_distribute/meta/declare_channels.js
@@ -75,7 +75,7 @@ describe('accumulate_distribute:meta:declare_channels', () => {
   })
 
   it('declares candle channels for cap/offset indicators if needed', async () => {
-    for (const indicatorType of ['ma', 'ema']) {
+    for (const indicatorType of ['sma', 'ema']) {
       for (const candleReqSource of ['relativeOffset', 'relativeCap']) {
         let sawChannel = false
 

--- a/test/lib/accumulate_distribute/meta/gen_order_label.js
+++ b/test/lib/accumulate_distribute/meta/gen_order_label.js
@@ -32,11 +32,11 @@ describe('accumulate_distribute:meta:gen_order_label', () => {
         ...state.args,
         orderType: null,
         relativeOffset: { type: 'ema' },
-        relativeCap: { type: 'ma' }
+        relativeCap: { type: 'sma' }
       }
     })
 
     assert.ok(_includes(str, 'Offset EMA'), 'relative offset type not included')
-    assert.ok(_includes(str, 'Cap MA'), 'relative cap type not included')
+    assert.ok(_includes(str, 'Cap SMA'), 'relative cap type not included')
   })
 })

--- a/test/lib/accumulate_distribute/meta/process_params.js
+++ b/test/lib/accumulate_distribute/meta/process_params.js
@@ -18,11 +18,11 @@ const args = {
   offsetIndicatorPriceEMA: 'high',
   offsetIndicatorTFEMA: 'ONE_MINUTE',
   offsetIndicatorPeriodEMA: 10,
-  capType: 'MA',
+  capType: 'SMA',
   capDelta: 12,
-  capIndicatorPriceMA: 'low',
-  capIndicatorTFMA: 'FIVE_MINUTES',
-  capIndicatorPeriodMA: 20,
+  capIndicatorPriceSMA: 'low',
+  capIndicatorTFSMA: 'FIVE_MINUTES',
+  capIndicatorPeriodSMA: 20,
   amount: 7,
   sliceAmount: 3
 }

--- a/test/lib/accumulate_distribute/meta/validate_params.js
+++ b/test/lib/accumulate_distribute/meta/validate_params.js
@@ -128,8 +128,8 @@ describe('accumulate_distribute:meta:validate_params', () => {
     })
 
     it('returns error if cap candle price is invalid', () => {
-      const err = validateParams({ ...params, relativeCap: { ...params.relativeCap, type: 'ma', candlePrice: false } }, pairConfig)
-      assert.deepStrictEqual(err.field, 'capIndicatorPriceMA')
+      const err = validateParams({ ...params, relativeCap: { ...params.relativeCap, type: 'sma', candlePrice: false } }, pairConfig)
+      assert.deepStrictEqual(err.field, 'capIndicatorPriceSMA')
       assert(_isString(err.message))
     })
 
@@ -154,8 +154,8 @@ describe('accumulate_distribute:meta:validate_params', () => {
     })
 
     it('returns error if offset candle price is invalid', () => {
-      const err = validateParams({ ...params, relativeOffset: { ...params.relativeOffset, type: 'ma', candlePrice: false } }, pairConfig)
-      assert.deepStrictEqual(err.field, 'offsetIndicatorPriceMA')
+      const err = validateParams({ ...params, relativeOffset: { ...params.relativeOffset, type: 'sma', candlePrice: false } }, pairConfig)
+      assert.deepStrictEqual(err.field, 'offsetIndicatorPriceSMA')
       assert(_isString(err.message))
     })
 

--- a/test/lib/accumulate_distribute/util/has_indicator_cap.js
+++ b/test/lib/accumulate_distribute/util/has_indicator_cap.js
@@ -6,7 +6,7 @@ const hasIndicatorCap = require('../../../../lib/accumulate_distribute/util/has_
 
 describe('accumulate_distribute:util:has_indicator_cap', () => {
   it('reports cap presence', () => {
-    assert.ok(hasIndicatorCap({ relativeCap: { type: 'ma' } }), 'cap presence not detected')
+    assert.ok(hasIndicatorCap({ relativeCap: { type: 'sma' } }), 'cap presence not detected')
     assert.ok(hasIndicatorCap({ relativeCap: { type: 'ema' } }), 'cap presence not detected')
   })
 

--- a/test/lib/accumulate_distribute/util/has_indicator_offset.js
+++ b/test/lib/accumulate_distribute/util/has_indicator_offset.js
@@ -6,7 +6,7 @@ const hasIndicatorOffset = require('../../../../lib/accumulate_distribute/util/h
 
 describe('accumulate_distribute:util:has_indicator_offset', () => {
   it('reports offset presence', () => {
-    assert.ok(hasIndicatorOffset({ relativeOffset: { type: 'ma' } }), 'offset presence not detected')
+    assert.ok(hasIndicatorOffset({ relativeOffset: { type: 'sma' } }), 'offset presence not detected')
     assert.ok(hasIndicatorOffset({ relativeOffset: { type: 'ema' } }), 'offset presence not detected')
   })
 


### PR DESCRIPTION
Since the error exists in acc/dist algo saying `Indicator class not a constructor` whenever moving average is selected by the user because of a typo, the following changes have been implemented along with some improvements. 

This PR includes two changes: 
1. Variable name and value changed from 'ma' to 'sma'.
2. updating the offset and relative indicator based on candle timeframe as selected by the user instead of adding all values to the indicator. 

Task: https://app.asana.com/0/1125859137800433/1200358390931756