### PR TITLE
channel key parser - support funding candles

### DIFF
--- a/lib/util/parse_channel_key.js
+++ b/lib/util/parse_channel_key.js
@@ -3,10 +3,21 @@
 const separator = ':'
 
 module.exports = (chanKey) => {
-  const [key, tf, ...symbol] = chanKey.split(separator)
-  return {
-    key,
-    tf,
-    symbol: symbol.join(separator)
+  const parts = chanKey.split(separator)
+  let type, tf, symbol, aggr, start, end, s1, s2
+
+  switch (parts.length) {
+    case 3:
+      [type, tf, symbol] = parts
+      return { type, tf, symbol }
+    case 4:
+      [type, tf, ...symbol] = parts
+      return { type, tf, symbol: symbol.join(separator) }
+    case 6:
+      [type, tf, symbol, aggr, start, end] = parts
+      return { type, tf, symbol, aggr, start, end }
+    case 7:
+      [type, tf, s1, s2, aggr, start, end] = parts
+      return { type, tf, symbol: s1 + separator + s2, aggr, start, end }
   }
 }

--- a/test/lib/util/parse_channel_key.js
+++ b/test/lib/util/parse_channel_key.js
@@ -5,21 +5,49 @@ const { expect } = require('chai')
 const parseChannelKey = require('../../../lib/util/parse_channel_key')
 
 describe('parseChannelKey', () => {
-  it('should parse channel key', () => {
-    const details = parseChannelKey('key:1m:LEOUSD')
-    expect(details).to.eql({
-      key: 'key',
-      tf: '1m',
-      symbol: 'LEOUSD'
+  describe('trading candles key', () => {
+    it('should parse channel key', () => {
+      const details = parseChannelKey('trade:1m:LEOUSD')
+      expect(details).to.eql({
+        type: 'trade',
+        tf: '1m',
+        symbol: 'LEOUSD'
+      })
+    })
+
+    it('should be able to parse symbols with colons', () => {
+      const details = parseChannelKey('trade:1m:tTESTBTC:TESTUSD')
+      expect(details).to.eql({
+        type: 'trade',
+        tf: '1m',
+        symbol: 'tTESTBTC:TESTUSD'
+      })
     })
   })
 
-  it('should be able to parse symbols with colons', () => {
-    const details = parseChannelKey('key:1m:tTESTBTC:TESTUSD')
-    expect(details).to.eql({
-      key: 'key',
-      tf: '1m',
-      symbol: 'tTESTBTC:TESTUSD'
+  describe('funding candles key', () => {
+    it('should parse channel key', () => {
+      const details = parseChannelKey('trade:1m:LEOUSD:a30:p2:p30')
+      expect(details).to.eql({
+        type: 'trade',
+        tf: '1m',
+        symbol: 'LEOUSD',
+        aggr: 'a30',
+        end: 'p30',
+        start: 'p2'
+      })
+    })
+
+    it('should be able to parse symbols with colons', () => {
+      const details = parseChannelKey('trade:1m:tTESTBTC:TESTUSD:a30:p2:p30')
+      expect(details).to.eql({
+        type: 'trade',
+        tf: '1m',
+        symbol: 'tTESTBTC:TESTUSD',
+        aggr: 'a30',
+        end: 'p30',
+        start: 'p2'
+      })
     })
   })
 })


### PR DESCRIPTION
After looking at the docs I've found out that the candles channel key format may vary for funding candles (https://docs.bitfinex.com/reference#ws-public-candles)

This can cause a failure when fetching the symbol or getting the other values for funding candles.