### PR TITLE
Ping pong orderform validation

### DIFF
--- a/lib/ping_pong/meta/validate_params.js
+++ b/lib/ping_pong/meta/validate_params.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const _isFinite = require('lodash/isFinite')
+const validationErrObj = require('../../util/validate_params_err')
 
 /**
  * Verifies that a parameters Object is valid, and all parameters are within
@@ -17,59 +18,105 @@ const _isFinite = require('lodash/isFinite')
  * @param {number} [args.pingMinPrice] - minimum price for ping orders
  * @param {number} [args.pingMaxPrice] - maximum price for ping orders
  * @param {number} [args.pongDistance] - pong offset from ping orders for multiple pairs
+ * @param {object} pairConfig - config for the selected market pair
+ * @param {number} pairConfig.minSize - minimum order size for the selected market pair
+ * @param {number} pairConfig.maxSize - maximum order size for the selected market pair
+ * @param {number} pairConfig.lev - leverage allowed for the selected market pair
  * @returns {string} error - null if parameters are valid, otherwise a
  *   description of which parameter is invalid.
  */
-const validateParams = (args = {}) => {
+const validateParams = (args = {}, pairConfig = {}) => {
+  const { minSize, maxSize, lev: maxLev } = pairConfig
   const {
     pingAmount, pongAmount, pingPrice, pongPrice, pingMinPrice, pingMaxPrice,
-    orderCount, pongDistance, lev, _futures
+    orderCount, pongDistance, lev, _futures, splitPingPongAmount
   } = args
 
   if (!_isFinite(orderCount) || orderCount < 1) {
-    return `Invalid order count: ${orderCount}`
+    return validationErrObj('orderCount', `Invalid order count: ${orderCount}`)
   }
 
-  if (!_isFinite(pingAmount) || pingAmount === 0) return 'Invalid ping amount'
-  if (!_isFinite(pongAmount) || pongAmount === 0) return 'Invalid pong amount'
+  if (!_isFinite(pingAmount) || pingAmount === 0) {
+    return validationErrObj(
+      splitPingPongAmount ? 'pingAmount' : 'amount',
+      splitPingPongAmount ? 'Invalid ping amount' : 'Invalid amount'
+    )
+  }
+
+  if (!_isFinite(pongAmount) || pongAmount === 0) {
+    return validationErrObj(
+      splitPingPongAmount ? 'pongAmount' : 'amount',
+      splitPingPongAmount ? 'Invalid pong amount' : 'Invalid amount'
+    )
+  }
 
   if (orderCount === 1) {
-    if (!_isFinite(pingPrice) || pingPrice === 0) return 'Invalid ping price'
-    if (!_isFinite(pongPrice) || pongPrice === 0) return 'Invalid pong price'
+    if (!_isFinite(pingPrice) || pingPrice <= 0) return validationErrObj('pingPrice', 'Invalid ping price')
+    if (!_isFinite(pongPrice) || pongPrice <= 0) return validationErrObj('pongPrice', 'Invalid pong price')
     if (pingAmount > 0 && pongPrice < pingPrice) {
-      return 'Pong price must be greater than ping price for buy orders'
+      return validationErrObj('pongPrice', 'Pong price must be greater than ping price for buy orders')
     }
     if (pingAmount < 0 && pongPrice > pingPrice) {
-      return 'Pong price must be less than ping price for sell orders'
+      return validationErrObj('pongPrice', 'Pong price must be less than ping price for sell orders')
     }
   }
 
   if (orderCount > 1) {
-    if (!_isFinite(pingMinPrice) || pingMinPrice === 0) {
-      return `Invalid ping min price: ${pingMinPrice}`
+    if (!_isFinite(pingMinPrice) || pingMinPrice <= 0) {
+      return validationErrObj('pingMinPrice', `Invalid ping min price: ${pingMinPrice}`)
     }
 
-    if (!_isFinite(pingMaxPrice) || pingMaxPrice === 0) {
-      return `Invalid ping max price: ${pingMaxPrice}`
+    if (!_isFinite(pingMaxPrice) || pingMaxPrice <= 0) {
+      return validationErrObj('pingMaxPrice', `Invalid ping max price: ${pingMaxPrice}`)
     }
 
-    if (!_isFinite(pongDistance) || pongDistance === 0) {
-      return `Invalid pong distance: ${pongDistance}`
+    if (!_isFinite(pongDistance)) {
+      return validationErrObj('pongDistance', `Invalid pong distance: ${pongDistance}`)
     }
 
     if (pingMaxPrice < pingMinPrice) {
-      return 'Ping max price must be greater than min price'
+      return validationErrObj('pingMaxPrice', 'Ping max price must be greater than min price')
     }
 
-    if (pongDistance < 0) {
-      return 'Pong distance must be positive'
+    if (pongDistance <= 0) {
+      return validationErrObj('pongDistance', 'Pong distance must be positive')
+    }
+  }
+
+  if (_isFinite(minSize)) {
+    if (Math.abs(pingAmount) < minSize) {
+      return validationErrObj(
+        splitPingPongAmount ? 'pingAmount' : 'amount',
+        `${splitPingPongAmount ? 'Ping amount' : 'Amount'} cannot be less than ${minSize}`
+      )
+    }
+    if (Math.abs(pongAmount) < minSize) {
+      return validationErrObj(
+        splitPingPongAmount ? 'pongAmount' : 'amount',
+        `${splitPingPongAmount ? 'Pong amount' : 'Amount'} cannot be less than ${minSize}`
+      )
+    }
+  }
+
+  if (_isFinite(maxSize)) {
+    if (Math.abs(pingAmount) > maxSize) {
+      return validationErrObj(
+        splitPingPongAmount ? 'pingAmount' : 'amount',
+        `${splitPingPongAmount ? 'Ping amount' : 'Amount'} cannot be greater than ${maxSize}`
+      )
+    }
+    if (Math.abs(pongAmount) > maxSize) {
+      return validationErrObj(
+        splitPingPongAmount ? 'pongAmount' : 'amount',
+        `${splitPingPongAmount ? 'Pong amount' : 'Amount'} cannot be greater than ${maxSize}`
+      )
     }
   }
 
   if (_futures) {
-    if (!_isFinite(lev)) return 'Invalid leverage'
-    if (lev < 1) return 'Leverage less than 1'
-    if (lev > 100) return 'Leverage greater than 100'
+    if (!_isFinite(lev)) return validationErrObj('lev', 'Invalid leverage')
+    if (lev < 1) return validationErrObj('lev', 'Leverage cannot be less than 1')
+    if (_isFinite(maxLev) && (lev > maxLev)) return validationErrObj('lev', `Leverage cannot be greater than ${maxLev}`)
   }
 
   return null

--- a/test/lib/ping_pong/meta/validate_params.js
+++ b/test/lib/ping_pong/meta/validate_params.js
@@ -1,7 +1,176 @@
 /* eslint-env mocha */
 'use strict'
 
-// const assert = require('assert')
-// const validateParams = require('../../../../lib/ping_pong/meta/validate_params')
+const assert = require('assert')
+const _isString = require('lodash/isString')
+const validateParams = require('../../../../lib/ping_pong/meta/validate_params')
 
-describe.skip('ping_pong:meta:unserialize', () => {})
+const params = {
+  action: 'Buy',
+  orderCount: 1,
+  pingAmount: 10,
+  pongAmount: 10,
+  pingMaxPrice: 500,
+  pingMinPrice: 400,
+  pingPrice: 1400,
+  pongPrice: 1500,
+  pongDistance: 10
+}
+
+const pairConfig = {
+  minSize: 0.01,
+  maxSize: 20,
+  lev: 5
+}
+
+describe('ping_pong:meta:validate_params', () => {
+  it('returns error if order count is invalid', () => {
+    const err = validateParams({ ...params, orderCount: 'nope' })
+    assert.deepStrictEqual(err.field, 'orderCount')
+    assert(_isString(err.message))
+  })
+
+  it('returns error when ping amount is invalid or zero', () => {
+    const invalidErr = validateParams({ ...params, pingAmount: 'not' })
+    assert.deepStrictEqual(invalidErr.field, 'amount')
+    assert(_isString(invalidErr.message))
+
+    const zeroErr = validateParams({ ...params, splitPingPongAmount: true, pingAmount: 0 })
+    assert.deepStrictEqual(zeroErr.field, 'pingAmount')
+    assert(_isString(zeroErr.message))
+  })
+
+  it('returns error when pong amount is invalid or zero', () => {
+    const invalidErr = validateParams({ ...params, pongAmount: 'not' })
+    assert.deepStrictEqual(invalidErr.field, 'amount')
+    assert(_isString(invalidErr.message))
+
+    const zeroErr = validateParams({ ...params, splitPingPongAmount: true, pongAmount: 0 })
+    assert.deepStrictEqual(zeroErr.field, 'pongAmount')
+    assert(_isString(zeroErr.message))
+  })
+
+  describe('validate parameters when order count is 1', () => {
+    it('returns error when ping price is invalid or zero', () => {
+      const invalidErr = validateParams({ ...params, pingPrice: 'not' })
+      assert.deepStrictEqual(invalidErr.field, 'pingPrice')
+      assert(_isString(invalidErr.message))
+
+      const zeroErr = validateParams({ ...params, pingPrice: 0 })
+      assert.deepStrictEqual(zeroErr.field, 'pingPrice')
+      assert(_isString(zeroErr.message))
+    })
+
+    it('returns error when pong price is invalid or zero', () => {
+      const invalidErr = validateParams({ ...params, pongPrice: 'not' })
+      assert.deepStrictEqual(invalidErr.field, 'pongPrice')
+      assert(_isString(invalidErr.message))
+
+      const zeroErr = validateParams({ ...params, pongPrice: 0 })
+      assert.deepStrictEqual(zeroErr.field, 'pongPrice')
+      assert(_isString(zeroErr.message))
+    })
+
+    it('returns error when pong price is less than ping price for buy order', () => {
+      const err = validateParams({ ...params, pingPrice: 1500, pongPrice: 1300 })
+      assert.deepStrictEqual(err.field, 'pongPrice')
+      assert(_isString(err.message))
+    })
+
+    it('returns error when pong price is greater than ping price for sell order', () => {
+      const err = validateParams({ ...params, pingAmount: -10, action: 'Sell' })
+      assert.deepStrictEqual(err.field, 'pongPrice')
+      assert(_isString(err.message))
+    })
+  })
+
+  describe('validate parameters when order count is greater than 1', () => {
+    it('returns error when minimum ping price is invalid or zero', () => {
+      const invalidErr = validateParams({ ...params, orderCount: 2, pingMinPrice: 'not' })
+      assert.deepStrictEqual(invalidErr.field, 'pingMinPrice')
+      assert(_isString(invalidErr.message))
+
+      const zeroErr = validateParams({ ...params, orderCount: 2, pingMinPrice: 0 })
+      assert.deepStrictEqual(zeroErr.field, 'pingMinPrice')
+      assert(_isString(zeroErr.message))
+    })
+
+    it('returns error when maximum ping price is invalid or zero', () => {
+      const invalidErr = validateParams({ ...params, orderCount: 2, pingMaxPrice: 'not' })
+      assert.deepStrictEqual(invalidErr.field, 'pingMaxPrice')
+      assert(_isString(invalidErr.message))
+
+      const zeroErr = validateParams({ ...params, orderCount: 2, pingMaxPrice: 0 })
+      assert.deepStrictEqual(zeroErr.field, 'pingMaxPrice')
+      assert(_isString(zeroErr.message))
+    })
+
+    it('returns error when pong distance is invalid, zero or negative', () => {
+      const invalidErr = validateParams({ ...params, orderCount: 2, pongDistance: 'not' })
+      assert.deepStrictEqual(invalidErr.field, 'pongDistance')
+      assert(_isString(invalidErr.message))
+
+      const zeroErr = validateParams({ ...params, orderCount: 2, pongDistance: 0 })
+      assert.deepStrictEqual(zeroErr.field, 'pongDistance')
+      assert(_isString(zeroErr.message))
+
+      const negativeErr = validateParams({ ...params, orderCount: 2, pongDistance: -10 })
+      assert.deepStrictEqual(negativeErr.field, 'pongDistance')
+      assert(_isString(negativeErr.message))
+    })
+
+    it('returns error when minimum ping price is greater than the maximum ping price', () => {
+      const err = validateParams({ ...params, orderCount: 2, pingMinPrice: 1000, pingMaxPrice: 800 })
+      assert.deepStrictEqual(err.field, 'pingMaxPrice')
+      assert(_isString(err.message))
+    })
+  })
+
+  describe('validate ping amount against minimum and maximum order size', () => {
+    it('returns error if ping amount is less than the minimum order size', () => {
+      const err = validateParams({ ...params, pingAmount: 0.001 }, pairConfig)
+      assert.deepStrictEqual(err.field, 'amount')
+      assert(_isString(err.message))
+    })
+
+    it('returns error if ping amount is greater than the maximum order size', () => {
+      const err = validateParams({ ...params, splitPingPongAmount: true, pingAmount: 25 }, pairConfig)
+      assert.deepStrictEqual(err.field, 'pingAmount')
+      assert(_isString(err.message))
+    })
+  })
+
+  describe('validate pong amount against minimum and maximum order size', () => {
+    it('returns error if pong amount is less than the minimum order size', () => {
+      const err = validateParams({ ...params, pongAmount: 0.001 }, pairConfig)
+      assert.deepStrictEqual(err.field, 'amount')
+      assert(_isString(err.message))
+    })
+
+    it('returns error if pong amount is greater than the maximum order size', () => {
+      const err = validateParams({ ...params, splitPingPongAmount: true, pongAmount: 25 }, pairConfig)
+      assert.deepStrictEqual(err.field, 'pongAmount')
+      assert(_isString(err.message))
+    })
+  })
+
+  describe('validate leverage for future pairs', () => {
+    it('returns error if leverage is not a number', () => {
+      const err = validateParams({ ...params, _futures: true, lev: '' }, pairConfig)
+      assert.deepStrictEqual(err.field, 'lev')
+      assert(_isString(err.message))
+    })
+
+    it('returns error if leverage is less than 1', () => {
+      const err = validateParams({ ...params, _futures: true, lev: 0 }, pairConfig)
+      assert.deepStrictEqual(err.field, 'lev')
+      assert(_isString(err.message))
+    })
+
+    it('returns error if leverage is greater than the allowed leverage', () => {
+      const err = validateParams({ ...params, _futures: true, lev: 6 }, pairConfig)
+      assert.deepStrictEqual(err.field, 'lev')
+      assert(_isString(err.message))
+    })
+  })
+})


### PR DESCRIPTION
This PR adds the functionality to be able to fetch the error fields as well so that it's easier in the UI side to show the error message on the specific field of the algo order. It can be used by UI to check for errors before submitting the order to algo server. However, the UI if wishes to use this function, it must process params first using processParams function before using the validateParams function.

Task: https://app.asana.com/0/1125859137800433/1200373978248382