### PR TITLE
Acc/DIst orderform validation

### DIFF
--- a/lib/accumulate_distribute/meta/validate_params.js
+++ b/lib/accumulate_distribute/meta/validate_params.js
@@ -5,6 +5,7 @@ const _isFinite = require('lodash/isFinite')
 const _isObject = require('lodash/isObject')
 const _isBoolean = require('lodash/isBoolean')
 const _includes = require('lodash/includes')
+const validationErrObj = require('../../util/validate_params_err')
 
 const ORDER_TYPES = ['MARKET', 'LIMIT', 'RELATIVE']
 
@@ -37,87 +38,113 @@ const ORDER_TYPES = ['MARKET', 'LIMIT', 'RELATIVE']
  * @param {number[]} [args.relativeCap.args] - MA or EMA indicator arguments [period]
  * @param {string} [args.relativeCap.candlePrice] - 'open', 'high', 'low', 'close' for MA or EMA indicators
  * @param {string} [args.relativeCap.candleTimeFrame] - '1m', '5m', '1D', etc, for MA or EMA indicators
+ * @param {object} pairConfig - config for the selected market pair
+ * @param {number} pairConfig.minSize - minimum order size for the selected market pair
+ * @param {number} pairConfig.maxSize - maximum order size for the selected market pair
+ * @param {number} pairConfig.lev - leverage allowed for the selected market pair
  * @returns {string} error - null if parameters are valid, otherwise a
  *   description of which parameter is invalid.
  */
-const validateParams = (args = {}) => {
+const validateParams = (args = {}, pairConfig = {}) => {
+  const { minSize, maxSize, lev: maxLev } = pairConfig
   const {
     limitPrice, amount, sliceAmount, orderType,
     intervalDistortion, amountDistortion, sliceInterval, relativeOffset,
     relativeCap, catchUp, awaitFill, lev, _futures
   } = args
 
-  if (!_includes(ORDER_TYPES, orderType)) return `Invalid order type: ${orderType}`
-  if (!_isFinite(amount) || amount === 0) return 'Invalid amount'
-  if (!_isFinite(sliceAmount) || sliceAmount === 0) return 'Invalid slice amount'
-  if (!_isBoolean(catchUp)) return 'Bool catch up flag required'
-  if (!_isBoolean(awaitFill)) return 'Bool await fill flag required'
-  if (!_isFinite(sliceInterval) || sliceInterval <= 0) return 'Invalid slice interval'
-  if (!_isFinite(intervalDistortion)) return 'Interval distortion required'
-  if (!_isFinite(amountDistortion)) return 'Amount distortion required'
+  if (!_includes(ORDER_TYPES, orderType)) return validationErrObj('orderType', `Invalid order type: ${orderType}`)
+  if (!_isFinite(amount) || amount === 0) return validationErrObj('amount', 'Invalid amount')
+  if (!_isFinite(sliceAmount) || sliceAmount === 0) return validationErrObj('sliceAmount', 'Invalid slice amount')
+  if (!_isBoolean(catchUp)) return validationErrObj('catchUp', 'Bool catch up flag required')
+  if (!_isBoolean(awaitFill)) return validationErrObj('awaitFill', 'Bool await fill flag required')
+  if (!_isFinite(sliceInterval) || sliceInterval <= 0) return validationErrObj('sliceInterval', 'Invalid slice interval')
+  if (!_isFinite(intervalDistortion)) return validationErrObj('intervalDistortion', 'Invalid interval distortion')
+  if (!_isFinite(amountDistortion)) return validationErrObj('amountDistortion', 'Invalid amount distortion')
+
+  if (
+    (amount < 0 && sliceAmount >= 0) ||
+    (amount > 0 && sliceAmount <= 0)
+  ) {
+    return validationErrObj('sliceAmount', 'Amount & slice amount must have same sign')
+  }
+
+  if (sliceAmount > amount) {
+    return validationErrObj('sliceAmount', 'Slice amount cannot be greater than amount')
+  }
+
   if (orderType === 'LIMIT' && !_isFinite(limitPrice)) {
-    return 'Limit price required for LIMIT order type'
+    return validationErrObj('limitPrice', 'Limit price required for LIMIT order type')
   }
 
   if (_isObject(relativeCap)) {
     if (!_isFinite(relativeCap.delta)) {
-      return 'Invalid relative cap delta'
+      return validationErrObj('capDelta', 'Invalid relative cap delta')
     }
 
     if ((relativeCap.type === 'ma') || (relativeCap.type === 'ema')) {
-      const { args = [] } = relativeCap
+      const { args = [], type } = relativeCap
+      const capitalizedType = type.toUpperCase()
 
       if (args.length !== 1) {
-        return 'Invalid args for relative cap indicator'
+        return validationErrObj(`capIndicatorPeriod${capitalizedType}`, `${capitalizedType} period required for relative cap indicator`)
+      } else if (!_isFinite(args[0])) {
+        return validationErrObj(`capIndicatorPeriod${capitalizedType}`, `Invalid relative cap indicator period: ${relativeCap.args[0]}`)
+      } else if (args[0] <= 0) {
+        return validationErrObj(`capIndicatorPeriod${capitalizedType}`, 'Invalid relative cap indicator period, please set a positive value')
       }
 
       if (!relativeCap.candlePrice) {
-        return 'Candle price required for relative cap indicator'
+        return validationErrObj(`capIndicatorPrice${capitalizedType}`, 'Candle price required for relative cap indicator')
       } else if (!relativeCap.candleTimeFrame) {
-        return 'Candle time frame required for relative cap indicator'
+        return validationErrObj(`capIndicatorTF${capitalizedType}`, 'Candle time frame required for relative cap indicator')
       } else if (!TIME_FRAME_WIDTHS[relativeCap.candleTimeFrame]) {
-        return `Unrecognized relative cap candle time frame: ${relativeCap.candleTimeFrame}`
-      } else if (!_isFinite(relativeCap.args[0])) {
-        return `Invalid relative cap indicator period: ${relativeCap.args[0]}`
+        return validationErrObj(`capIndicatorTF${capitalizedType}`, `Unrecognized relative cap candle time frame: ${relativeCap.candleTimeFrame}`)
       }
     }
   }
 
   if (_isObject(relativeOffset)) {
     if (!_isFinite(relativeOffset.delta)) {
-      return 'Invalid relative offset delta'
+      return validationErrObj('offsetDelta', 'Invalid relative offset delta')
     }
 
     if ((relativeOffset.type === 'ma') || (relativeOffset.type === 'ema')) {
-      const { args = [] } = relativeOffset
+      const { args = [], type } = relativeOffset
+      const capitalizedType = type.toUpperCase()
 
       if (args.length !== 1) {
-        return 'Invalid args for relative offset indicator'
+        return validationErrObj(`offsetIndicatorPeriod${capitalizedType}`, `${capitalizedType} period required for relative offset indicator`)
+      } else if (!_isFinite(args[0])) {
+        return validationErrObj(`offsetIndicatorPeriod${capitalizedType}`, `Invalid relative offset indicator period: ${relativeOffset.args[0]}`)
+      } else if (args[0] <= 0) {
+        return validationErrObj(`offsetIndicatorPeriod${capitalizedType}`, 'Invalid relative offset indicator period, please set a positive value')
       }
 
       if (!relativeOffset.candlePrice) {
-        return 'Candle price required for relative offset indicator'
+        return validationErrObj(`offsetIndicatorPrice${capitalizedType}`, 'Candle price required for relative offset indicator')
       } else if (!relativeOffset.candleTimeFrame) {
-        return 'Candle time frame required for relative offset indicator'
+        return validationErrObj(`offsetIndicatorTF${capitalizedType}`, 'Candle time frame required for relative offset indicator')
       } else if (!TIME_FRAME_WIDTHS[relativeOffset.candleTimeFrame]) {
-        return `Unrecognized relative offset candle time frame: ${relativeOffset.candleTimeFrame}`
-      } else if (!_isFinite(relativeOffset.args[0])) {
-        return `Invalid relative offset indicator period: ${relativeOffset.args[0]}`
+        return validationErrObj(`offsetIndicatorTF${capitalizedType}`, `Unrecognized relative offset candle time frame: ${relativeOffset.candleTimeFrame}`)
       }
     }
   }
 
-  if (
-    (amount < 0 && sliceAmount >= 0) ||
-    (amount > 0 && sliceAmount <= 0)
-  ) {
-    return 'Amount & slice amount must have same sign'
+  if (_isFinite(minSize)) {
+    if (Math.abs(amount) < minSize) return validationErrObj('amount', `Amount cannot be less than ${minSize}`)
+    if (Math.abs(sliceAmount) < minSize) return validationErrObj('sliceAmount', `Slice amount cannot be less than ${minSize}`)
+  }
+
+  if (_isFinite(maxSize)) {
+    if (Math.abs(amount) > maxSize) return validationErrObj('amount', `Amount cannot be greater than ${maxSize}`)
+    if (Math.abs(sliceAmount) > maxSize) return validationErrObj('sliceAmount', `Slice amount cannot be greater than ${maxSize}`)
   }
 
   if (_futures) {
-    if (!_isFinite(lev)) return 'Invalid leverage'
-    if (lev < 1) return 'Leverage less than 1'
-    if (lev > 100) return 'Leverage greater than 100' // TODO: change limit?
+    if (!_isFinite(lev)) return validationErrObj('lev', 'Invalid leverage')
+    if (lev < 1) return validationErrObj('lev', 'Leverage cannot be less than 1')
+    if (_isFinite(maxLev) && (lev > maxLev)) return validationErrObj('lev', `Leverage cannot be greater than ${maxLev}`)
   }
 
   return null

--- a/test/lib/accumulate_distribute/meta/validate_params.js
+++ b/test/lib/accumulate_distribute/meta/validate_params.js
@@ -2,7 +2,7 @@
 'use strict'
 
 const assert = require('assert')
-const _isEmpty = require('lodash/isEmpty')
+const _isString = require('lodash/isString')
 const validateParams = require('../../../../lib/accumulate_distribute/meta/validate_params')
 
 const params = {
@@ -33,34 +33,190 @@ const params = {
   _futures: true
 }
 
-describe('accumulate_distribute:meta:unserialize', () => {
-  it('returns an error string for invalid parameters', () => {
-    assert.ok(!_isEmpty(validateParams({ ...params, orderType: 'unknown' })))
-    assert.ok(!_isEmpty(validateParams({ ...params, amount: 0 })))
-    assert.ok(!_isEmpty(validateParams({ ...params, amount: 'not' })))
-    assert.ok(!_isEmpty(validateParams({ ...params, amount: 1, sliceAmount: -1 })))
-    assert.ok(!_isEmpty(validateParams({ ...params, amount: -1, sliceAmount: 1 })))
-    assert.ok(!_isEmpty(validateParams({ ...params, lev: '' })))
-    assert.ok(!_isEmpty(validateParams({ ...params, lev: 0 })))
-    assert.ok(!_isEmpty(validateParams({ ...params, lev: 101 })))
-    assert.ok(!_isEmpty(validateParams({ ...params, sliceAmount: 0 })))
-    assert.ok(!_isEmpty(validateParams({ ...params, sliceAmount: 'not' })))
-    assert.ok(!_isEmpty(validateParams({ ...params, catchUp: 'day' })))
-    assert.ok(!_isEmpty(validateParams({ ...params, awaitFill: 'and' })))
-    assert.ok(!_isEmpty(validateParams({ ...params, sliceInterval: 'it' })))
-    assert.ok(!_isEmpty(validateParams({ ...params, sliceInterval: -1 })))
-    assert.ok(!_isEmpty(validateParams({ ...params, intervalDistortion: 'does\'t' })))
-    assert.ok(!_isEmpty(validateParams({ ...params, amountDistortion: 'stop' })))
-    assert.ok(!_isEmpty(validateParams({ ...params, orderType: 'LIMIT', limitPrice: 'nope' })))
+const pairConfig = {
+  minSize: 0.01,
+  maxSize: 20,
+  lev: 5
+}
 
-    assert.ok(!_isEmpty(validateParams({ ...params, relativeCap: { ...params.relativeCap, delta: '' } })))
-    assert.ok(!_isEmpty(validateParams({ ...params, relativeCap: { ...params.relativeCap, candlePrice: false } })))
-    assert.ok(!_isEmpty(validateParams({ ...params, relativeCap: { ...params.relativeCap, candleTimeFrame: '' } })))
-    assert.ok(!_isEmpty(validateParams({ ...params, relativeCap: { ...params.relativeCap, args: ['nope'] } })))
+describe('accumulate_distribute:meta:validate_params', () => {
+  describe('validate general order parameters', () => {
+    it('returns error on invalid order type', () => {
+      const err = validateParams({ ...params, orderType: 'unknown' })
+      assert.deepStrictEqual(err.field, 'orderType')
+      assert(_isString(err.message))
+    })
 
-    assert.ok(!_isEmpty(validateParams({ ...params, relativeOffset: { ...params.relativeOffset, delta: '' } })))
-    assert.ok(!_isEmpty(validateParams({ ...params, relativeOffset: { ...params.relativeOffset, candlePrice: false } })))
-    assert.ok(!_isEmpty(validateParams({ ...params, relativeOffset: { ...params.relativeOffset, candleTimeFrame: '' } })))
-    assert.ok(!_isEmpty(validateParams({ ...params, relativeOffset: { ...params.relativeOffset, args: ['nope'] } })))
+    it('returns error when amount is invalid or zero', () => {
+      const invalidErr = validateParams({ ...params, amount: 'not' })
+      assert.deepStrictEqual(invalidErr.field, 'amount')
+      assert(_isString(invalidErr.message))
+
+      const zeroErr = validateParams({ ...params, amount: 0 })
+      assert.deepStrictEqual(zeroErr.field, 'amount')
+      assert(_isString(zeroErr.message))
+    })
+
+    it('returns error when slice amount is invalid or zero', () => {
+      const invalidErr = validateParams({ ...params, sliceInterval: 'it' })
+      assert.deepStrictEqual(invalidErr.field, 'sliceInterval')
+      assert(_isString(invalidErr.message))
+
+      const lessThanZeroErr = validateParams({ ...params, sliceInterval: -1 })
+      assert.deepStrictEqual(lessThanZeroErr.field, 'sliceInterval')
+      assert(_isString(lessThanZeroErr.message))
+    })
+
+    it('returns error when slice interval is invalid or less than or equals zero', () => {
+      const invalidErr = validateParams({ ...params, sliceAmount: 'not' })
+      assert.deepStrictEqual(invalidErr.field, 'sliceAmount')
+      assert(_isString(invalidErr.message))
+
+      const zeroErr = validateParams({ ...params, sliceAmount: 0 })
+      assert.deepStrictEqual(zeroErr.field, 'sliceAmount')
+      assert(_isString(zeroErr.message))
+    })
+
+    it('returns error when interval distortion is invalid', () => {
+      const err = validateParams({ ...params, intervalDistortion: 'does\'t' })
+      assert.deepStrictEqual(err.field, 'intervalDistortion')
+      assert(_isString(err.message))
+    })
+
+    it('returns error when amount distortion is invalid', () => {
+      const err = validateParams({ ...params, amountDistortion: 'stop' })
+      assert.deepStrictEqual(err.field, 'amountDistortion')
+      assert(_isString(err.message))
+    })
+
+    it('returns error when slice amount and amount are not the same sign', () => {
+      const err = validateParams({ ...params, amount: 1, sliceAmount: -1 })
+      assert.deepStrictEqual(err.field, 'sliceAmount')
+      assert(_isString(err.message))
+    })
+
+    it('returns error when slice amount is greater than the amount', () => {
+      const err = validateParams({ ...params, sliceAmount: 10 })
+      assert.deepStrictEqual(err.field, 'sliceAmount')
+      assert(_isString(err.message))
+    })
+
+    it('returns error when limit price is invalid for limit order type', () => {
+      const err = validateParams({ ...params, orderType: 'LIMIT', limitPrice: 'nope' })
+      assert.deepStrictEqual(err.field, 'limitPrice')
+      assert(_isString(err.message))
+    })
+
+    it('returns error when catchUp field is not boolean', () => {
+      const err = validateParams({ ...params, catchUp: 'day' })
+      assert.deepStrictEqual(err.field, 'catchUp')
+      assert(_isString(err.message))
+    })
+
+    it('returns error when awaitFill field is not boolean', () => {
+      const err = validateParams({ ...params, awaitFill: 'and' })
+      assert.deepStrictEqual(err.field, 'awaitFill')
+      assert(_isString(err.message))
+    })
+  })
+
+  describe('validate relative cap parameters', () => {
+    it('returns error if cap delta is not a number', () => {
+      const err = validateParams({ ...params, relativeCap: { ...params.relativeCap, delta: '' } }, pairConfig)
+      assert.deepStrictEqual(err.field, 'capDelta')
+      assert(_isString(err.message))
+    })
+
+    it('returns error if cap candle price is invalid', () => {
+      const err = validateParams({ ...params, relativeCap: { ...params.relativeCap, type: 'ma', candlePrice: false } }, pairConfig)
+      assert.deepStrictEqual(err.field, 'capIndicatorPriceMA')
+      assert(_isString(err.message))
+    })
+
+    it('returns error if cap candle time frame is invalid', () => {
+      const err = validateParams({ ...params, relativeCap: { ...params.relativeCap, candleTimeFrame: '' } }, pairConfig)
+      assert.deepStrictEqual(err.field, 'capIndicatorTFEMA')
+      assert(_isString(err.message))
+    })
+
+    it('returns error if cap args does not have a valid number', () => {
+      const err = validateParams({ ...params, relativeCap: { ...params.relativeCap, args: ['nope'] } }, pairConfig)
+      assert.deepStrictEqual(err.field, 'capIndicatorPeriodEMA')
+      assert(_isString(err.message))
+    })
+  })
+
+  describe('validate relative offset parameters', () => {
+    it('returns error if offset delta is not a number', () => {
+      const err = validateParams({ ...params, relativeOffset: { ...params.relativeOffset, delta: '' } }, pairConfig)
+      assert.deepStrictEqual(err.field, 'offsetDelta')
+      assert(_isString(err.message))
+    })
+
+    it('returns error if offset candle price is invalid', () => {
+      const err = validateParams({ ...params, relativeOffset: { ...params.relativeOffset, type: 'ma', candlePrice: false } }, pairConfig)
+      assert.deepStrictEqual(err.field, 'offsetIndicatorPriceMA')
+      assert(_isString(err.message))
+    })
+
+    it('returns error if offset candle time frame is invalid', () => {
+      const err = validateParams({ ...params, relativeOffset: { ...params.relativeOffset, candleTimeFrame: '' } }, pairConfig)
+      assert.deepStrictEqual(err.field, 'offsetIndicatorTFEMA')
+      assert(_isString(err.message))
+    })
+
+    it('returns error if offset args does not have a valid number', () => {
+      const err = validateParams({ ...params, relativeOffset: { ...params.relativeOffset, args: ['nope'] } }, pairConfig)
+      assert.deepStrictEqual(err.field, 'offsetIndicatorPeriodEMA')
+      assert(_isString(err.message))
+    })
+  })
+
+  describe('validate amount against minimum and maximum order size', () => {
+    it('returns error if amount is less than the minimum order size', () => {
+      const err = validateParams({ ...params, amount: 0.001, sliceAmount: 0.001 }, pairConfig)
+      assert.deepStrictEqual(err.field, 'amount')
+      assert(_isString(err.message))
+    })
+
+    it('returns error if amount is greater than the maximum order size', () => {
+      const err = validateParams({ ...params, amount: 25 }, pairConfig)
+      assert.deepStrictEqual(err.field, 'amount')
+      assert(_isString(err.message))
+    })
+  })
+
+  describe('validate slice amount against minimum and maximum order size', () => {
+    it('returns error if slice amount is less than the minimum order size', () => {
+      const err = validateParams({ ...params, sliceAmount: 0.001 }, pairConfig)
+      assert.deepStrictEqual(err.field, 'sliceAmount')
+      assert(_isString(err.message))
+    })
+
+    it('returns error if slice amount is greater than the maximum order size', () => {
+      const err = validateParams({ ...params, sliceAmount: 25 }, pairConfig)
+      assert.deepStrictEqual(err.field, 'sliceAmount')
+      assert(_isString(err.message))
+    })
+  })
+
+  describe('validate leverage for future pairs', () => {
+    it('returns error if leverage is not a number', () => {
+      const err = validateParams({ ...params, lev: '' }, pairConfig)
+      assert.deepStrictEqual(err.field, 'lev')
+      assert(_isString(err.message))
+    })
+
+    it('returns error if leverage is less than 1', () => {
+      const err = validateParams({ ...params, lev: 0 }, pairConfig)
+      assert.deepStrictEqual(err.field, 'lev')
+      assert(_isString(err.message))
+    })
+
+    it('returns error if leverage is greater than the allowed leverage', () => {
+      const err = validateParams({ ...params, lev: 6 }, pairConfig)
+      assert.deepStrictEqual(err.field, 'lev')
+      assert(_isString(err.message))
+    })
   })
 })


### PR DESCRIPTION
This PR adds the functionality to be able to fetch the error fields as well so that it's easier in the UI side to show the error message on the specific field of the algo order. It can be used by UI to check for errors before submitting the order to algo server. However, the UI if wishes to use this function, it must process params first using processParams function before using the validateParams function.

Task: https://app.asana.com/0/1125859137800433/1200373978248379

Related PR: https://github.com/bitfinexcom/bfx-hf-algo/pull/155