### PR TITLE
use UUIDs as GID

### DIFF
--- a/lib/util/gen_client_id.js
+++ b/lib/util/gen_client_id.js
@@ -1,9 +1,7 @@
 'use strict'
 
-let last = Date.now()
+const { v4: uuid } = require('uuid')
 
 module.exports = () => {
-  const now = Date.now()
-  last = (last < now) ? now : last + 1
-  return last
+  return uuid()
 }

--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
     "bluebird": "^3.5.5",
     "debug": "^4.3.1",
     "flat-promise": "^1.0.2",
-    "lodash": "^4.17.15"
+    "lodash": "^4.17.15",
+    "uuid": "^8.3.2"
   },
   "devDependencies": {
     "autocannon": "^7.3.0",

--- a/test/lib/host/init_ao_state.js
+++ b/test/lib/host/init_ao_state.js
@@ -36,7 +36,6 @@ describe('host:init_ao_state', () => {
   it('generates a valid group ID', () => {
     const { gid } = initAOState()
     assert.ok(_isString(gid))
-    assert.ok(_isFinite(+gid))
   })
 
   it('defaults to active:false', () => {


### PR DESCRIPTION
The actual key is a combination of gid with the name of the algo order, whereas gid is a timestamp. this did work in the desktop app, but for the hosted version we'll have conflicts at one point, so gid should become a UUID