### PR TITLE
Add pair config to aohost

### DIFF
--- a/lib/ao_host.js
+++ b/lib/ao_host.js
@@ -7,6 +7,7 @@ const _get = require('lodash/get')
 const debug = require('debug')('bfx:hf:algo:ao-host')
 
 const WsAdapter = require('./ws_adapter')
+const { RESTv2 } = require('bfx-api-node-rest')
 const AsyncEventEmitter = require('./async_event_emitter')
 const onUnknownError = require('./host/events/unknown_error')
 const onMinimumSizeError = require('./host/events/minimum_size_error')
@@ -70,11 +71,18 @@ const genHelpers = require('./host/gen_helpers')
 class AOHost extends AsyncEventEmitter {
   /**
    * @param {object} [args] - arguments
-   * @param {object} [args.db] - optional
-   * @param {string} [args.wsURL] - wss://api.bitfinex.com/ws/2
-   * @param {object} [args.agent] - optional proxy agent
    * @param {object[]} [args.aos] - algo orders to manage
-   * @param {number} [args.dms] - dead man switch, active 4 (default)
+   * @param {object} [args.logAlgoOpts] - logging options for algo orders
+   * @param {boolean} [args.logAlgoOpts.logAlgo] - option to enable/disable logging
+   * @param {string} [args.logAlgoOpts.logAlgoDir] - directory for logs to be saved
+   * @param {object} [args.wsSettings] - web socket settings
+   * @param {string} [args.wsSettings.apiKey] - api key
+   * @param {string} [args.wsSettings.apiSecret] - api secret
+   * @param {string} [args.wsSettings.restURL] - https://api.bitfinex.com
+   * @param {string} [args.wsSettings.wsURL] - wss://api.bitfinex.com/ws/2
+   * @param {number} [args.wsSettings.dms] - dead man switch, active 4 (default)
+   * @param {string} [args.wsSettings.affiliateCode] - user's affiliate code
+   * @param {boolean} [args.wsSettings.withHeartbeat] - option to enable/disable heartbeat
    */
   constructor (args = {}) {
     super()
@@ -84,6 +92,9 @@ class AOHost extends AsyncEventEmitter {
     this.aos = aos
     this.logAlgoOpts = logAlgoOpts
     this.adapter = new WsAdapter(wsSettings)
+
+    const { restURL } = wsSettings
+    this.rest = new RESTv2({ url: restURL })
 
     this.instances = {}
 
@@ -191,6 +202,27 @@ class AOHost extends AsyncEventEmitter {
   onMetaReload () {
     this.cleanState()
     this.emit('meta:reload')
+  }
+
+  async getPairConfig (symbol) {
+    const pairConfig = await this.rest.conf([
+      'pub:info:pair',
+      'pub:info:pair:futures'
+    ])
+
+    const [pairInfo = [], futurePairInfo = []] = pairConfig || []
+    const mergedPairConfig = pairInfo.concat(futurePairInfo)
+
+    const matchedPairConfig = mergedPairConfig.find(conf => `t${conf[0]}` === symbol)
+
+    if (!matchedPairConfig) return {}
+
+    const [, [,,, minSize, maxSize]] = matchedPairConfig
+
+    return {
+      minSize: +minSize,
+      maxSize: +maxSize
+    }
   }
 
   /**
@@ -393,8 +425,12 @@ class AOHost extends AsyncEventEmitter {
       ? unserialize(loadedState)
       : { ...loadedState }
 
+    const { args: { symbol } } = state
+    const pairConfig = await this.getPairConfig(symbol)
+
     state.id = id
     state.gid = gid
+    state.pairConfig = pairConfig
     state.headersForLogFile = headersForLogFile
     state.channels = []
     state.orders = {}
@@ -437,7 +473,10 @@ class AOHost extends AsyncEventEmitter {
       throw new Error(`unknown algo order: ${id}`)
     }
 
-    const inst = initAO(this.adapter, ao, args)
+    const { _symbol } = args
+    const pairConfig = await this.getPairConfig(_symbol)
+
+    const inst = initAO(this.adapter, ao, args, pairConfig)
 
     return this.bootstrapAO(ao, inst)
   }

--- a/lib/host/init_ao.js
+++ b/lib/host/init_ao.js
@@ -12,8 +12,8 @@ const genHelpers = require('./gen_helpers')
  * @param {object} args - instance arguments
  * @returns {object} instance
  */
-module.exports = (adapter, aoDef = {}, args = {}) => {
-  const state = initAOState(aoDef, args)
+module.exports = (adapter, aoDef = {}, args = {}, pairConfig = {}) => {
+  const state = initAOState(aoDef, args, pairConfig)
   const h = genHelpers(state, adapter)
 
   return { state, h }

--- a/lib/host/init_ao_state.js
+++ b/lib/host/init_ao_state.js
@@ -13,7 +13,7 @@ const AsyncEventEmitter = require('../async_event_emitter')
  * @param {object} args - instance arguments
  * @returns {object} initialState
  */
-module.exports = (aoDef = {}, args = {}) => {
+module.exports = (aoDef = {}, args = {}, pairConfig = {}) => {
   const { meta = {}, id, name, headersForLogFile } = aoDef
   const { validateParams, processParams, initState, genOrderLabel } = meta
   const params = _isFunction(processParams)
@@ -21,7 +21,7 @@ module.exports = (aoDef = {}, args = {}) => {
     : args
 
   if (_isFunction(validateParams)) {
-    const vError = validateParams(params)
+    const vError = validateParams(params, pairConfig)
 
     if (vError) {
       throw new Error(_isString(vError) ? vError : vError.message)
@@ -29,7 +29,7 @@ module.exports = (aoDef = {}, args = {}) => {
   }
 
   const initialState = _isFunction(initState)
-    ? initState(params)
+    ? initState(params, pairConfig)
     : {}
 
   const gid = clientID() + ''

--- a/lib/util/get_min_max_distorted_amount.js
+++ b/lib/util/get_min_max_distorted_amount.js
@@ -1,0 +1,29 @@
+'use strict'
+
+const _isFinite = require('lodash/isFinite')
+const { prepareAmount } = require('bfx-api-node-util')
+
+module.exports = (args = {}, pairConfig = {}) => {
+  const { amount, sliceAmount, amountDistortion = 0 } = args
+  const { minSize, maxSize } = pairConfig
+
+  const m = amount < 0 ? -1 : 1
+
+  let maxDistortedAmount = (1 + amountDistortion) * sliceAmount
+  let minDistortedAmount = (1 - amountDistortion) * sliceAmount
+
+  if (_isFinite(minSize)) {
+    if (Math.abs(minDistortedAmount) < minSize) minDistortedAmount = m * minSize
+    if (Math.abs(maxDistortedAmount) < minSize) maxDistortedAmount = m * minSize
+  }
+
+  if (_isFinite(maxSize)) {
+    if (Math.abs(minDistortedAmount) > maxSize) minDistortedAmount = m * maxSize
+    if (Math.abs(maxDistortedAmount) > maxSize) maxDistortedAmount = m * maxSize
+  }
+
+  return {
+    minDistortedAmount: +prepareAmount(minDistortedAmount),
+    maxDistortedAmount: +prepareAmount(maxDistortedAmount)
+  }
+}

--- a/lib/util/get_random_number_in_range.js
+++ b/lib/util/get_random_number_in_range.js
@@ -1,0 +1,7 @@
+'use strict'
+
+const { prepareAmount } = require('bfx-api-node-util')
+
+module.exports = (min, max) => {
+  return +prepareAmount(Math.random() * (max - min) + min) // Generate random number between min and max
+}

--- a/test/lib/util/get_min_max_distorted_amount.js
+++ b/test/lib/util/get_min_max_distorted_amount.js
@@ -33,4 +33,12 @@ describe('util:get_min_max_distorted_amount', () => {
     assert.deepStrictEqual(minDistortedAmount, 0.75, 'should have distorted to minimum possible slice amount')
     assert.deepStrictEqual(maxDistortedAmount, 1.25, 'should have distorted to maximum possible slice amount')
   })
+
+  it('returns the distorted float amounts properly', () => {
+    const orderParams = { amount: 10, sliceAmount: 0.1, amountDistortion: 0.25 }
+    const { minDistortedAmount, maxDistortedAmount } = getMinMaxDistortedAmount(orderParams, pairConfig)
+
+    assert.deepStrictEqual(minDistortedAmount, 0.075, 'should have distorted to minimum possible slice amount')
+    assert.deepStrictEqual(maxDistortedAmount, 0.125, 'should have distorted to maximum possible slice amount')
+  })
 })

--- a/test/lib/util/get_min_max_distorted_amount.js
+++ b/test/lib/util/get_min_max_distorted_amount.js
@@ -1,0 +1,36 @@
+/* eslint-env mocha */
+'use strict'
+
+const assert = require('assert')
+const getMinMaxDistortedAmount = require('../../../lib/util/get_min_max_distorted_amount')
+
+const pairConfig = {
+  minSize: 0.006,
+  maxSize: 100
+}
+
+describe('util:get_min_max_distorted_amount', () => {
+  it('should return distorted amounts equal to the minimum order size', () => {
+    const orderParams = { amount: 0.1, sliceAmount: 0.001, amountDistortion: 0.25 }
+    const { minDistortedAmount, maxDistortedAmount } = getMinMaxDistortedAmount(orderParams, pairConfig)
+
+    assert.deepStrictEqual(minDistortedAmount, 0.006, 'should have equalled to minimum order size')
+    assert.deepStrictEqual(maxDistortedAmount, 0.006, 'should have equalled to minimum order size')
+  })
+
+  it('should return distorted amounts equal to the maximum order size', () => {
+    const orderParams = { amount: -200, sliceAmount: -150, amountDistortion: 0.25 } // sell order
+    const { minDistortedAmount, maxDistortedAmount } = getMinMaxDistortedAmount(orderParams, pairConfig)
+
+    assert.deepStrictEqual(minDistortedAmount, -100, 'should have equalled to maximum order size')
+    assert.deepStrictEqual(maxDistortedAmount, -100, 'should have equalled to maximum order size')
+  })
+
+  it('returns the distorted amounts properly', () => {
+    const orderParams = { amount: 10, sliceAmount: 1, amountDistortion: 0.25 }
+    const { minDistortedAmount, maxDistortedAmount } = getMinMaxDistortedAmount(orderParams, pairConfig)
+
+    assert.deepStrictEqual(minDistortedAmount, 0.75, 'should have distorted to minimum possible slice amount')
+    assert.deepStrictEqual(maxDistortedAmount, 1.25, 'should have distorted to maximum possible slice amount')
+  })
+})

--- a/test/lib/util/get_random_number_in_range.js
+++ b/test/lib/util/get_random_number_in_range.js
@@ -1,0 +1,17 @@
+/* eslint-env mocha */
+'use strict'
+
+const { expect } = require('chai')
+const getRandomNumberInRange = require('../../../lib/util/get_random_number_in_range')
+
+describe('util:get_random_number_in_range', () => {
+  it('generates random number within the given number range', () => {
+    const random = getRandomNumberInRange(1, 10)
+    expect(random).to.be.within(1, 10)
+  })
+
+  it('generates random number within the given number range for negative numbers', () => {
+    const random = getRandomNumberInRange(-1, -10)
+    expect(random).to.be.within(-10, -1)
+  })
+})


### PR DESCRIPTION
- Config pair added to AO host that can used to save in the instance state.
- Using pair config to generate allowed order sizes for the selected pair
- Util function to generate random number within the given range
