### PR TITLE
TWAP orderform validation

### DIFF
--- a/lib/twap/meta/validate_params.js
+++ b/lib/twap/meta/validate_params.js
@@ -5,6 +5,7 @@ const _isFinite = require('lodash/isFinite')
 const _isString = require('lodash/isString')
 const _isUndefined = require('lodash/isUndefined')
 const Config = require('../config')
+const validationErrObj = require('../../util/validate_params_err')
 
 /**
  * Verifies that a parameters Object is valid, and all parameters are within
@@ -22,50 +23,62 @@ const Config = require('../config')
  * @param {number|string} args.priceTarget - numeric, or OB_SIDE, OB_MID, LAST
  * @param {boolean} args.tradeBeyondEnd - if true, slices are not cancelled after their interval expires
  * @param {string} args.orderType - LIMIT or MARKET
+ * @param {object} pairConfig - config for the selected market pair
+ * @param {number} pairConfig.minSize - minimum order size for the selected market pair
+ * @param {number} pairConfig.maxSize - maximum order size for the selected market pair
+ * @param {number} pairConfig.lev - leverage allowed for the selected market pair
  * @returns {string} error - null if parameters are valid, otherwise a
  *   description of which parameter is invalid.
  */
-const validateParams = (args = {}) => {
+const validateParams = (args = {}, pairConfig = {}) => {
+  const { minSize, maxSize, lev: maxLev } = pairConfig
   const {
     orderType, amount, sliceAmount, sliceInterval, amountDistortion, priceTarget, priceCondition,
     priceDelta, lev, _futures
   } = args
 
-  let err = null
-
-  if (!Order.type[orderType]) err = 'invalid order type'
-  if (!_isFinite(amount)) err = 'invalid amount'
-  if (!_isFinite(sliceAmount)) err = 'invalid slice amount'
-  if (!_isFinite(sliceInterval)) err = 'slice interval not a number'
-  if (!_isFinite(amountDistortion)) return 'Amount distortion required'
-  if (Math.abs(sliceAmount) > Math.abs(amount)) return 'Slice amount cannot be greater than total amount'
-  if (sliceInterval <= 0) err = 'slice interval <= 0'
+  if (!Order.type[orderType]) return validationErrObj('orderType', `Invalid order type: ${orderType}`)
+  if (!_isFinite(amount)) return validationErrObj('amount', 'Invalid amount')
+  if (!_isFinite(sliceAmount)) return validationErrObj('sliceAmount', 'Invalid slice amount')
+  if (!_isFinite(sliceInterval) || sliceInterval <= 0) return validationErrObj('sliceInterval', 'Invalid slice interval')
+  if (!_isFinite(amountDistortion)) return validationErrObj('amountDistortion', 'Invalid amount distortion')
+  if (Math.abs(sliceAmount) > Math.abs(amount)) return validationErrObj('sliceAmount', 'Slice amount cannot be greater than total amount')
   if (!_isString(priceTarget) && !_isFinite(priceTarget)) {
-    err = 'invalid price target'
+    return validationErrObj('priceTarget', 'Invalid price target')
   } else if (_isFinite(priceTarget) && priceTarget <= 0) {
-    err = 'negative custom price target'
+    return validationErrObj('priceTarget', 'Negative custom price target')
   } else if (_isFinite(priceTarget) && !Config.PRICE_COND[priceCondition]) {
-    err = 'invalid condition for custom price target'
+    return validationErrObj('priceTarget', 'Invalid condition for custom price target')
   } else if (_isString(priceTarget) && !Config.PRICE_TARGET[priceTarget]) {
-    err = 'invalid matched price target'
+    return validationErrObj('priceTarget', 'Invalid matched price target')
   } else if (!_isUndefined(priceDelta) && !_isFinite(priceDelta)) {
-    err = 'invalid price delta provided'
+    return validationErrObj('priceDelta', 'Invalid price delta provided')
   }
 
   if (
     (amount < 0 && sliceAmount >= 0) ||
     (amount > 0 && sliceAmount <= 0)
   ) {
-    return 'Amount & slice amount must have same sign'
+    return validationErrObj('sliceAmount', 'Amount & slice amount must have same sign')
+  }
+
+  if (_isFinite(minSize)) {
+    if (Math.abs(amount) < minSize) return validationErrObj('amount', `Amount cannot be less than ${minSize}`)
+    if (Math.abs(sliceAmount) < minSize) return validationErrObj('sliceAmount', `Slice amount cannot be less than ${minSize}`)
+  }
+
+  if (_isFinite(maxSize)) {
+    if (Math.abs(amount) > maxSize) return validationErrObj('amount', `Amount cannot be greater than ${maxSize}`)
+    if (Math.abs(sliceAmount) > maxSize) return validationErrObj('sliceAmount', `Slice amount cannot be greater than ${maxSize}`)
   }
 
   if (_futures) {
-    if (!_isFinite(lev)) return 'Invalid leverage'
-    if (lev < 1) return 'Leverage less than 1'
-    if (lev > 100) return 'Leverage greater than 100'
+    if (!_isFinite(lev)) return validationErrObj('lev', 'Invalid leverage')
+    if (lev < 1) return validationErrObj('lev', 'Leverage cannot be less than 1')
+    if (_isFinite(maxLev) && (lev > maxLev)) return validationErrObj('lev', `Leverage cannot be greater than ${maxLev}`)
   }
 
-  return err
+  return null
 }
 
 module.exports = validateParams

--- a/test/lib/twap/meta/validate_params.js
+++ b/test/lib/twap/meta/validate_params.js
@@ -15,97 +15,167 @@ const validParams = {
   priceCondition: 'MATCH_LAST'
 }
 
+const pairConfig = {
+  minSize: 0.02,
+  maxSize: 20,
+  lev: 5
+}
+
 describe('twap:meta:validate_params', () => {
   it('returns no error on valid params', () => {
     assert.strictEqual(validateParams(validParams), null)
   })
 
   it('returns error on invalid order type', () => {
-    assert(_isString(validateParams({
+    const err = validateParams({
       ...validParams,
       orderType: 'nope'
-    })))
+    })
+    assert.deepStrictEqual(err.field, 'orderType')
+    assert(_isString(err.message))
   })
 
   it('returns error on invalid amount', () => {
-    assert(_isString(validateParams({
+    const err = validateParams({
       ...validParams,
       amount: 'nope'
-    })))
-  })
-
-  it('returns error on invalid slice amount', () => {
-    assert(_isString(validateParams({
-      ...validParams,
-      sliceAmount: 'nope'
-    })))
+    })
+    assert.deepStrictEqual(err.field, 'amount')
+    assert(_isString(err.message))
   })
 
   it('returns error on invalid or negative slice interval', () => {
-    assert(_isString(validateParams({
+    const invalidErr = validateParams({
       ...validParams,
-      sliceInterval: 'nope'
-    })))
+      sliceAmount: 'nope'
+    })
+    assert.deepStrictEqual(invalidErr.field, 'sliceAmount')
+    assert(_isString(invalidErr.message))
 
-    assert(_isString(validateParams({
+    const negativeCheckErr = validateParams({
       ...validParams,
-      sliceInterval: -100
-    })))
+      sliceAmount: -100
+    })
+    assert.deepStrictEqual(negativeCheckErr.field, 'sliceAmount')
+    assert(_isString(negativeCheckErr.message))
   })
 
   it('returns error if amount & sliceAmount differ in sign', () => {
-    assert(_isString(validateParams({
+    const err = validateParams({
       ...validParams,
       amount: -1
-    })))
+    })
+    assert.deepStrictEqual(err.field, 'sliceAmount')
+    assert(_isString(err.message))
   })
 
   it('returns error on non-numeric and non-string price target', () => {
-    assert(_isString(validateParams({
+    const err = validateParams({
       ...validParams,
       priceTarget: { nope: 42 }
-    })))
+    })
+    assert.deepStrictEqual(err.field, 'priceTarget')
+    assert(_isString(err.message))
   })
 
   it('returns error on negative explicit price target', () => {
-    assert(_isString(validateParams({
+    const err = validateParams({
       ...validParams,
       priceTarget: -1
-    })))
+    })
+    assert.deepStrictEqual(err.field, 'priceTarget')
+    assert(_isString(err.message))
   })
 
   it('returns error on numeric price target with invalid price condition', () => {
-    assert(_isString(validateParams({
+    const err = validateParams({
       ...validParams,
       priceTarget: 100,
       priceCondition: 'nope'
-    })))
+    })
+    assert.deepStrictEqual(err.field, 'priceTarget')
+    assert(_isString(err.message))
   })
 
   it('returns error on conditional price target with invalid condition', () => {
-    assert(_isString(validateParams({
+    const err = validateParams({
       ...validParams,
       priceTarget: 'nope'
-    })))
+    })
+    assert.deepStrictEqual(err.field, 'priceTarget')
+    assert(_isString(err.message))
   })
 
   it('returns error on non-numeric price delta if provided', () => {
-    assert(_isString(validateParams({
+    const err = validateParams({
       ...validParams,
       priceDelta: 'nope'
-    })))
+    })
+    assert.deepStrictEqual(err.field, 'priceDelta')
+    assert(_isString(err.message))
   })
 
   it('returns error when slice amount is greater than total amount', () => {
-    assert(_isString(validateParams({
+    const buyOrderErr = validateParams({
       ...validParams,
       sliceAmount: 2
-    })), 'doesn\'t return error when submitted buy order')
+    })
+    assert.deepStrictEqual(buyOrderErr.field, 'sliceAmount')
+    assert(_isString(buyOrderErr.message), 'doesn\'t return error when submitted buy order')
 
-    assert(_isString(validateParams({
+    const sellOrderErr = validateParams({
       ...validParams,
       amount: -1,
       sliceAmount: -2
-    })), 'doesn\'t return error when submitted sell order')
+    })
+    assert.deepStrictEqual(sellOrderErr.field, 'sliceAmount')
+    assert(_isString(sellOrderErr.message), 'doesn\'t return error when submitted buy order')
+  })
+
+  it('returns error if amount is less than the minimum order size', () => {
+    const err = validateParams({
+      ...validParams,
+      amount: 0.01,
+      sliceAmount: 0.0005
+    }, pairConfig)
+    assert.deepStrictEqual(err.field, 'amount')
+    assert(_isString(err.message))
+  })
+
+  it('returns error if slice amount is less than the minimum order size', () => {
+    const err = validateParams({
+      ...validParams,
+      sliceAmount: 0.001
+    }, pairConfig)
+    assert.deepStrictEqual(err.field, 'sliceAmount')
+    assert(_isString(err.message))
+  })
+
+  it('returns error if amount is greater than the maximum order size', () => {
+    const err = validateParams({
+      ...validParams,
+      amount: 25
+    }, pairConfig)
+    assert.deepStrictEqual(err.field, 'amount')
+    assert(_isString(err.message))
+  })
+
+  it('returns error if slice amount is greater than the maximum order size', () => {
+    const err = validateParams({
+      ...validParams,
+      sliceAmount: 25
+    }, pairConfig)
+    assert.deepStrictEqual(err.field, 'sliceAmount')
+    assert(_isString(err.message))
+  })
+
+  it('returns error if leverage is greater than the allowed leverage', () => {
+    const err = validateParams({
+      ...validParams,
+      _futures: true,
+      lev: 6
+    }, pairConfig)
+    assert.deepStrictEqual(err.field, 'lev')
+    assert(_isString(err.message))
   })
 })


### PR DESCRIPTION
This PR adds the functionality to be able to fetch the error fields as well so that it's easier in the UI side to show the error message on the specific field of the algo order. It can be used by UI to check for errors before submitting the order to algo server. However, the UI if wishes to use this function, it must process params first using processParams function before using the validateParams function.

Task: https://app.asana.com/0/1125859137800433/1200373978248384