### PR TITLE
MA crossover orderform validation

### DIFF
--- a/lib/ma_crossover/meta/validate_params.js
+++ b/lib/ma_crossover/meta/validate_params.js
@@ -3,6 +3,7 @@
 const _isFinite = require('lodash/isFinite')
 const _isObject = require('lodash/isObject')
 const _includes = require('lodash/includes')
+const validationErrObj = require('../../util/validate_params_err')
 
 const ORDER_TYPES = ['MARKET', 'LIMIT']
 
@@ -31,39 +32,49 @@ const ORDER_TYPES = ['MARKET', 'LIMIT']
  * @param {string} [args.longMATF] - candle time frame for long MA signal
  * @param {number} [args.longMAPeriod] - cadnel period for long MA signal
  * @param {string} [args.longMAPrice] - candle price key for long MA signal
+ * @param {object} pairConfig - config for the selected market pair
+ * @param {number} pairConfig.minSize - minimum order size for the selected market pair
+ * @param {number} pairConfig.maxSize - maximum order size for the selected market pair
+ * @param {number} pairConfig.lev - leverage allowed for the selected market pair
  * @returns {string} error - null if parameters are valid, otherwise a
  *   description of which parameter is invalid.
  */
-const validateParams = (args = {}) => {
-  const {
-    orderPrice, amount, orderType, long, short, lev,
-    _futures
-  } = args
+const validateParams = (args = {}, pairConfig = {}) => {
+  const { minSize, maxSize, lev: maxLev } = pairConfig
+  const { orderPrice, amount, orderType, long, short, lev, _futures } = args
 
-  if (!_includes(ORDER_TYPES, orderType)) return `Invalid order type: ${orderType}`
-  if (!_isFinite(amount) || amount === 0) return 'Invalid amount'
+  if (!_includes(ORDER_TYPES, orderType)) return validationErrObj('orderType', `Invalid order type: ${orderType}`)
+  if (!_isFinite(amount) || amount === 0) return validationErrObj('amount', 'Invalid amount')
   if (orderType === 'LIMIT' && !_isFinite(orderPrice)) {
-    return 'Limit price required for LIMIT order type'
+    return validationErrObj('orderPrice', 'Limit price required for LIMIT order type')
   }
 
-  if (!_isObject(long)) return 'Invalid long indicator config'
-  if (long.args.length !== 1) return 'Invalid args for long ma indicator '
-  if (long.args[0] <= 0) return 'Invalid long period, please set a positive value'
-  if (!long.candlePrice) return 'Candle price required for long indicator'
-  if (!long.candleTimeFrame) return 'Candle time frame required for long indicator'
-  if (!_isFinite(long.args[0])) return `Invalid long indicator period: ${long.args[0]}`
+  if (!_isObject(long)) return validationErrObj('longType', 'Invalid long indicator type')
+  if (long.args.length !== 1) return validationErrObj(`long${long.type.toUpperCase()}Period`, 'Invalid args for long ma indicator')
+  if (!_isFinite(long.args[0])) return validationErrObj(`long${long.type.toUpperCase()}Period`, `Invalid long indicator period: ${long.args[0]}`)
+  if (long.args[0] <= 0) return validationErrObj(`long${long.type.toUpperCase()}Period`, 'Invalid long period, please set a positive value')
+  if (!long.candlePrice) return validationErrObj(`long${long.type.toUpperCase()}Price`, 'Candle price required for long indicator')
+  if (!long.candleTimeFrame) return validationErrObj(`long${long.type.toUpperCase()}TF`, 'Candle time frame required for long indicator')
 
-  if (!_isObject(short)) return 'Invalid short indicator config'
-  if (short.args.length !== 1) return 'Invalid args for short ma indicator '
-  if (short.args[0] <= 0) return 'Invalid short period, please set a positive value'
-  if (!short.candlePrice) return 'Candle price required for short indicator'
-  if (!short.candleTimeFrame) return 'Candle time frame required for short indicator'
-  if (!_isFinite(short.args[0])) return `Invalid short indicator period: ${short.args[0]}`
+  if (!_isObject(short)) return validationErrObj('shortType', 'Invalid short indicator type')
+  if (short.args.length !== 1) return validationErrObj(`short${short.type.toUpperCase()}Period`, 'Invalid args for short ma indicator ')
+  if (!_isFinite(short.args[0])) return validationErrObj(`short${short.type.toUpperCase()}Period`, `Invalid short indicator period: ${short.args[0]}`)
+  if (short.args[0] <= 0) return validationErrObj(`short${short.type.toUpperCase()}Period`, 'Invalid short period, please set a positive value')
+  if (!short.candlePrice) return validationErrObj(`short${short.type.toUpperCase()}Price`, 'Candle price required for short indicator')
+  if (!short.candleTimeFrame) return validationErrObj(`short${short.type.toUpperCase()}TF`, 'Candle time frame required for short indicator')
+
+  if (_isFinite(minSize) && Math.abs(amount) < minSize) {
+    return validationErrObj('amount', `Amount cannot be less than ${minSize}`)
+  }
+
+  if (_isFinite(maxSize) && Math.abs(amount) > maxSize) {
+    return validationErrObj('amount', `Amount cannot be greater than ${maxSize}`)
+  }
 
   if (_futures) {
-    if (!_isFinite(lev)) return 'Invalid leverage'
-    if (lev < 1) return 'Leverage less than 1'
-    if (lev > 100) return 'Leverage greater than 100'
+    if (!_isFinite(lev)) return validationErrObj('lev', 'Invalid leverage')
+    if (lev < 1) return validationErrObj('lev', 'Leverage cannot be less than 1')
+    if (_isFinite(maxLev) && (lev > maxLev)) return validationErrObj('lev', `Leverage cannot be greater than ${maxLev}`)
   }
 
   return null

--- a/test/lib/ma_crossover/meta/validate_params.js
+++ b/test/lib/ma_crossover/meta/validate_params.js
@@ -2,7 +2,7 @@
 'use strict'
 
 const assert = require('assert')
-const _isEmpty = require('lodash/isEmpty')
+const _isString = require('lodash/isString')
 const validateParams = require('../../../../lib/ma_crossover/meta/validate_params')
 
 const params = {
@@ -27,27 +27,132 @@ const params = {
   }
 }
 
-describe('ma_crossover:meta:unserialize', () => {
-  it('validates', () => {
-    assert.ok(!_isEmpty(validateParams({ ...params, orderType: '' })))
-    assert.ok(!_isEmpty(validateParams({ ...params, amount: '' })))
-    assert.ok(!_isEmpty(validateParams({ ...params, amount: 0 })))
-    assert.ok(!_isEmpty(validateParams({ ...params, orderPrice: '' })))
+const pairConfig = {
+  minSize: 0.02,
+  maxSize: 20,
+  lev: 5
+}
 
-    assert.ok(!_isEmpty(validateParams({ ...params, long: '' })))
-    assert.ok(!_isEmpty(validateParams({ ...params, long: { ...params.long, args: [] } })))
-    assert.ok(!_isEmpty(validateParams({ ...params, long: { ...params.long, args: [''] } })))
-    assert.ok(!_isEmpty(validateParams({ ...params, long: { ...params.long, candlePrice: null } })))
-    assert.ok(!_isEmpty(validateParams({ ...params, long: { ...params.long, candleTimeFrame: null } })))
+describe('ma_crossover:meta:validate_params', () => {
+  describe('validate general order parameters', () => {
+    it('returns error on invalid order type', () => {
+      const err = validateParams({ ...params, orderType: '' })
+      assert.deepStrictEqual(err.field, 'orderType')
+      assert(_isString(err.message))
+    })
 
-    assert.ok(!_isEmpty(validateParams({ ...params, short: '' })))
-    assert.ok(!_isEmpty(validateParams({ ...params, short: { ...params.short, args: [] } })))
-    assert.ok(!_isEmpty(validateParams({ ...params, short: { ...params.short, args: [''] } })))
-    assert.ok(!_isEmpty(validateParams({ ...params, short: { ...params.short, candlePrice: null } })))
-    assert.ok(!_isEmpty(validateParams({ ...params, short: { ...params.short, candleTimeFrame: null } })))
+    it('returns error when amount is invalid or zero', () => {
+      const invalidErr = validateParams({ ...params, amount: '' })
+      assert.deepStrictEqual(invalidErr.field, 'amount')
+      assert(_isString(invalidErr.message))
 
-    assert.ok(!_isEmpty(validateParams({ ...params, _futures: true, lev: null })))
-    assert.ok(!_isEmpty(validateParams({ ...params, _futures: true, lev: 0 })))
-    assert.ok(!_isEmpty(validateParams({ ...params, _futures: true, lev: 101 })))
+      const zeroErr = validateParams({ ...params, amount: 0 })
+      assert.deepStrictEqual(zeroErr.field, 'amount')
+      assert(_isString(zeroErr.message))
+    })
+
+    it('returns error for order price is invalid for limit orderType', () => {
+      const err = validateParams({ ...params, orderPrice: '' })
+      assert.deepStrictEqual(err.field, 'orderPrice')
+      assert(_isString(err.message))
+    })
+  })
+
+  describe('validate long ma settings', () => {
+    it('returns error when long ma settings is not an object', () => {
+      const err = validateParams({ ...params, long: '' })
+      assert.deepStrictEqual(err.field, 'longType')
+      assert(_isString(err.message))
+    })
+
+    it('returns error when the long ma time period is not in proper format', () => {
+      const err = validateParams({ ...params, long: { ...params.long, args: [] } })
+      assert.deepStrictEqual(err.field, 'longEMAPeriod')
+      assert(_isString(err.message))
+    })
+
+    it('returns error when the long ma time period is invalid', () => {
+      const err = validateParams({ ...params, long: { ...params.long, type: 'ma', args: [''] } })
+      assert.deepStrictEqual(err.field, 'longMAPeriod')
+      assert(_isString(err.message))
+    })
+
+    it('returns error when the long ma candle price is invalid', () => {
+      const err = validateParams({ ...params, long: { ...params.long, candlePrice: null } })
+      assert.deepStrictEqual(err.field, 'longEMAPrice')
+      assert(_isString(err.message))
+    })
+
+    it('returns error when the long ma candle timeframe is invalid', () => {
+      const err = validateParams({ ...params, long: { ...params.long, candleTimeFrame: null } })
+      assert.deepStrictEqual(err.field, 'longEMATF')
+      assert(_isString(err.message))
+    })
+  })
+
+  describe('validate short ma settings', () => {
+    it('returns error when short ma settings is not an object', () => {
+      const err = validateParams({ ...params, short: '' })
+      assert.deepStrictEqual(err.field, 'shortType')
+      assert(_isString(err.message))
+    })
+
+    it('returns error when the short ma time period is not in proper format', () => {
+      const err = validateParams({ ...params, short: { ...params.short, args: [] } })
+      assert.deepStrictEqual(err.field, 'shortEMAPeriod')
+      assert(_isString(err.message))
+    })
+
+    it('returns error when the short ma time period is invalid', () => {
+      const err = validateParams({ ...params, short: { ...params.short, type: 'ma', args: [''] } })
+      assert.deepStrictEqual(err.field, 'shortMAPeriod')
+      assert(_isString(err.message))
+    })
+
+    it('returns error when the short ma candle price is invalid', () => {
+      const err = validateParams({ ...params, short: { ...params.short, candlePrice: null } })
+      assert.deepStrictEqual(err.field, 'shortEMAPrice')
+      assert(_isString(err.message))
+    })
+
+    it('returns error when the short ma candle timeframe is invalid', () => {
+      const err = validateParams({ ...params, short: { ...params.short, candleTimeFrame: null } })
+      assert.deepStrictEqual(err.field, 'shortEMATF')
+      assert(_isString(err.message))
+    })
+  })
+
+  describe('validate amount against minimum and maximum order size', () => {
+    it('returns error if amount is less than the minimum order size', () => {
+      const err = validateParams({ ...params, amount: 0.001 }, pairConfig)
+      assert.deepStrictEqual(err.field, 'amount')
+      assert(_isString(err.message))
+    })
+
+    it('returns error if amount is greater than the maximum order size', () => {
+      const err = validateParams({ ...params, amount: 25 }, pairConfig)
+      assert.deepStrictEqual(err.field, 'amount')
+      assert(_isString(err.message))
+    })
+  })
+
+  describe('validate leverage for future pairs', () => {
+    it('returns error if leverage is not a number', () => {
+      const err = validateParams({ ...params, _futures: true, lev: null }, pairConfig)
+      assert.deepStrictEqual(err.field, 'lev')
+      assert(_isString(err.message))
+    })
+
+    it('returns error if leverage is less than 1', () => {
+      const err = validateParams({ ...params, _futures: true, lev: 0 }, pairConfig)
+      assert.deepStrictEqual(err.field, 'lev')
+      assert(_isString(err.message))
+    })
+
+    it('returns error if leverage is greater than the allowed leverage', () => {
+      const err = validateParams({ ...params, _futures: true, lev: 6 }, pairConfig)
+      assert.deepStrictEqual(err.field, 'lev')
+      assert(_isString(err.message))
+    })
   })
 })


### PR DESCRIPTION
This PR adds the functionality to be able to fetch the error fields as well so that it's easier in the UI side to show the error message on the specific field of the algo order. It can be used by UI to check for errors before submitting the order to algo server. However, the UI if wishes to use this function, it must process params first using processParams function before using the validateParams function.

Task: https://app.asana.com/0/1125859137800433/1200373978248381