### PR TITLE
emit algo order stop event required for ui updates

### DIFF
--- a/lib/ao_host.js
+++ b/lib/ao_host.js
@@ -625,6 +625,8 @@ class AOHost extends AsyncEventEmitter {
     await this.triggerAOEvent(instance, 'life', 'stop', opts)
     await this.emit('ao:persist', gid)
 
+    this.emit('ao:stopped', gid)
+
     const serialized = this.getSerializedAO(instance)
 
     if (algoLogStream) {


### PR DESCRIPTION
Emits `ao:stopped` event whenever algo order is stopped so that UI can be updated accordingly.