### PR TITLE
Twap last min order issue fix

### DIFF
--- a/lib/twap/events/life_start.js
+++ b/lib/twap/events/life_start.js
@@ -2,6 +2,7 @@
 
 const _isFinite = require('lodash/isFinite')
 const _isString = require('lodash/isString')
+const getMinMaxDistortedAmount = require('../../util/get_min_max_distorted_amount')
 
 /**
  * Sets up the `self:interval_tick` interval and saves it on the state.
@@ -14,9 +15,9 @@ const _isString = require('lodash/isString')
  */
 const onLifeStart = async (instance = {}) => {
   const { state = {}, h = {} } = instance
-  const { args = {} } = state
+  const { args = {}, pairConfig } = state
   const { priceTarget, priceCondition, orderType } = args
-  const { debug, emitSelf, subscribeDataChannels } = h
+  const { debug, emitSelf, updateState, subscribeDataChannels } = h
 
   if (!/MARKET/.test(orderType)) {
     if (_isFinite(priceTarget) && _isString(priceCondition)) {
@@ -28,6 +29,10 @@ const onLifeStart = async (instance = {}) => {
       return
     }
   }
+
+  const { minDistortedAmount, maxDistortedAmount } = getMinMaxDistortedAmount(args, pairConfig)
+
+  await updateState(instance, { minDistortedAmount, maxDistortedAmount })
 
   try {
     await subscribeDataChannels(state, { timeout: 30 * 1000 })

--- a/lib/twap/events/orders_order_fill.js
+++ b/lib/twap/events/orders_order_fill.js
@@ -33,7 +33,7 @@ const onOrdersOrderFill = async (instance = {}, order) => {
 
   await updateState(instance, { remainingAmount })
 
-  if (absRem > DUST && absRem >= minDistortedAmount) { // continue, await next tick
+  if (absRem > DUST && absRem >= Math.abs(minDistortedAmount)) { // continue, await next tick
     return
   }
 

--- a/lib/twap/events/orders_order_fill.js
+++ b/lib/twap/events/orders_order_fill.js
@@ -18,7 +18,7 @@ const { nBN } = require('@bitfinex/lib-js-util-math')
  */
 const onOrdersOrderFill = async (instance = {}, order) => {
   const { state = {}, h = {} } = instance
-  const { args = {} } = state
+  const { args = {}, minDistortedAmount } = state
   const { emit, updateState, debug } = h
   const { amount } = args
   const m = amount < 0 ? -1 : 1
@@ -33,7 +33,7 @@ const onOrdersOrderFill = async (instance = {}, order) => {
 
   await updateState(instance, { remainingAmount })
 
-  if (absRem > DUST) { // continue, await next tick
+  if (absRem > DUST && absRem >= minDistortedAmount) { // continue, await next tick
     return
   }
 

--- a/lib/twap/meta/get_ui_def.js
+++ b/lib/twap/meta/get_ui_def.js
@@ -20,7 +20,7 @@ const getUIDef = () => ({
     'price targets, the price condition may be specified to match against',
     'either the order book or last trade. If a price delta is specified, the',
     'target must be within the delta in order to match.',
-    '\n\nNote: If amount distortion is provided, the total sliced order amounts will',
+    '\n\nNote: If amount distortion is provided, the total order amounts will',
     'not exceed the total amount but may be slightly less than the total amount specified.'
   ].join(' '),
 

--- a/lib/twap/meta/get_ui_def.js
+++ b/lib/twap/meta/get_ui_def.js
@@ -19,7 +19,9 @@ const getUIDef = () => ({
     'that must be conditionally matched against another factor.\n\nWith custom',
     'price targets, the price condition may be specified to match against',
     'either the order book or last trade. If a price delta is specified, the',
-    'target must be within the delta in order to match.'
+    'target must be within the delta in order to match.',
+    '\n\nNote: If amount distortion is provided, the total sliced order amounts will',
+    'not exceed the total amount but may be slightly less than the total amount specified.'
   ].join(' '),
 
   connectionTimeout: 10000,

--- a/lib/twap/util/generate_order.js
+++ b/lib/twap/util/generate_order.js
@@ -5,8 +5,6 @@ const _isString = require('lodash/isString')
 const { prepareAmount } = require('bfx-api-node-util')
 const { Order } = require('bfx-api-node-models')
 const genCID = require('../../util/gen_client_id')
-const { Config } = require('bfx-api-node-core')
-const { DUST } = Config
 
 const getRandomNumberInRange = require('../../util/get_random_number_in_range')
 

--- a/lib/twap/util/generate_order.js
+++ b/lib/twap/util/generate_order.js
@@ -8,7 +8,6 @@ const genCID = require('../../util/gen_client_id')
 const { Config } = require('bfx-api-node-core')
 const { DUST } = Config
 
-const getMinMaxDistortedAmount = require('../../util/get_min_max_distorted_amount')
 const getRandomNumberInRange = require('../../util/get_random_number_in_range')
 
 /**
@@ -23,14 +22,13 @@ const getRandomNumberInRange = require('../../util/get_random_number_in_range')
  * @returns {object} order - null if no amount remains
  */
 const generateOrder = (state = {}, price) => {
-  const { args = {}, remainingAmount, pairConfig } = state
+  const { args = {}, remainingAmount, minDistortedAmount, maxDistortedAmount } = state
   const {
     sliceAmount, orderType, symbol, amount, lev, _margin, _futures, amountDistortion
   } = args
   let orderAmount = 0
 
   if (_isFinite(amountDistortion) && amountDistortion > 0) {
-    const { minDistortedAmount, maxDistortedAmount } = getMinMaxDistortedAmount(args, pairConfig)
     orderAmount = getRandomNumberInRange(minDistortedAmount, maxDistortedAmount)
   } else {
     orderAmount = sliceAmount
@@ -41,7 +39,7 @@ const generateOrder = (state = {}, price) => {
     ? Math.min(orderAmount, remainingAmount)
     : Math.max(orderAmount, remainingAmount))
 
-  if (Math.abs(rem) < DUST) {
+  if (Math.abs(rem) < minDistortedAmount) {
     return null
   }
 

--- a/lib/twap/util/generate_order.js
+++ b/lib/twap/util/generate_order.js
@@ -37,7 +37,7 @@ const generateOrder = (state = {}, price) => {
     ? Math.min(orderAmount, remainingAmount)
     : Math.max(orderAmount, remainingAmount))
 
-  if (Math.abs(rem) < minDistortedAmount) {
+  if (Math.abs(rem) < Math.abs(minDistortedAmount)) {
     return null
   }
 

--- a/test/lib/twap/events/life_start.js
+++ b/test/lib/twap/events/life_start.js
@@ -20,6 +20,9 @@ describe('twap:events:life_start', () => {
       h: {
         debug: () => {},
         subscribeDataChannels: async () => {},
+        updateState: (instance, state) => {
+          assert.deepStrictEqual(Object.keys(state), ['minDistortedAmount', 'maxDistortedAmount'])
+        },
         emitSelf: (eName) => {
           return new Promise((resolve) => {
             assert.strictEqual(eName, 'interval_tick')

--- a/test/lib/twap/events/orders_order_fill.js
+++ b/test/lib/twap/events/orders_order_fill.js
@@ -10,6 +10,7 @@ describe('twap:events:orders_order_fill', () => {
   const instance = {
     state: {
       gid: 100,
+      minDistortedAmount: 40,
       orders: orderState,
       args: {
         amount: 100
@@ -112,5 +113,9 @@ describe('twap:events:orders_order_fill', () => {
 
   it('emits stop event if no amount is left', (done) => {
     testStopAmount(42, done)
+  })
+
+  it('emits stop event if amount less than minimum order size is left', (done) => {
+    testStopAmount(60, done)
   })
 })

--- a/test/lib/twap/events/orders_order_fill.js
+++ b/test/lib/twap/events/orders_order_fill.js
@@ -59,7 +59,8 @@ describe('twap:events:orders_order_fill', () => {
       ...instance,
       state: {
         ...instance.state,
-        remainingAmount: 100
+        remainingAmount: 100,
+        minDistortedAmount: 0.002
       },
 
       h: {

--- a/test/lib/twap/util/generate_order.js
+++ b/test/lib/twap/util/generate_order.js
@@ -54,36 +54,42 @@ describe('twap:util:generate_order', () => {
   describe('check order amount within distortion range', () => {
     it('distorts the amount to the given distortion range', () => {
       const amountDistortion = 0.2
-      const state = getState({ argOverrides: { amountDistortion } })
-      const highestDistortedAmount = nBN(state.args.sliceAmount).multipliedBy(1.2).toNumber()
-      const lowestDistortedAmount = nBN(state.args.sliceAmount).multipliedBy(0.8).toNumber()
+      const maxDistortedAmount = 1.2
+      const minDistortedAmount = 0.8
+      const state = getState({
+        argOverrides: { amountDistortion },
+        overrides: { minDistortedAmount, maxDistortedAmount }
+      })
       const o = generateOrder(state, 42)
-      const amountInDistortedRange = o.amount <= highestDistortedAmount && o.amount >= lowestDistortedAmount
+      const amountInDistortedRange = o.amount <= maxDistortedAmount && o.amount >= minDistortedAmount
       assert.strictEqual(amountInDistortedRange, true)
     })
 
     it('distorts the amount within the range of minimum allowed size and max distorted size', () => {
       const amountDistortion = 0.4
       const pairConfig = { minSize: 1, maxSize: 100 }
-      const state = getState({ argOverrides: { amountDistortion }, overrides: { pairConfig } })
-      const highestDistortedAmount = nBN(state.args.sliceAmount).multipliedBy(1.4).toNumber()
-      const lowestDistortedAmount = 1
+      const minDistortedAmount = 1
+      const maxDistortedAmount = 1.4
+      const state = getState({
+        argOverrides: { amountDistortion },
+        overrides: { pairConfig, minDistortedAmount, maxDistortedAmount }
+      })
       const o = generateOrder(state, 42)
-      const amountInDistortedRange = o.amount <= highestDistortedAmount && o.amount >= lowestDistortedAmount
+      const amountInDistortedRange = o.amount <= maxDistortedAmount && o.amount >= minDistortedAmount
       assert.strictEqual(amountInDistortedRange, true)
     })
 
     it('distorts the amount within the range of minimum distorted size and max allowed size', () => {
       const amountDistortion = 0.4
       const pairConfig = { minSize: 1, maxSize: 100 }
+      const maxDistortedAmount = 100
+      const minDistortedAmount = 0.6
       const state = getState({
         argOverrides: { amountDistortion, sliceAmount: 100, amount: 1000 },
-        overrides: { pairConfig, remainingAmount: 1000 }
+        overrides: { pairConfig, remainingAmount: 1000, minDistortedAmount, maxDistortedAmount }
       })
-      const highestDistortedAmount = 100
-      const lowestDistortedAmount = nBN(state.args.sliceAmount).multipliedBy(0.6).toNumber()
       const o = generateOrder(state, 42)
-      const amountInDistortedRange = o.amount <= highestDistortedAmount && o.amount >= lowestDistortedAmount
+      const amountInDistortedRange = o.amount <= maxDistortedAmount && o.amount >= minDistortedAmount
       assert.strictEqual(amountInDistortedRange, true)
     })
   })
@@ -96,7 +102,7 @@ describe('twap:util:generate_order', () => {
     const remainingAmount = nBN(amount).minus(openAmount).toNumber()
     const amountDistortion = 0.02
     const state = getState({
-      overrides: { orders, amount, remainingAmount },
+      overrides: { orders, amount, remainingAmount, minDistortedAmount: 0.98, maxDistortedAmount: 1.02 },
       argOverrides: { amountDistortion }
     })
     const o = generateOrder(state, 42)


### PR DESCRIPTION
Issue: The last order generated may be less than the minimum order size because of the remaining amount, hence, causing it to stop the  algo order.

This PR provides fix to this issue.