### PR TITLE
OCOCO order form validation

### DIFF
--- a/lib/ococo/meta/validate_params.js
+++ b/lib/ococo/meta/validate_params.js
@@ -2,6 +2,7 @@
 
 const _isFinite = require('lodash/isFinite')
 const _includes = require('lodash/includes')
+const validationErrObj = require('../../util/validate_params_err')
 
 const ORDER_TYPES = ['MARKET', 'LIMIT']
 
@@ -22,32 +23,47 @@ const ORDER_TYPES = ['MARKET', 'LIMIT']
  * @param {number} args.stopPrice - oco order stop price
  * @param {number} args.ocoAmount - oco order amount
  * @param {string} args.ocoAction - oco order direction, Buy or Sell
+ * @param {object} pairConfig - config for the selected market pair
+ * @param {number} pairConfig.minSize - minimum order size for the selected market pair
+ * @param {number} pairConfig.maxSize - maximum order size for the selected market pair
+ * @param {number} pairConfig.lev - leverage allowed for the selected market pair
  * @returns {string} error - null if parameters are valid, otherwise a
  *   description of which parameter is invalid.
  */
-const validateParams = (args = {}) => {
+const validateParams = (args = {}, pairConfig = {}) => {
+  const { minSize, maxSize, lev: maxLev } = pairConfig
   const {
     orderPrice, amount, orderType, limitPrice,
     stopPrice, ocoAmount, lev, _futures, action, ocoAction
   } = args
 
-  if (!_includes(ORDER_TYPES, orderType)) return `Invalid order type: ${orderType}`
-  if (!_isFinite(amount)) return 'Invalid amount'
+  if (!_includes(ORDER_TYPES, orderType)) return validationErrObj('orderType', `Invalid order type: ${orderType}`)
+  if (!_isFinite(amount) || amount === 0) return validationErrObj('amount', 'Invalid amount')
   if (orderType === 'LIMIT' && !_isFinite(orderPrice)) {
-    return 'Limit price required for LIMIT order type'
+    return validationErrObj('orderPrice', 'Limit price required for LIMIT order type')
   }
 
-  if (!_isFinite(limitPrice)) return 'Invalid OCO limit price'
-  if (!_isFinite(stopPrice)) return 'Invalid OCO stop price'
-  if (!_isFinite(ocoAmount)) return 'Invalid OCO amount'
+  if (!_isFinite(limitPrice)) return validationErrObj('limitPrice', 'Invalid OCO limit price')
+  if (!_isFinite(stopPrice)) return validationErrObj('stopPrice', 'Invalid OCO stop price')
+  if (!_isFinite(ocoAmount) || ocoAmount === 0) return validationErrObj('ocoAmount', 'Invalid OCO amount')
 
-  if (action !== 'Buy' && action !== 'Sell') return `Invalid action: ${action}`
-  if (ocoAction !== 'Buy' && ocoAction !== 'Sell') return `Invalid OCO action: ${ocoAction}`
+  if (action !== 'Buy' && action !== 'Sell') return validationErrObj('action', `Invalid action: ${action}`)
+  if (ocoAction !== 'Buy' && ocoAction !== 'Sell') return validationErrObj('ocoAction', `Invalid OCO action: ${ocoAction}`)
+
+  if (_isFinite(minSize)) {
+    if (Math.abs(amount) < minSize) return validationErrObj('amount', `Amount cannot be less than ${minSize}`)
+    if (Math.abs(ocoAmount) < minSize) return validationErrObj('ocoAmount', `Slice amount cannot be less than ${minSize}`)
+  }
+
+  if (_isFinite(maxSize)) {
+    if (Math.abs(amount) > maxSize) return validationErrObj('amount', `Amount cannot be greater than ${maxSize}`)
+    if (Math.abs(ocoAmount) > maxSize) return validationErrObj('ocoAmount', `Slice amount cannot be greater than ${maxSize}`)
+  }
 
   if (_futures) {
-    if (!_isFinite(lev)) return 'Invalid leverage'
-    if (lev < 1) return 'Leverage less than 1'
-    if (lev > 100) return 'Leverage greater than 100'
+    if (!_isFinite(lev)) return validationErrObj('lev', 'Invalid leverage')
+    if (lev < 1) return validationErrObj('lev', 'Leverage cannot be less than 1')
+    if (_isFinite(maxLev) && (lev > maxLev)) return validationErrObj('lev', `Leverage cannot be greater than ${maxLev}`)
   }
 
   return null

--- a/test/lib/ococo/meta/validate_params.js
+++ b/test/lib/ococo/meta/validate_params.js
@@ -2,7 +2,7 @@
 'use strict'
 
 const assert = require('assert')
-const _isEmpty = require('lodash/isEmpty')
+const _isString = require('lodash/isString')
 const validateParams = require('../../../../lib/ococo/meta/validate_params')
 
 const params = {
@@ -15,23 +15,124 @@ const params = {
   ocoAmount: 6,
 
   action: 'Buy',
+  ocoAction: 'Sell',
 
   _futures: false,
   lev: 3.3
 }
 
-describe('ococo:meta:unserialize', () => {
-  it('validates params correctly', () => {
-    assert.ok(!_isEmpty(validateParams({ ...params, orderType: '' })))
-    assert.ok(!_isEmpty(validateParams({ ...params, orderType: 'LIMIT', ordePrice: null })))
-    assert.ok(!_isEmpty(validateParams({ ...params, amount: '' })))
-    assert.ok(!_isEmpty(validateParams({ ...params, limitPrice: '' })))
-    assert.ok(!_isEmpty(validateParams({ ...params, stopPrice: '' })))
-    assert.ok(!_isEmpty(validateParams({ ...params, ocoAmount: '' })))
-    assert.ok(!_isEmpty(validateParams({ ...params, action: 'none' })))
-    assert.ok(!_isEmpty(validateParams({ ...params, ocoAction: 'none' })))
-    assert.ok(!_isEmpty(validateParams({ ...params, _futures: true, lev: null })))
-    assert.ok(!_isEmpty(validateParams({ ...params, _futures: true, lev: 0 })))
-    assert.ok(!_isEmpty(validateParams({ ...params, _futures: true, lev: 101 })))
+const pairConfig = {
+  minSize: 0.01,
+  maxSize: 20,
+  lev: 5
+}
+
+describe('ococo:meta:validate_params', () => {
+  describe('validate general order parameters', () => {
+    it('returns error on invalid order type', () => {
+      const err = validateParams({ ...params, orderType: '' })
+      assert.deepStrictEqual(err.field, 'orderType')
+      assert(_isString(err.message))
+    })
+
+    it('returns error when amount is invalid or zero', () => {
+      const invalidErr = validateParams({ ...params, amount: '' })
+      assert.deepStrictEqual(invalidErr.field, 'amount')
+      assert(_isString(invalidErr.message))
+
+      const zeroErr = validateParams({ ...params, amount: 0 })
+      assert.deepStrictEqual(zeroErr.field, 'amount')
+      assert(_isString(zeroErr.message))
+    })
+
+    it('returns error when order price is invalid for limit orderType', () => {
+      const err = validateParams({ ...params, orderType: 'LIMIT', orderPrice: null })
+      assert.deepStrictEqual(err.field, 'orderPrice')
+      assert(_isString(err.message))
+    })
+
+    it('returns error for invalid action', () => {
+      const err = validateParams({ ...params, action: 'none' })
+      assert.deepStrictEqual(err.field, 'action')
+      assert(_isString(err.message))
+    })
+  })
+
+  describe('validate oco settings', () => {
+    it('returns error on invalid limit price', () => {
+      const err = validateParams({ ...params, limitPrice: '' })
+      assert.deepStrictEqual(err.field, 'limitPrice')
+      assert(_isString(err.message))
+    })
+
+    it('returns error on invalid stop price', () => {
+      const err = validateParams({ ...params, stopPrice: '' })
+      assert.deepStrictEqual(err.field, 'stopPrice')
+      assert(_isString(err.message))
+    })
+
+    it('returns error when oco amount is invalid or zero', () => {
+      const invalidErr = validateParams({ ...params, ocoAmount: '' })
+      assert.deepStrictEqual(invalidErr.field, 'ocoAmount')
+      assert(_isString(invalidErr.message))
+
+      const zeroErr = validateParams({ ...params, ocoAmount: 0 })
+      assert.deepStrictEqual(zeroErr.field, 'ocoAmount')
+      assert(_isString(zeroErr.message))
+    })
+
+    it('returns error for invalid oco action', () => {
+      const err = validateParams({ ...params, ocoAction: 'none' })
+      assert.deepStrictEqual(err.field, 'ocoAction')
+      assert(_isString(err.message))
+    })
+  })
+
+  describe('validate amount against minimum and maximum order size', () => {
+    it('returns error if amount is less than the minimum order size', () => {
+      const err = validateParams({ ...params, amount: 0.001, sliceAmount: 0.001 }, pairConfig)
+      assert.deepStrictEqual(err.field, 'amount')
+      assert(_isString(err.message))
+    })
+
+    it('returns error if amount is greater than the maximum order size', () => {
+      const err = validateParams({ ...params, amount: 25 }, pairConfig)
+      assert.deepStrictEqual(err.field, 'amount')
+      assert(_isString(err.message))
+    })
+  })
+
+  describe('validate oco amount against minimum and maximum order size', () => {
+    it('returns error if oco amount is less than the minimum order size', () => {
+      const err = validateParams({ ...params, ocoAmount: 0.001 }, pairConfig)
+      assert.deepStrictEqual(err.field, 'ocoAmount')
+      assert(_isString(err.message))
+    })
+
+    it('returns error if oco amount is greater than the maximum order size', () => {
+      const err = validateParams({ ...params, ocoAmount: 25 }, pairConfig)
+      assert.deepStrictEqual(err.field, 'ocoAmount')
+      assert(_isString(err.message))
+    })
+  })
+
+  describe('validate leverage for future pairs', () => {
+    it('returns error if leverage is not a number', () => {
+      const err = validateParams({ ...params, _futures: true, lev: null }, pairConfig)
+      assert.deepStrictEqual(err.field, 'lev')
+      assert(_isString(err.message))
+    })
+
+    it('returns error if leverage is less than 1', () => {
+      const err = validateParams({ ...params, _futures: true, lev: 0 }, pairConfig)
+      assert.deepStrictEqual(err.field, 'lev')
+      assert(_isString(err.message))
+    })
+
+    it('returns error if leverage is greater than the allowed leverage', () => {
+      const err = validateParams({ ...params, _futures: true, lev: 6 }, pairConfig)
+      assert.deepStrictEqual(err.field, 'lev')
+      assert(_isString(err.message))
+    })
   })
 })


### PR DESCRIPTION
This PR adds the functionality to be able to fetch the error fields as well so that it's easier in the UI side to show the error message on the specific field of the algo order. It can be used by UI to check for errors before submitting the order to algo server. However, the UI if wishes to use this function, it must process params first using processParams function before using the validateParams function.

Task: https://app.asana.com/0/1125859137800433/1200373978248387