### PR TITLE
Handle min max amount twap

### DIFF
--- a/lib/twap/meta/init_state.js
+++ b/lib/twap/meta/init_state.js
@@ -9,13 +9,14 @@
  * @param {object} args - instance execution parameters
  * @returns {object} initialState
  */
-const initState = (args = {}) => {
+const initState = (args = {}, pairConfig = {}) => {
   const { amount } = args
 
   return {
     timeout: null,
     remainingAmount: amount,
     args,
+    pairConfig,
     shutdown: false
   }
 }

--- a/lib/twap/util/generate_order.js
+++ b/lib/twap/util/generate_order.js
@@ -7,7 +7,9 @@ const { Order } = require('bfx-api-node-models')
 const genCID = require('../../util/gen_client_id')
 const { Config } = require('bfx-api-node-core')
 const { DUST } = Config
-const { nBN } = require('@bitfinex/lib-js-util-math')
+
+const getMinMaxDistortedAmount = require('../../util/get_min_max_distorted_amount')
+const getRandomNumberInRange = require('../../util/get_random_number_in_range')
 
 /**
  * Generates the next slice order for the provided instance, taking into
@@ -21,16 +23,15 @@ const { nBN } = require('@bitfinex/lib-js-util-math')
  * @returns {object} order - null if no amount remains
  */
 const generateOrder = (state = {}, price) => {
-  const { args = {}, remainingAmount } = state
+  const { args = {}, remainingAmount, pairConfig } = state
   const {
     sliceAmount, orderType, symbol, amount, lev, _margin, _futures, amountDistortion
   } = args
   let orderAmount = 0
 
   if (_isFinite(amountDistortion) && amountDistortion > 0) {
-    const plusOrMinus = Math.random() > 0.5 ? 1 : -1
-    const randomPercentage = nBN(Math.random()).multipliedBy(amountDistortion).multipliedBy(plusOrMinus).toNumber() + 1 // random percentage from 1 to amountDistortion
-    orderAmount = nBN(sliceAmount).multipliedBy(randomPercentage).toNumber()
+    const { minDistortedAmount, maxDistortedAmount } = getMinMaxDistortedAmount(args, pairConfig)
+    orderAmount = getRandomNumberInRange(minDistortedAmount, maxDistortedAmount)
   } else {
     orderAmount = sliceAmount
   }


### PR DESCRIPTION
Fixes the bug that results in halting the twap order because of the error `Invalid order: Minimum size`

Task: https://app.asana.com/0/1125859137800433/1200528734066763

Changes pulled from: https://github.com/bitfinexcom/bfx-hf-algo/pull/174