### PR TITLE
Acc dist issue for catch up fixes

### DIFF
--- a/lib/accumulate_distribute/events/life_start.js
+++ b/lib/accumulate_distribute/events/life_start.js
@@ -55,7 +55,7 @@ const onLifeStart = async (instance = {}) => {
   subscribeDataChannels(state)
     .catch(e => debug('failed to subscribe to data channels: %s', e.message))
 
-  await scheduleTick.tick(instance)
+  scheduleTick.tick(instance)
 }
 
 module.exports = onLifeStart

--- a/lib/accumulate_distribute/events/life_stop.js
+++ b/lib/accumulate_distribute/events/life_stop.js
@@ -11,7 +11,7 @@
  */
 const onLifeStop = async (instance = {}) => {
   const { state = {}, h = {} } = instance
-  const { timeout, orders = {}, gid } = state
+  const { timeout, gid } = state
   const { debug, emit } = h
 
   if (timeout) {
@@ -21,7 +21,7 @@ const onLifeStop = async (instance = {}) => {
 
   debug('detected acccumulate/distribute algo cancelation, stopping...')
 
-  await emit('exec:order:cancel:all', gid, orders)
+  await emit('exec:order:cancel:gid', gid)
 }
 
 module.exports = onLifeStop

--- a/lib/accumulate_distribute/events/orders_order_fill.js
+++ b/lib/accumulate_distribute/events/orders_order_fill.js
@@ -56,7 +56,7 @@ const onOrdersOrderFill = async (instance = {}, order) => {
     debug('catching up (behind with %d orders)', newOrdersBehind)
 
     clearTimeout(timeout)
-    await scheduleTick.tick(instance, true) // re-schedule early submit
+    scheduleTick.tick(instance) // re-schedule early submit
   } else if (ordersBehind > 0 && newOrdersBehind === 0) {
     debug('caught up!')
   }

--- a/lib/accumulate_distribute/events/self_interval_tick.js
+++ b/lib/accumulate_distribute/events/self_interval_tick.js
@@ -29,8 +29,6 @@ const onSelfIntervalTick = async (instance = {}) => {
   const { emit, emitSelf, debug, updateState } = h
   const { awaitFill } = args
 
-  await scheduleTick.tick(instance)
-
   if (hasOpenOrders(orders)) { // prev order still open
     const nextOrdersBehind = Math.min(orderAmounts.length - currentOrder, ordersBehind + 1)
     await updateState(instance, { // for catching up
@@ -43,6 +41,8 @@ const onSelfIntervalTick = async (instance = {}) => {
       await emit('exec:order:cancel:all', gid, orders)
     } else {
       debug('awaiting fill...')
+      scheduleTick.tick(instance)
+
       return // await order fill, then rely on ordersBehind
     }
   }
@@ -54,6 +54,7 @@ const onSelfIntervalTick = async (instance = {}) => {
    * @event module:AccumulateDistribute~selfSubmitOrder
    */
   await emitSelf('submit_order') // submit next slice order
+  scheduleTick.tick(instance)
 }
 
 module.exports = onSelfIntervalTick

--- a/lib/accumulate_distribute/meta/get_ui_def.js
+++ b/lib/accumulate_distribute/meta/get_ui_def.js
@@ -22,7 +22,7 @@ const getUIDef = () => ({
     'algorithm to ignore the slice interval for the next order if previous',
     'orders have taken longer than expected to fill, thereby ensuring the',
     'time-to-fill for the entire order is not adversely affected.\n\nNote:',
-    'When \'catching up\', the slice interval is hard-coded to 2 seconds'
+    'When \'catching up\', the slice interval is hard-coded to 0.2 seconds'
   ].join(' '),
 
   connectionTimeout: 10000,

--- a/lib/accumulate_distribute/util/schedule_tick.js
+++ b/lib/accumulate_distribute/util/schedule_tick.js
@@ -19,7 +19,7 @@ const _isFinite = require('lodash/isFinite')
  */
 const scheduleTick = async (instance) => {
   const { state = {}, h = {} } = instance
-  const { emitSelf, updateState, notifyUI } = h
+  const { emitSelf, updateState, timeout, notifyUI } = h
   const { args = {} } = state
   const { sliceInterval, intervalDistortion, catchUp } = args
   let timeoutDelay = catchUp ? 200 : sliceInterval
@@ -30,23 +30,13 @@ const scheduleTick = async (instance) => {
     timeoutDelay *= 1 + (Math.random() * intervalDistortion * m)
   }
 
-  const timeout = setTimeout(async () => { // schedule first tick
-    /**
-     * Triggers verification of the price target, and a potential atomic order
-     * submit.
-     *
-     * @event module:AccumulateDistribute~selfIntervalTick
-     */
-    await emitSelf('interval_tick', timeoutDelay)
-  }, timeoutDelay)
-
   await notifyUI('info', `scheduled tick in ~${(timeoutDelay / 1000).toFixed(4)}s`)
 
-  return updateState(instance, {
-    timeout,
-    timeoutDelay,
-    timeoutScheduledAt: Date.now()
-  })
+  const [id, t] = timeout(timeoutDelay)
+  await updateState(instance, { timeout: id, timeoutDelay, timeoutScheduledAt: Date.now() })
+  await t()
+
+  await emitSelf('interval_tick')
 }
 
 module.exports = {

--- a/test/lib/accumulate_distribute/events/data_managed_candles.js
+++ b/test/lib/accumulate_distribute/events/data_managed_candles.js
@@ -89,7 +89,6 @@ describe('accumulate_distribute:events:data_managed_candles', () => {
   })
 
   it('updates cap indicator if needed', async () => {
-    console.log(CANDLE.constructor.unserialize + '')
     const candles = [Candle.unserialize({
       ...CANDLE.toJS(),
       high: 42

--- a/test/lib/accumulate_distribute/events/life_start.js
+++ b/test/lib/accumulate_distribute/events/life_start.js
@@ -4,17 +4,7 @@
 const assert = require('assert')
 const { EMA } = require('bfx-hf-indicators')
 const lifeStart = require('../../../../lib/accumulate_distribute/events/life_start')
-
-const timeout = (ms) => {
-  let id = null
-
-  const p = new Promise((resolve) => {
-    id = { ms }
-    resolve()
-  })
-
-  return [id, () => p]
-}
+const timeout = require('../../../util/timeout')
 
 const getInstance = ({
   params = {}, argParams = {}, stateParams = {}, helperParams = {}

--- a/test/lib/accumulate_distribute/events/life_start.js
+++ b/test/lib/accumulate_distribute/events/life_start.js
@@ -5,6 +5,17 @@ const assert = require('assert')
 const { EMA } = require('bfx-hf-indicators')
 const lifeStart = require('../../../../lib/accumulate_distribute/events/life_start')
 
+const timeout = (ms) => {
+  let id = null
+
+  const p = new Promise((resolve) => {
+    id = { ms }
+    resolve()
+  })
+
+  return [id, () => p]
+}
+
 const getInstance = ({
   params = {}, argParams = {}, stateParams = {}, helperParams = {}
 }) => ({
@@ -18,8 +29,10 @@ const getInstance = ({
   },
 
   h: {
+    timeout,
     debug: () => {},
     emit: async () => {},
+    emitSelf: async () => {},
     updateState: async () => {},
     scheduleTick: async () => {},
     notifyUI: async () => {},

--- a/test/lib/accumulate_distribute/events/life_stop.js
+++ b/test/lib/accumulate_distribute/events/life_stop.js
@@ -44,7 +44,7 @@ describe('accumulate_distribute:events:life_stop', () => {
         updateState: () => {},
         debug: () => {},
         emit: (eventName) => {
-          if (eventName === 'exec:order:cancel:all') {
+          if (eventName === 'exec:order:cancel:gid') {
             cancelledOrders = true
           }
         }

--- a/test/lib/accumulate_distribute/events/orders_order_fill.js
+++ b/test/lib/accumulate_distribute/events/orders_order_fill.js
@@ -5,18 +5,8 @@ const assert = require('assert')
 const Promise = require('bluebird')
 const _isObject = require('lodash/isObject')
 const { Order } = require('bfx-api-node-models')
+const timeout = require('../../../util/timeout')
 const ordersOrderFill = require('../../../../lib/accumulate_distribute/events/orders_order_fill')
-
-const timeout = (ms) => {
-  let id = null
-
-  const p = new Promise((resolve) => {
-    id = { ms }
-    resolve()
-  })
-
-  return [id, () => p]
-}
 
 const getInstance = ({
   params = {}, argParams = {}, stateParams = {}, helperParams = {}

--- a/test/lib/accumulate_distribute/events/orders_order_fill.js
+++ b/test/lib/accumulate_distribute/events/orders_order_fill.js
@@ -7,6 +7,17 @@ const _isObject = require('lodash/isObject')
 const { Order } = require('bfx-api-node-models')
 const ordersOrderFill = require('../../../../lib/accumulate_distribute/events/orders_order_fill')
 
+const timeout = (ms) => {
+  let id = null
+
+  const p = new Promise((resolve) => {
+    id = { ms }
+    resolve()
+  })
+
+  return [id, () => p]
+}
+
 const getInstance = ({
   params = {}, argParams = {}, stateParams = {}, helperParams = {}
 }) => ({
@@ -22,7 +33,9 @@ const getInstance = ({
   },
 
   h: {
+    timeout,
     emit: async () => {},
+    emitSelf: async () => {},
     updateState: async () => {},
     notifyUI: async () => {},
     debug: () => {},

--- a/test/util/timeout.js
+++ b/test/util/timeout.js
@@ -1,0 +1,11 @@
+'use strict'
+
+module.exports = (ms) => {
+  let id = null
+
+  const p = new Promise((resolve) => {
+    id = setTimeout(resolve, ms)
+  })
+
+  return [id, () => p]
+}


### PR DESCRIPTION
This PR fixes the following issues:

- Acc/Dist algo custom help description typo for catch-up slice interval info
- Acc/Dist algo submitting orders greater than the user input total amount
- Acc/Dist algo showing two order at once
- Acc/Dist algo leaving out order not cancelled sometimes when algo is cancelled

Task: https://app.asana.com/0/1125859137800433/1200420964765198 