### PR TITLE
send 'sliceIntervalSec' as error field instead of 'sliceInterval'

### DIFF
--- a/lib/accumulate_distribute/meta/validate_params.js
+++ b/lib/accumulate_distribute/meta/validate_params.js
@@ -58,7 +58,7 @@ const validateParams = (args = {}, pairConfig = {}) => {
   if (!_isFinite(sliceAmount) || sliceAmount === 0) return validationErrObj('sliceAmount', 'Invalid slice amount')
   if (!_isBoolean(catchUp)) return validationErrObj('catchUp', 'Bool catch up flag required')
   if (!_isBoolean(awaitFill)) return validationErrObj('awaitFill', 'Bool await fill flag required')
-  if (!_isFinite(sliceInterval) || sliceInterval <= 0) return validationErrObj('sliceInterval', 'Invalid slice interval')
+  if (!_isFinite(sliceInterval) || sliceInterval <= 0) return validationErrObj('sliceIntervalSec', 'Invalid slice interval')
   if (!_isFinite(intervalDistortion)) return validationErrObj('intervalDistortion', 'Invalid interval distortion')
   if (!_isFinite(amountDistortion)) return validationErrObj('amountDistortion', 'Invalid amount distortion')
 

--- a/test/lib/accumulate_distribute/meta/validate_params.js
+++ b/test/lib/accumulate_distribute/meta/validate_params.js
@@ -59,11 +59,11 @@ describe('accumulate_distribute:meta:validate_params', () => {
 
     it('returns error when slice amount is invalid or zero', () => {
       const invalidErr = validateParams({ ...params, sliceInterval: 'it' })
-      assert.deepStrictEqual(invalidErr.field, 'sliceInterval')
+      assert.deepStrictEqual(invalidErr.field, 'sliceIntervalSec')
       assert(_isString(invalidErr.message))
 
       const lessThanZeroErr = validateParams({ ...params, sliceInterval: -1 })
-      assert.deepStrictEqual(lessThanZeroErr.field, 'sliceInterval')
+      assert.deepStrictEqual(lessThanZeroErr.field, 'sliceIntervalSec')
       assert(_isString(lessThanZeroErr.message))
     })
 


### PR DESCRIPTION
Send `sliceIntervalSec` as error field instead of `sliceInterval` in acc/dist algo orderform validation since, UI uses `sliceIntervalSec` as order field.