### PR TITLE
dont stop algo for postonly cancelled cases

### DIFF
--- a/lib/accumulate_distribute/events/orders_order_cancel.js
+++ b/lib/accumulate_distribute/events/orders_order_cancel.js
@@ -11,9 +11,14 @@
  * @param {object} order - the order that was cancelled externally
  * @returns {Promise} p
  */
-const onOrdersOrderCancel = async (instance = {}, order) => {
+const onOrdersOrderCancel = async (instance = {}, order = {}) => {
   const { h = {} } = instance
   const { emit, debug } = h
+  const { status } = order
+
+  if (status === 'POSTONLY CANCELED') {
+    return
+  }
 
   debug('detected atomic cancelation, stopping...')
 


### PR DESCRIPTION
When an active algo receives postonly cancelled orders, it stops the running algo since it considers it as a cancelled order. This is a problem for postonly orders, so a fix is provided for this case.  