### PR TITLE
use flake ids

### DIFF
--- a/lib/util/gen_client_id.js
+++ b/lib/util/gen_client_id.js
@@ -1,9 +1,20 @@
 'use strict'
 
-let last = Date.now()
+const FlakeId = require('flake-idgen')
+const format = require('biguint-format')
+
+let generator
 
 module.exports = () => {
-  const now = Date.now()
-  last = (last < now) ? now : last + 1
-  return last
+  if (!generator) {
+    const {
+      FLAKE_WORKER_ID: worker,
+      FLAKE_DATACENTER_ID: datacenter
+    } = process.env
+
+    generator = new FlakeId({ worker, datacenter })
+  }
+
+  const id = generator.next()
+  return format(id, 'dec')
 }

--- a/package.json
+++ b/package.json
@@ -47,8 +47,10 @@
     "bfx-api-node-util": "^1.0.2",
     "bfx-hf-indicators": "^2.0.8",
     "bfx-hf-util": "^1.0.1",
+    "biguint-format": "^1.0.2",
     "bluebird": "^3.5.5",
     "debug": "^4.3.1",
+    "flake-idgen": "^1.4.0",
     "flat-promise": "^1.0.2",
     "lodash": "^4.17.15"
   },


### PR DESCRIPTION
The actual key is a combination of gid with the name of the algo order, whereas gid is a timestamp. this did work in the desktop app, but for the hosted version we'll have conflicts at one point, so gid should become a global distributed ID.

Flake ID generator yields k-ordered, conflict-free ids in a distributed environment.

This way we can set the cluster id as datacenter and shard id as worker id.