### PR TITLE
Internationalization support

### DIFF
--- a/lib/accumulate_distribute/meta/gen_order_label.js
+++ b/lib/accumulate_distribute/meta/gen_order_label.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { apply: applyI18N } = require('../../util/i18n')
+
 /**
  * Generates a label for an AccumulateDistribute instance for rendering in an
  * UI.
@@ -14,25 +16,34 @@
  */
 const genOrderLabel = (state = {}) => {
   const { args = {} } = state
-  const { orderType, amount, limitPrice, sliceAmount, sliceInterval } = args
+  const {
+    orderType, amount, limitPrice, sliceAmount, sliceInterval,
+    relativeOffset, relativeCap
+  } = args
+  const interval = Math.floor(sliceInterval / 1000)
 
   const labelParts = [
     'A/D',
     ` | ${amount} @ ${limitPrice || orderType} `,
     ` | slice ${sliceAmount}`,
-    ' | interval ', Math.floor(sliceInterval / 1000), 's'
+    ' | interval ', interval, 's'
   ]
 
   if (orderType === 'LIMIT') {
-    labelParts.push(` | LIMIT ${args.limitPrice}`)
+    labelParts.push(` | LIMIT ${limitPrice}`)
   } else if (orderType === 'MARKET') {
     labelParts.push(' | MARKET')
   } else {
-    labelParts.push(` | Offset ${args.relativeOffset.type.toUpperCase()}`)
-    labelParts.push(` | Cap ${args.relativeCap.type.toUpperCase()}`)
+    labelParts.push(` | Offset ${relativeOffset.type.toUpperCase()}`)
+    labelParts.push(` | Cap ${relativeCap.type.toUpperCase()}`)
   }
 
-  return labelParts.join('')
+  return applyI18N({
+    origin: labelParts.join('')
+  },
+  `accDist${orderType === 'LIMIT' ? 'Limit' : (orderType === 'MARKET' ? 'Market' : '')}.label`,
+  { amount, limitPrice, orderType, sliceAmount, interval, relativeOffset, relativeCap }
+  )
 }
 
 module.exports = genOrderLabel

--- a/lib/accumulate_distribute/meta/get_ui_def.js
+++ b/lib/accumulate_distribute/meta/get_ui_def.js
@@ -1,3 +1,6 @@
+'use strict'
+const { t } = require('../../util/i18n')
+
 /**
  * Returns the UI layout definition for AccumulateDistribute, with a field for
  * each parameter.
@@ -8,12 +11,12 @@
  *
  * @returns {AOUIDefinition} uiDef
  */
-const getUIDef = () => ({
-  label: 'Accumulate/Distribute',
+const getUIDef = ({ i18n } = {}) => ({
+  label: t(i18n, 'orderForm.accdist.title', 'Accumulate/Distribute'),
   id: 'bfx-accumulate_distribute',
 
   uiIcon: 'distribute-active',
-  customHelp: [
+  customHelp: t(i18n, 'orderForm.accdist.help', [
     'Accumulate/Distribute allows you to break up a large order into smaller',
     'randomized chunks, submitted at regular or irregular intervals to minimise',
     'detection by other players in the market.\n\nBy enabling the \'Await Fill\'',
@@ -25,7 +28,7 @@ const getUIDef = () => ({
     'when \'catching up\', the slice interval is hard-coded to 0.2 seconds.',
     '\n\nNote: If the remaining order amount is less than the minimum order size,',
     'it will be ignored.'
-  ].join(' '),
+  ].join(' ')),
 
   connectionTimeout: 10000,
   actionTimeout: 10000,
@@ -45,7 +48,7 @@ const getUIDef = () => ({
       [null, 'limitPrice']
     ]
   }, {
-    title: 'Price Offset',
+    title: t(i18n, 'orderForm.priceOffset', 'Price Offset'),
     name: 'offset',
     fixed: true,
     visible: {
@@ -57,7 +60,7 @@ const getUIDef = () => ({
     ]
   }, {
     name: 'offsetIndicatorSMA',
-    title: 'Price Offset SMA',
+    title: t(i18n, 'orderForm.priceOffsetSMA', 'Price Offset SMA'),
     fixed: true,
     visible: {
       orderType: { eq: 'RELATIVE' },
@@ -69,7 +72,7 @@ const getUIDef = () => ({
     ]
   }, {
     name: 'offsetIndicatorEMA',
-    title: 'Price Offset EMA',
+    title: t(i18n, 'orderForm.priceOffsetEMA', 'Price Offset EMA'),
     fixed: true,
     visible: {
       orderType: { eq: 'RELATIVE' },
@@ -80,7 +83,7 @@ const getUIDef = () => ({
       [null, 'offsetIndicatorTFEMA']
     ]
   }, {
-    title: 'Price Cap',
+    title: t(i18n, 'orderForm.priceCap', 'Price Cap'),
     name: 'cap',
     fixed: true,
     visible: {
@@ -91,7 +94,7 @@ const getUIDef = () => ({
       ['capType', 'capDelta']
     ]
   }, {
-    title: 'Price Cap SMA',
+    title: t(i18n, 'orderForm.priceCapSMA', 'Price Cap SMA'),
     name: 'capIndicatorSMA',
     fixed: true,
     visible: {
@@ -103,7 +106,7 @@ const getUIDef = () => ({
       [null, 'capIndicatorTFSMA']
     ]
   }, {
-    title: 'Price Cap EMA',
+    title: t(i18n, 'orderForm.priceCapEMA', 'Price Cap EMA'),
     name: 'capIndicatorEMA',
     fixed: true,
     visible: {
@@ -136,11 +139,11 @@ const getUIDef = () => ({
     // General section/header
     postonly: {
       component: 'input.checkbox',
-      label: 'Post-Only',
+      label: t(i18n, 'orderForm.postOnly', 'Post-Only'),
       default: false,
-      customHelp: `"Post Only" limit orders are orders that allow you to be sure to always pay the maker fee.
+      customHelp: t(i18n, 'orderForm.postOnly.help', `"Post Only" limit orders are orders that allow you to be sure to always pay the maker fee.
       When placed, a "Post Only" limit order is either inserted into the orderbook or cancelled and not matched
-      with a pre-existing order`,
+      with a pre-existing order`),
       disabled: {
         orderType: { neq: 'LIMIT' }
       }
@@ -148,73 +151,73 @@ const getUIDef = () => ({
 
     catchUp: {
       component: 'input.checkbox',
-      label: 'Catch Up',
+      label: t(i18n, 'orderForm.catchUp', 'Catch Up'),
       default: true,
-      customHelp: 'If the algo falls behind in filling orders, disregard the slice interval and submit the next order after a 2 second delay'
+      customHelp: t(i18n, 'orderForm.catchUp.help', 'If the algo falls behind in filling orders, disregard the slice interval and submit the next order after a 2 second delay')
     },
 
     awaitFill: {
       component: 'input.checkbox',
-      label: 'Await Fill',
+      label: t(i18n, 'orderForm.awaitFill', 'Await Fill'),
       default: true,
-      customHelp: 'Keeps the current order open until it fills, while tracking progress for \'Catch up\''
+      customHelp: t(i18n, 'orderForm.awaitFill.help', 'Keeps the current order open until it fills, while tracking progress for \'Catch up\'')
     },
 
     hidden: {
       component: 'input.checkbox',
-      label: 'HIDDEN',
+      label: t(i18n, 'orderForm.hidden', 'HIDDEN'),
       default: false,
-      customHelp: `This option allows you to place an order into the book but not have it displayed to
+      customHelp: t(i18n, 'orderForm.hidden.help', `This option allows you to place an order into the book but not have it displayed to
       other traders. Price/time priority is the same as a displayed order, but the hidden order will
-      always pay the "taker" fee while those trading against a hidden order will pay the "maker" fee`
+      always pay the "taker" fee while those trading against a hidden order will pay the "maker" fee`)
     },
 
     orderType: {
       component: 'input.dropdown',
-      label: 'Order Type',
+      label: t(i18n, 'orderForm.orderType', 'Order Type'),
       default: 'MARKET',
       options: {
-        LIMIT: 'Limit',
-        MARKET: 'Market',
-        RELATIVE: 'Relative'
+        LIMIT: t(i18n, 'orderForm.limit', 'Limit'),
+        MARKET: t(i18n, 'orderForm.market', 'Market'),
+        RELATIVE: t(i18n, 'orderForm.relative', 'Relative')
       }
     },
 
     amount: {
       component: 'input.amount',
-      label: 'Amount $BASE',
-      customHelp: 'Total order amount, to be executed slice-by-slice',
+      label: `${t(i18n, 'orderForm.amount', 'Amount')} $BASE`,
+      customHelp: t(i18n, 'orderForm.amount.help', 'Total order amount, to be executed slice-by-slice'),
       priceField: 'limitPrice'
     },
 
     sliceAmount: {
       component: 'input.number',
-      label: 'Slice Amount $BASE',
-      customHelp: 'Allows individual buy & sell amounts to be adjusted'
+      label: `${t(i18n, 'orderForm.sliceAmount', 'Slice Amount')} $BASE`,
+      customHelp: t(i18n, 'orderForm.sliceAmount.help', 'Allows individual buy & sell amounts to be adjusted')
     },
 
     amountDistortion: {
       component: 'input.percent',
-      label: 'Amount Distortion %',
-      customHelp: 'Amount to distort individual order sizes to prevent detection, in percent'
+      label: t(i18n, 'orderForm.accdist.amountDistortion', 'Amount Distortion %'),
+      customHelp: t(i18n, 'orderForm.accdist.amountDistortion.help', 'Amount to distort individual order sizes to prevent detection, in percent')
     },
 
     sliceIntervalSec: {
       component: 'input.number',
-      label: 'Slice Interval S',
-      customHelp: 'Time to wait between each slice order, in seconds'
+      label: t(i18n, 'orderForm.accdist.sliceIntervalSec', 'Slice Interval S'),
+      customHelp: t(i18n, 'orderForm.sliceIntervalSec.help', 'Time to wait between each slice order, in seconds')
     },
 
     intervalDistortion: {
       component: 'input.percent',
-      label: 'Interval Distortion %',
-      customHelp: 'Amount to distort each slice interval, in percent'
+      label: t(i18n, 'orderForm.intervalDistortion', 'Interval Distortion %'),
+      customHelp: t(i18n, 'orderForm.intervalDistortion.help', 'Amount to distort each slice interval, in percent')
     },
 
     limitPrice: {
       component: 'input.price',
-      label: 'Price $QUOTE',
-      customHelp: 'Price for LIMIT order type',
+      label: `${t(i18n, 'orderForm.limitPrice', 'Price')} $QUOTE`,
+      customHelp: t(i18n, 'orderForm.limitPrice.help', 'Price for LIMIT order type'),
       visible: {
         orderType: { eq: 'LIMIT' }
       }
@@ -223,30 +226,30 @@ const getUIDef = () => ({
     // Offset section
     offsetType: {
       component: 'input.dropdown',
-      label: 'Offset Type',
+      label: t(i18n, 'orderForm.offsetType', 'Offset Type'),
       default: 'MID',
-      customHelp: 'Relative order price as offset from an indicator/book/last trade',
+      customHelp: t(i18n, 'orderForm.offsetType.help', 'Relative order price as offset from an indicator/book/last trade'),
       options: {
-        BID: 'Top Bid',
-        ASK: 'Top Ask',
-        MID: 'Book Mid Price',
-        TRADE: 'Last Trade Price',
-        SMA: 'Simple Moving Average',
-        EMA: 'Exp Moving Average'
+        BID: t(i18n, 'orderForm.topBid', 'Top Bid'),
+        ASK: t(i18n, 'orderForm.topAsk', 'Top Ask'),
+        MID: t(i18n, 'orderForm.bookMidPrice', 'Book Mid Price'),
+        TRADE: t(i18n, 'orderForm.lastTradePrice', 'Last Trade Price'),
+        SMA: t(i18n, 'orderForm.simpleMovingAverage', 'Simple Moving Average'),
+        EMA: t(i18n, 'orderForm.expMovingAverage', 'Exp Moving Average')
       }
     },
 
     offsetDelta: {
       component: 'input.number',
-      label: 'Offset Delta',
-      customHelp: 'Price as distance from offset value',
+      label: t(i18n, 'orderForm.offsetDelta', 'Offset Delta'),
+      customHelp: t(i18n, 'orderForm.offsetDelta.help', 'Price as distance from offset value'),
       default: 0
     },
 
     offsetIndicatorPeriodSMA: {
       component: 'input.number',
-      label: 'SMA Period',
-      customHelp: 'Period for simple moving average indicator',
+      label: t(i18n, 'orderForm.smaPeriod', 'SMA Period'),
+      customHelp: t(i18n, 'orderForm.smaPeriod.help', 'Period for simple moving average indicator'),
       visible: {
         offsetType: { eq: 'SMA' }
       }
@@ -254,13 +257,13 @@ const getUIDef = () => ({
 
     offsetIndicatorPriceSMA: {
       component: 'input.dropdown',
-      label: 'SMA Candle Price',
+      label: t(i18n, 'orderForm.smaCandlePrice', 'SMA Candle Price'),
       default: 'CLOSE',
       options: {
-        OPEN: 'Open',
-        HIGH: 'High',
-        LOW: 'Low',
-        CLOSE: 'Close'
+        OPEN: t(i18n, 'orderForm.open', 'Open'),
+        HIGH: t(i18n, 'orderForm.high', 'High'),
+        LOW: t(i18n, 'orderForm.low', 'Low'),
+        CLOSE: t(i18n, 'orderForm.close', 'Close')
       },
 
       visible: {
@@ -270,8 +273,8 @@ const getUIDef = () => ({
 
     offsetIndicatorPeriodEMA: {
       component: 'input.number',
-      label: 'EMA Period',
-      customHelp: 'Period for exponential moving average indicator',
+      label: t(i18n, 'orderForm.emaPeriod', 'EMA Period'),
+      customHelp: t(i18n, 'orderForm.emaPeriod.help', 'Period for exponential moving average indicator'),
       visible: {
         offsetType: { eq: 'EMA' }
       }
@@ -279,13 +282,13 @@ const getUIDef = () => ({
 
     offsetIndicatorPriceEMA: {
       component: 'input.dropdown',
-      label: 'EMA Candle Price',
+      label: t(i18n, 'orderForm.emaCandlePrice', 'EMA Candle Price'),
       default: 'CLOSE',
       options: {
-        OPEN: 'Open',
-        HIGH: 'High',
-        LOW: 'Low',
-        CLOSE: 'Close'
+        OPEN: t(i18n, 'orderForm.open', 'Open'),
+        HIGH: t(i18n, 'orderForm.high', 'High'),
+        LOW: t(i18n, 'orderForm.low', 'Low'),
+        CLOSE: t(i18n, 'orderForm.close', 'Close')
       },
 
       visible: {
@@ -295,21 +298,21 @@ const getUIDef = () => ({
 
     offsetIndicatorTFSMA: {
       component: 'input.dropdown',
-      label: 'SMA Candle Time Frame',
+      label: t(i18n, 'orderForm.smaCandleTimeFrame', 'SMA Candle Time Frame'),
       default: 'ONE_HOUR',
       options: {
-        ONE_MINUTE: '1m',
-        FIVE_MINUTES: '5m',
-        FIFTEEN_MINUTES: '15m',
-        THIRTY_MINUTES: '30m',
-        ONE_HOUR: '1h',
-        THREE_HOURS: '3h',
-        SIX_HOURS: '6h',
-        TWELVE_HOURS: '12h',
-        ONE_DAY: '1D',
-        SEVEN_DAYS: '7D',
-        FOURTEEN_DAYS: '14D',
-        ONE_MONTH: '1M'
+        ONE_MINUTE: t(i18n, 'orderForm.m', '1m', { number: 1 }),
+        FIVE_MINUTES: t(i18n, 'orderForm.m', '5m', { number: 5 }),
+        FIFTEEN_MINUTES: t(i18n, 'orderForm.m', '15m', { number: 15 }),
+        THIRTY_MINUTES: t(i18n, 'orderForm.m', '30m', { number: 30 }),
+        ONE_HOUR: t(i18n, 'orderForm.h', '1h', { number: 1 }),
+        THREE_HOURS: t(i18n, 'orderForm.h', '3h', { number: 3 }),
+        SIX_HOURS: t(i18n, 'orderForm.h', '6h', { number: 6 }),
+        TWELVE_HOURS: t(i18n, 'orderForm.h', '12h', { number: 12 }),
+        ONE_DAY: t(i18n, 'orderForm.D', '1D', { number: 1 }),
+        SEVEN_DAYS: t(i18n, 'orderForm.D', '7D', { number: 7 }),
+        FOURTEEN_DAYS: t(i18n, 'orderForm.D', '14D', { number: 14 }),
+        ONE_MONTH: t(i18n, 'orderForm.M', '1M', { number: 1 })
       },
 
       visible: {
@@ -319,21 +322,21 @@ const getUIDef = () => ({
 
     offsetIndicatorTFEMA: {
       component: 'input.dropdown',
-      label: 'EMA Candle Time Frame',
+      label: t(i18n, 'orderForm.emaCandleTimeFrame', 'EMA Candle Time Frame'),
       default: 'ONE_HOUR',
       options: {
-        ONE_MINUTE: '1m',
-        FIVE_MINUTES: '5m',
-        FIFTEEN_MINUTES: '15m',
-        THIRTY_MINUTES: '30m',
-        ONE_HOUR: '1h',
-        THREE_HOURS: '3h',
-        SIX_HOURS: '6h',
-        TWELVE_HOURS: '12h',
-        ONE_DAY: '1D',
-        SEVEN_DAYS: '7D',
-        FOURTEEN_DAYS: '14D',
-        ONE_MONTH: '1M'
+        ONE_MINUTE: t(i18n, 'orderForm.m', '1m', { number: 1 }),
+        FIVE_MINUTES: t(i18n, 'orderForm.m', '5m', { number: 5 }),
+        FIFTEEN_MINUTES: t(i18n, 'orderForm.m', '15m', { number: 15 }),
+        THIRTY_MINUTES: t(i18n, 'orderForm.m', '30m', { number: 30 }),
+        ONE_HOUR: t(i18n, 'orderForm.h', '1h', { number: 1 }),
+        THREE_HOURS: t(i18n, 'orderForm.h', '3h', { number: 3 }),
+        SIX_HOURS: t(i18n, 'orderForm.h', '6h', { number: 6 }),
+        TWELVE_HOURS: t(i18n, 'orderForm.h', '12h', { number: 12 }),
+        ONE_DAY: t(i18n, 'orderForm.D', '1D', { number: 1 }),
+        SEVEN_DAYS: t(i18n, 'orderForm.D', '7D', { number: 7 }),
+        FOURTEEN_DAYS: t(i18n, 'orderForm.D', '14D', { number: 14 }),
+        ONE_MONTH: t(i18n, 'orderForm.M', '1M', { number: 1 })
       },
 
       visible: {
@@ -344,24 +347,24 @@ const getUIDef = () => ({
     // Cap section
     capType: {
       component: 'input.dropdown',
-      label: 'Price Cap Type',
+      label: t(i18n, 'orderForm.priceCapType', 'Price Cap Type'),
       default: 'MID',
-      customHelp: 'Upper price limit for relative order type',
+      customHelp: t(i18n, 'orderForm.priceCapType.help', 'Upper price limit for relative order type'),
       options: {
-        BID: 'Top Bid',
-        ASK: 'Top Ask',
-        MID: 'Book Mid Price',
-        TRADE: 'Last Trade Price',
-        SMA: 'Simple Moving Average',
-        EMA: 'Exp Moving Average',
-        NONE: 'None'
+        BID: t(i18n, 'orderForm.topBid', 'Top Bid'),
+        ASK: t(i18n, 'orderForm.topAsk', 'Top Ask'),
+        MID: t(i18n, 'orderForm.bookMidPrice', 'Book Mid Price'),
+        TRADE: t(i18n, 'orderForm.lastTradePrice', 'Last Trade Price'),
+        SMA: t(i18n, 'orderForm.simpleMovingAverage', 'Simple Moving Average'),
+        EMA: t(i18n, 'orderForm.expMovingAverage', 'Exp Moving Average'),
+        NONE: t(i18n, 'orderForm.none', 'None')
       }
     },
 
     capDelta: {
       component: 'input.number',
-      label: 'Cap Delta',
-      customHelp: 'Price as distance from cap value',
+      label: t(i18n, 'orderForm.capDelta', 'Cap Delta'),
+      customHelp: t(i18n, 'orderForm.capDelta.help', 'Price as distance from cap value'),
       default: 0,
 
       disabled: {
@@ -371,8 +374,8 @@ const getUIDef = () => ({
 
     capIndicatorPeriodSMA: {
       component: 'input.number',
-      label: 'SMA Period',
-      customHelp: 'Period for moving average indicator',
+      label: t(i18n, 'orderForm.smaPeriod', 'SMA Period'),
+      customHelp: t(i18n, 'orderForm.smaPeriod.help', 'Period for moving average indicator'),
       visible: {
         capType: { eq: 'SMA' }
       }
@@ -380,13 +383,13 @@ const getUIDef = () => ({
 
     capIndicatorPriceSMA: {
       component: 'input.dropdown',
-      label: 'SMA Candle Price',
+      label: t(i18n, 'orderForm.smaCandlePrice', 'SMA Candle Price'),
       default: 'CLOSE',
       options: {
-        OPEN: 'Open',
-        HIGH: 'High',
-        LOW: 'Low',
-        CLOSE: 'Close'
+        OPEN: t(i18n, 'orderForm.open', 'Open'),
+        HIGH: t(i18n, 'orderForm.high', 'High'),
+        LOW: t(i18n, 'orderForm.low', 'Low'),
+        CLOSE: t(i18n, 'orderForm.close', 'Close')
       },
       visible: {
         capType: { eq: 'SMA' }
@@ -395,8 +398,8 @@ const getUIDef = () => ({
 
     capIndicatorPeriodEMA: {
       component: 'input.number',
-      label: 'EMA Period',
-      customHelp: 'Period for exponential moving average indicator',
+      label: t(i18n, 'orderForm.emaPeriod', 'EMA Period'),
+      customHelp: t(i18n, 'orderForm.emaPeriod.help', 'Period for exponential moving average indicator'),
       visible: {
         capType: { eq: 'EMA' }
       }
@@ -404,13 +407,13 @@ const getUIDef = () => ({
 
     capIndicatorPriceEMA: {
       component: 'input.dropdown',
-      label: 'EMA Candle Price',
+      label: t(i18n, 'orderForm.emaCandlePrice', 'EMA Candle Price'),
       default: 'CLOSE',
       options: {
-        OPEN: 'Open',
-        HIGH: 'High',
-        LOW: 'Low',
-        CLOSE: 'Close'
+        OPEN: t(i18n, 'orderForm.open', 'Open'),
+        HIGH: t(i18n, 'orderForm.high', 'High'),
+        LOW: t(i18n, 'orderForm.low', 'Low'),
+        CLOSE: t(i18n, 'orderForm.close', 'Close')
       },
       visible: {
         capType: { eq: 'EMA' }
@@ -419,21 +422,21 @@ const getUIDef = () => ({
 
     capIndicatorTFSMA: {
       component: 'input.dropdown',
-      label: 'SMA Candle Time Frame',
+      label: t(i18n, 'orderForm.smaCandleTimeFrame', 'SMA Candle Time Frame'),
       default: 'ONE_HOUR',
       options: {
-        ONE_MINUTE: '1m',
-        FIVE_MINUTES: '5m',
-        FIFTEEN_MINUTES: '15m',
-        THIRTY_MINUTES: '30m',
-        ONE_HOUR: '1h',
-        THREE_HOURS: '3h',
-        SIX_HOURS: '6h',
-        TWELVE_HOURS: '12h',
-        ONE_DAY: '1D',
-        SEVEN_DAYS: '7D',
-        FOURTEEN_DAYS: '14D',
-        ONE_MONTH: '1M'
+        ONE_MINUTE: t(i18n, 'orderForm.m', '1m', { number: 1 }),
+        FIVE_MINUTES: t(i18n, 'orderForm.m', '5m', { number: 5 }),
+        FIFTEEN_MINUTES: t(i18n, 'orderForm.m', '15m', { number: 15 }),
+        THIRTY_MINUTES: t(i18n, 'orderForm.m', '30m', { number: 30 }),
+        ONE_HOUR: t(i18n, 'orderForm.h', '1h', { number: 1 }),
+        THREE_HOURS: t(i18n, 'orderForm.h', '3h', { number: 3 }),
+        SIX_HOURS: t(i18n, 'orderForm.h', '6h', { number: 6 }),
+        TWELVE_HOURS: t(i18n, 'orderForm.h', '12h', { number: 12 }),
+        ONE_DAY: t(i18n, 'orderForm.D', '1D', { number: 1 }),
+        SEVEN_DAYS: t(i18n, 'orderForm.D', '7D', { number: 7 }),
+        FOURTEEN_DAYS: t(i18n, 'orderForm.D', '14D', { number: 14 }),
+        ONE_MONTH: t(i18n, 'orderForm.M', '1M', { number: 1 })
       },
       visible: {
         capType: { eq: 'SMA' }
@@ -442,21 +445,21 @@ const getUIDef = () => ({
 
     capIndicatorTFEMA: {
       component: 'input.dropdown',
-      label: 'EMA Candle Time Frame',
+      label: t(i18n, 'orderForm.emaCandleTimeFrame', 'EMA Candle Time Frame'),
       default: 'ONE_HOUR',
       options: {
-        ONE_MINUTE: '1m',
-        FIVE_MINUTES: '5m',
-        FIFTEEN_MINUTES: '15m',
-        THIRTY_MINUTES: '30m',
-        ONE_HOUR: '1h',
-        THREE_HOURS: '3h',
-        SIX_HOURS: '6h',
-        TWELVE_HOURS: '12h',
-        ONE_DAY: '1D',
-        SEVEN_DAYS: '7D',
-        FOURTEEN_DAYS: '14D',
-        ONE_MONTH: '1M'
+        ONE_MINUTE: t(i18n, 'orderForm.m', '1m', { number: 1 }),
+        FIVE_MINUTES: t(i18n, 'orderForm.m', '5m', { number: 5 }),
+        FIFTEEN_MINUTES: t(i18n, 'orderForm.m', '15m', { number: 15 }),
+        THIRTY_MINUTES: t(i18n, 'orderForm.m', '30m', { number: 30 }),
+        ONE_HOUR: t(i18n, 'orderForm.h', '1h', { number: 1 }),
+        THREE_HOURS: t(i18n, 'orderForm.h', '3h', { number: 3 }),
+        SIX_HOURS: t(i18n, 'orderForm.h', '6h', { number: 6 }),
+        TWELVE_HOURS: t(i18n, 'orderForm.h', '12h', { number: 12 }),
+        ONE_DAY: t(i18n, 'orderForm.D', '1D', { number: 1 }),
+        SEVEN_DAYS: t(i18n, 'orderForm.D', '7D', { number: 7 }),
+        FOURTEEN_DAYS: t(i18n, 'orderForm.D', '14D', { number: 14 }),
+        ONE_MONTH: t(i18n, 'orderForm.M', '1M', { number: 1 })
       },
       visible: {
         capType: { eq: 'EMA' }
@@ -465,7 +468,7 @@ const getUIDef = () => ({
 
     lev: {
       component: 'input.range',
-      label: 'Leverage',
+      label: t(i18n, 'leverage', 'Leverage'),
       min: 1,
       max: 100,
       default: 10
@@ -473,10 +476,10 @@ const getUIDef = () => ({
 
     action: {
       component: 'input.radio',
-      label: 'Action',
-      options: ['Buy', 'Sell'],
+      label: t(i18n, 'orderForm.action', 'Action'),
+      options: [t(i18n, 'orderForm.buy', 'Buy'), t(i18n, 'orderForm.sell', 'Sell')],
       inline: true,
-      default: 'Buy'
+      default: t(i18n, 'orderForm.buy', 'Buy')
     }
   },
 

--- a/lib/accumulate_distribute/meta/get_ui_def.js
+++ b/lib/accumulate_distribute/meta/get_ui_def.js
@@ -12,11 +12,11 @@ const { t } = require('../../util/i18n')
  * @returns {AOUIDefinition} uiDef
  */
 const getUIDef = ({ i18n } = {}) => ({
-  label: t(i18n, 'orderForm.accdist.title', 'Accumulate/Distribute'),
+  label: t(i18n, 'accdist.title', 'Accumulate/Distribute'),
   id: 'bfx-accumulate_distribute',
 
   uiIcon: 'distribute-active',
-  customHelp: t(i18n, 'orderForm.accdist.help', [
+  customHelp: t(i18n, 'accdist.help', [
     'Accumulate/Distribute allows you to break up a large order into smaller',
     'randomized chunks, submitted at regular or irregular intervals to minimise',
     'detection by other players in the market.\n\nBy enabling the \'Await Fill\'',
@@ -48,7 +48,7 @@ const getUIDef = ({ i18n } = {}) => ({
       [null, 'limitPrice']
     ]
   }, {
-    title: t(i18n, 'orderForm.priceOffset', 'Price Offset'),
+    title: t(i18n, 'priceOffset', 'Price Offset'),
     name: 'offset',
     fixed: true,
     visible: {
@@ -60,7 +60,7 @@ const getUIDef = ({ i18n } = {}) => ({
     ]
   }, {
     name: 'offsetIndicatorSMA',
-    title: t(i18n, 'orderForm.priceOffsetSMA', 'Price Offset SMA'),
+    title: t(i18n, 'priceOffsetSMA', 'Price Offset SMA'),
     fixed: true,
     visible: {
       orderType: { eq: 'RELATIVE' },
@@ -72,7 +72,7 @@ const getUIDef = ({ i18n } = {}) => ({
     ]
   }, {
     name: 'offsetIndicatorEMA',
-    title: t(i18n, 'orderForm.priceOffsetEMA', 'Price Offset EMA'),
+    title: t(i18n, 'priceOffsetEMA', 'Price Offset EMA'),
     fixed: true,
     visible: {
       orderType: { eq: 'RELATIVE' },
@@ -83,7 +83,7 @@ const getUIDef = ({ i18n } = {}) => ({
       [null, 'offsetIndicatorTFEMA']
     ]
   }, {
-    title: t(i18n, 'orderForm.priceCap', 'Price Cap'),
+    title: t(i18n, 'priceCap', 'Price Cap'),
     name: 'cap',
     fixed: true,
     visible: {
@@ -94,7 +94,7 @@ const getUIDef = ({ i18n } = {}) => ({
       ['capType', 'capDelta']
     ]
   }, {
-    title: t(i18n, 'orderForm.priceCapSMA', 'Price Cap SMA'),
+    title: t(i18n, 'priceCapSMA', 'Price Cap SMA'),
     name: 'capIndicatorSMA',
     fixed: true,
     visible: {
@@ -106,7 +106,7 @@ const getUIDef = ({ i18n } = {}) => ({
       [null, 'capIndicatorTFSMA']
     ]
   }, {
-    title: t(i18n, 'orderForm.priceCapEMA', 'Price Cap EMA'),
+    title: t(i18n, 'priceCapEMA', 'Price Cap EMA'),
     name: 'capIndicatorEMA',
     fixed: true,
     visible: {
@@ -139,9 +139,9 @@ const getUIDef = ({ i18n } = {}) => ({
     // General section/header
     postonly: {
       component: 'input.checkbox',
-      label: t(i18n, 'orderForm.postOnly', 'Post-Only'),
+      label: t(i18n, 'postOnly', 'Post-Only'),
       default: false,
-      customHelp: t(i18n, 'orderForm.postOnly.help', `"Post Only" limit orders are orders that allow you to be sure to always pay the maker fee.
+      customHelp: t(i18n, 'postOnly.help', `"Post Only" limit orders are orders that allow you to be sure to always pay the maker fee.
       When placed, a "Post Only" limit order is either inserted into the orderbook or cancelled and not matched
       with a pre-existing order`),
       disabled: {
@@ -151,73 +151,73 @@ const getUIDef = ({ i18n } = {}) => ({
 
     catchUp: {
       component: 'input.checkbox',
-      label: t(i18n, 'orderForm.catchUp', 'Catch Up'),
+      label: t(i18n, 'catchUp', 'Catch Up'),
       default: true,
-      customHelp: t(i18n, 'orderForm.catchUp.help', 'If the algo falls behind in filling orders, disregard the slice interval and submit the next order after a 2 second delay')
+      customHelp: t(i18n, 'catchUp.help', 'If the algo falls behind in filling orders, disregard the slice interval and submit the next order after a 2 second delay')
     },
 
     awaitFill: {
       component: 'input.checkbox',
-      label: t(i18n, 'orderForm.awaitFill', 'Await Fill'),
+      label: t(i18n, 'awaitFill', 'Await Fill'),
       default: true,
-      customHelp: t(i18n, 'orderForm.awaitFill.help', 'Keeps the current order open until it fills, while tracking progress for \'Catch up\'')
+      customHelp: t(i18n, 'awaitFill.help', 'Keeps the current order open until it fills, while tracking progress for \'Catch up\'')
     },
 
     hidden: {
       component: 'input.checkbox',
-      label: t(i18n, 'orderForm.hidden', 'HIDDEN'),
+      label: t(i18n, 'hidden', 'HIDDEN'),
       default: false,
-      customHelp: t(i18n, 'orderForm.hidden.help', `This option allows you to place an order into the book but not have it displayed to
+      customHelp: t(i18n, 'hidden.help', `This option allows you to place an order into the book but not have it displayed to
       other traders. Price/time priority is the same as a displayed order, but the hidden order will
       always pay the "taker" fee while those trading against a hidden order will pay the "maker" fee`)
     },
 
     orderType: {
       component: 'input.dropdown',
-      label: t(i18n, 'orderForm.orderType', 'Order Type'),
+      label: t(i18n, 'orderType', 'Order Type'),
       default: 'MARKET',
       options: {
-        LIMIT: t(i18n, 'orderForm.limit', 'Limit'),
-        MARKET: t(i18n, 'orderForm.market', 'Market'),
-        RELATIVE: t(i18n, 'orderForm.relative', 'Relative')
+        LIMIT: t(i18n, 'limit', 'Limit'),
+        MARKET: t(i18n, 'market', 'Market'),
+        RELATIVE: t(i18n, 'relative', 'Relative')
       }
     },
 
     amount: {
       component: 'input.amount',
-      label: `${t(i18n, 'orderForm.amount', 'Amount')} $BASE`,
-      customHelp: t(i18n, 'orderForm.amount.help', 'Total order amount, to be executed slice-by-slice'),
+      label: `${t(i18n, 'amount', 'Amount')} $BASE`,
+      customHelp: t(i18n, 'amount.help', 'Total order amount, to be executed slice-by-slice'),
       priceField: 'limitPrice'
     },
 
     sliceAmount: {
       component: 'input.number',
-      label: `${t(i18n, 'orderForm.sliceAmount', 'Slice Amount')} $BASE`,
-      customHelp: t(i18n, 'orderForm.sliceAmount.help', 'Allows individual buy & sell amounts to be adjusted')
+      label: `${t(i18n, 'sliceAmount', 'Slice Amount')} $BASE`,
+      customHelp: t(i18n, 'sliceAmount.help', 'Allows individual buy & sell amounts to be adjusted')
     },
 
     amountDistortion: {
       component: 'input.percent',
-      label: t(i18n, 'orderForm.accdist.amountDistortion', 'Amount Distortion %'),
-      customHelp: t(i18n, 'orderForm.accdist.amountDistortion.help', 'Amount to distort individual order sizes to prevent detection, in percent')
+      label: t(i18n, 'accdist.amountDistortion', 'Amount Distortion %'),
+      customHelp: t(i18n, 'accdist.amountDistortion.help', 'Amount to distort individual order sizes to prevent detection, in percent')
     },
 
     sliceIntervalSec: {
       component: 'input.number',
-      label: t(i18n, 'orderForm.accdist.sliceIntervalSec', 'Slice Interval S'),
-      customHelp: t(i18n, 'orderForm.sliceIntervalSec.help', 'Time to wait between each slice order, in seconds')
+      label: t(i18n, 'accdist.sliceIntervalSec', 'Slice Interval S'),
+      customHelp: t(i18n, 'sliceIntervalSec.help', 'Time to wait between each slice order, in seconds')
     },
 
     intervalDistortion: {
       component: 'input.percent',
-      label: t(i18n, 'orderForm.intervalDistortion', 'Interval Distortion %'),
-      customHelp: t(i18n, 'orderForm.intervalDistortion.help', 'Amount to distort each slice interval, in percent')
+      label: t(i18n, 'intervalDistortion', 'Interval Distortion %'),
+      customHelp: t(i18n, 'intervalDistortion.help', 'Amount to distort each slice interval, in percent')
     },
 
     limitPrice: {
       component: 'input.price',
-      label: `${t(i18n, 'orderForm.limitPrice', 'Price')} $QUOTE`,
-      customHelp: t(i18n, 'orderForm.limitPrice.help', 'Price for LIMIT order type'),
+      label: `${t(i18n, 'limitPrice', 'Price')} $QUOTE`,
+      customHelp: t(i18n, 'limitPrice.help', 'Price for LIMIT order type'),
       visible: {
         orderType: { eq: 'LIMIT' }
       }
@@ -226,30 +226,30 @@ const getUIDef = ({ i18n } = {}) => ({
     // Offset section
     offsetType: {
       component: 'input.dropdown',
-      label: t(i18n, 'orderForm.offsetType', 'Offset Type'),
+      label: t(i18n, 'offsetType', 'Offset Type'),
       default: 'MID',
-      customHelp: t(i18n, 'orderForm.offsetType.help', 'Relative order price as offset from an indicator/book/last trade'),
+      customHelp: t(i18n, 'offsetType.help', 'Relative order price as offset from an indicator/book/last trade'),
       options: {
-        BID: t(i18n, 'orderForm.topBid', 'Top Bid'),
-        ASK: t(i18n, 'orderForm.topAsk', 'Top Ask'),
-        MID: t(i18n, 'orderForm.bookMidPrice', 'Book Mid Price'),
-        TRADE: t(i18n, 'orderForm.lastTradePrice', 'Last Trade Price'),
-        SMA: t(i18n, 'orderForm.simpleMovingAverage', 'Simple Moving Average'),
-        EMA: t(i18n, 'orderForm.expMovingAverage', 'Exp Moving Average')
+        BID: t(i18n, 'topBid', 'Top Bid'),
+        ASK: t(i18n, 'topAsk', 'Top Ask'),
+        MID: t(i18n, 'bookMidPrice', 'Book Mid Price'),
+        TRADE: t(i18n, 'lastTradePrice', 'Last Trade Price'),
+        SMA: t(i18n, 'simpleMovingAverage', 'Simple Moving Average'),
+        EMA: t(i18n, 'expMovingAverage', 'Exp Moving Average')
       }
     },
 
     offsetDelta: {
       component: 'input.number',
-      label: t(i18n, 'orderForm.offsetDelta', 'Offset Delta'),
-      customHelp: t(i18n, 'orderForm.offsetDelta.help', 'Price as distance from offset value'),
+      label: t(i18n, 'offsetDelta', 'Offset Delta'),
+      customHelp: t(i18n, 'offsetDelta.help', 'Price as distance from offset value'),
       default: 0
     },
 
     offsetIndicatorPeriodSMA: {
       component: 'input.number',
-      label: t(i18n, 'orderForm.smaPeriod', 'SMA Period'),
-      customHelp: t(i18n, 'orderForm.smaPeriod.help', 'Period for simple moving average indicator'),
+      label: t(i18n, 'smaPeriod', 'SMA Period'),
+      customHelp: t(i18n, 'smaPeriod.help', 'Period for simple moving average indicator'),
       visible: {
         offsetType: { eq: 'SMA' }
       }
@@ -257,13 +257,13 @@ const getUIDef = ({ i18n } = {}) => ({
 
     offsetIndicatorPriceSMA: {
       component: 'input.dropdown',
-      label: t(i18n, 'orderForm.smaCandlePrice', 'SMA Candle Price'),
+      label: t(i18n, 'smaCandlePrice', 'SMA Candle Price'),
       default: 'CLOSE',
       options: {
-        OPEN: t(i18n, 'orderForm.open', 'Open'),
-        HIGH: t(i18n, 'orderForm.high', 'High'),
-        LOW: t(i18n, 'orderForm.low', 'Low'),
-        CLOSE: t(i18n, 'orderForm.close', 'Close')
+        OPEN: t(i18n, 'open', 'Open'),
+        HIGH: t(i18n, 'high', 'High'),
+        LOW: t(i18n, 'low', 'Low'),
+        CLOSE: t(i18n, 'close', 'Close')
       },
 
       visible: {
@@ -273,8 +273,8 @@ const getUIDef = ({ i18n } = {}) => ({
 
     offsetIndicatorPeriodEMA: {
       component: 'input.number',
-      label: t(i18n, 'orderForm.emaPeriod', 'EMA Period'),
-      customHelp: t(i18n, 'orderForm.emaPeriod.help', 'Period for exponential moving average indicator'),
+      label: t(i18n, 'emaPeriod', 'EMA Period'),
+      customHelp: t(i18n, 'emaPeriod.help', 'Period for exponential moving average indicator'),
       visible: {
         offsetType: { eq: 'EMA' }
       }
@@ -282,13 +282,13 @@ const getUIDef = ({ i18n } = {}) => ({
 
     offsetIndicatorPriceEMA: {
       component: 'input.dropdown',
-      label: t(i18n, 'orderForm.emaCandlePrice', 'EMA Candle Price'),
+      label: t(i18n, 'emaCandlePrice', 'EMA Candle Price'),
       default: 'CLOSE',
       options: {
-        OPEN: t(i18n, 'orderForm.open', 'Open'),
-        HIGH: t(i18n, 'orderForm.high', 'High'),
-        LOW: t(i18n, 'orderForm.low', 'Low'),
-        CLOSE: t(i18n, 'orderForm.close', 'Close')
+        OPEN: t(i18n, 'open', 'Open'),
+        HIGH: t(i18n, 'high', 'High'),
+        LOW: t(i18n, 'low', 'Low'),
+        CLOSE: t(i18n, 'close', 'Close')
       },
 
       visible: {
@@ -298,21 +298,21 @@ const getUIDef = ({ i18n } = {}) => ({
 
     offsetIndicatorTFSMA: {
       component: 'input.dropdown',
-      label: t(i18n, 'orderForm.smaCandleTimeFrame', 'SMA Candle Time Frame'),
+      label: t(i18n, 'smaCandleTimeFrame', 'SMA Candle Time Frame'),
       default: 'ONE_HOUR',
       options: {
-        ONE_MINUTE: t(i18n, 'orderForm.m', '1m', { number: 1 }),
-        FIVE_MINUTES: t(i18n, 'orderForm.m', '5m', { number: 5 }),
-        FIFTEEN_MINUTES: t(i18n, 'orderForm.m', '15m', { number: 15 }),
-        THIRTY_MINUTES: t(i18n, 'orderForm.m', '30m', { number: 30 }),
-        ONE_HOUR: t(i18n, 'orderForm.h', '1h', { number: 1 }),
-        THREE_HOURS: t(i18n, 'orderForm.h', '3h', { number: 3 }),
-        SIX_HOURS: t(i18n, 'orderForm.h', '6h', { number: 6 }),
-        TWELVE_HOURS: t(i18n, 'orderForm.h', '12h', { number: 12 }),
-        ONE_DAY: t(i18n, 'orderForm.D', '1D', { number: 1 }),
-        SEVEN_DAYS: t(i18n, 'orderForm.D', '7D', { number: 7 }),
-        FOURTEEN_DAYS: t(i18n, 'orderForm.D', '14D', { number: 14 }),
-        ONE_MONTH: t(i18n, 'orderForm.M', '1M', { number: 1 })
+        ONE_MINUTE: t(i18n, 'm', '1m', { number: 1 }),
+        FIVE_MINUTES: t(i18n, 'm', '5m', { number: 5 }),
+        FIFTEEN_MINUTES: t(i18n, 'm', '15m', { number: 15 }),
+        THIRTY_MINUTES: t(i18n, 'm', '30m', { number: 30 }),
+        ONE_HOUR: t(i18n, 'h', '1h', { number: 1 }),
+        THREE_HOURS: t(i18n, 'h', '3h', { number: 3 }),
+        SIX_HOURS: t(i18n, 'h', '6h', { number: 6 }),
+        TWELVE_HOURS: t(i18n, 'h', '12h', { number: 12 }),
+        ONE_DAY: t(i18n, 'D', '1D', { number: 1 }),
+        SEVEN_DAYS: t(i18n, 'D', '7D', { number: 7 }),
+        FOURTEEN_DAYS: t(i18n, 'D', '14D', { number: 14 }),
+        ONE_MONTH: t(i18n, 'M', '1M', { number: 1 })
       },
 
       visible: {
@@ -322,21 +322,21 @@ const getUIDef = ({ i18n } = {}) => ({
 
     offsetIndicatorTFEMA: {
       component: 'input.dropdown',
-      label: t(i18n, 'orderForm.emaCandleTimeFrame', 'EMA Candle Time Frame'),
+      label: t(i18n, 'emaCandleTimeFrame', 'EMA Candle Time Frame'),
       default: 'ONE_HOUR',
       options: {
-        ONE_MINUTE: t(i18n, 'orderForm.m', '1m', { number: 1 }),
-        FIVE_MINUTES: t(i18n, 'orderForm.m', '5m', { number: 5 }),
-        FIFTEEN_MINUTES: t(i18n, 'orderForm.m', '15m', { number: 15 }),
-        THIRTY_MINUTES: t(i18n, 'orderForm.m', '30m', { number: 30 }),
-        ONE_HOUR: t(i18n, 'orderForm.h', '1h', { number: 1 }),
-        THREE_HOURS: t(i18n, 'orderForm.h', '3h', { number: 3 }),
-        SIX_HOURS: t(i18n, 'orderForm.h', '6h', { number: 6 }),
-        TWELVE_HOURS: t(i18n, 'orderForm.h', '12h', { number: 12 }),
-        ONE_DAY: t(i18n, 'orderForm.D', '1D', { number: 1 }),
-        SEVEN_DAYS: t(i18n, 'orderForm.D', '7D', { number: 7 }),
-        FOURTEEN_DAYS: t(i18n, 'orderForm.D', '14D', { number: 14 }),
-        ONE_MONTH: t(i18n, 'orderForm.M', '1M', { number: 1 })
+        ONE_MINUTE: t(i18n, 'm', '1m', { number: 1 }),
+        FIVE_MINUTES: t(i18n, 'm', '5m', { number: 5 }),
+        FIFTEEN_MINUTES: t(i18n, 'm', '15m', { number: 15 }),
+        THIRTY_MINUTES: t(i18n, 'm', '30m', { number: 30 }),
+        ONE_HOUR: t(i18n, 'h', '1h', { number: 1 }),
+        THREE_HOURS: t(i18n, 'h', '3h', { number: 3 }),
+        SIX_HOURS: t(i18n, 'h', '6h', { number: 6 }),
+        TWELVE_HOURS: t(i18n, 'h', '12h', { number: 12 }),
+        ONE_DAY: t(i18n, 'D', '1D', { number: 1 }),
+        SEVEN_DAYS: t(i18n, 'D', '7D', { number: 7 }),
+        FOURTEEN_DAYS: t(i18n, 'D', '14D', { number: 14 }),
+        ONE_MONTH: t(i18n, 'M', '1M', { number: 1 })
       },
 
       visible: {
@@ -347,24 +347,24 @@ const getUIDef = ({ i18n } = {}) => ({
     // Cap section
     capType: {
       component: 'input.dropdown',
-      label: t(i18n, 'orderForm.priceCapType', 'Price Cap Type'),
+      label: t(i18n, 'priceCapType', 'Price Cap Type'),
       default: 'MID',
-      customHelp: t(i18n, 'orderForm.priceCapType.help', 'Upper price limit for relative order type'),
+      customHelp: t(i18n, 'priceCapType.help', 'Upper price limit for relative order type'),
       options: {
-        BID: t(i18n, 'orderForm.topBid', 'Top Bid'),
-        ASK: t(i18n, 'orderForm.topAsk', 'Top Ask'),
-        MID: t(i18n, 'orderForm.bookMidPrice', 'Book Mid Price'),
-        TRADE: t(i18n, 'orderForm.lastTradePrice', 'Last Trade Price'),
-        SMA: t(i18n, 'orderForm.simpleMovingAverage', 'Simple Moving Average'),
-        EMA: t(i18n, 'orderForm.expMovingAverage', 'Exp Moving Average'),
-        NONE: t(i18n, 'orderForm.none', 'None')
+        BID: t(i18n, 'topBid', 'Top Bid'),
+        ASK: t(i18n, 'topAsk', 'Top Ask'),
+        MID: t(i18n, 'bookMidPrice', 'Book Mid Price'),
+        TRADE: t(i18n, 'lastTradePrice', 'Last Trade Price'),
+        SMA: t(i18n, 'simpleMovingAverage', 'Simple Moving Average'),
+        EMA: t(i18n, 'expMovingAverage', 'Exp Moving Average'),
+        NONE: t(i18n, 'none', 'None')
       }
     },
 
     capDelta: {
       component: 'input.number',
-      label: t(i18n, 'orderForm.capDelta', 'Cap Delta'),
-      customHelp: t(i18n, 'orderForm.capDelta.help', 'Price as distance from cap value'),
+      label: t(i18n, 'capDelta', 'Cap Delta'),
+      customHelp: t(i18n, 'capDelta.help', 'Price as distance from cap value'),
       default: 0,
 
       disabled: {
@@ -374,8 +374,8 @@ const getUIDef = ({ i18n } = {}) => ({
 
     capIndicatorPeriodSMA: {
       component: 'input.number',
-      label: t(i18n, 'orderForm.smaPeriod', 'SMA Period'),
-      customHelp: t(i18n, 'orderForm.smaPeriod.help', 'Period for moving average indicator'),
+      label: t(i18n, 'smaPeriod', 'SMA Period'),
+      customHelp: t(i18n, 'smaPeriod.help', 'Period for moving average indicator'),
       visible: {
         capType: { eq: 'SMA' }
       }
@@ -383,13 +383,13 @@ const getUIDef = ({ i18n } = {}) => ({
 
     capIndicatorPriceSMA: {
       component: 'input.dropdown',
-      label: t(i18n, 'orderForm.smaCandlePrice', 'SMA Candle Price'),
+      label: t(i18n, 'smaCandlePrice', 'SMA Candle Price'),
       default: 'CLOSE',
       options: {
-        OPEN: t(i18n, 'orderForm.open', 'Open'),
-        HIGH: t(i18n, 'orderForm.high', 'High'),
-        LOW: t(i18n, 'orderForm.low', 'Low'),
-        CLOSE: t(i18n, 'orderForm.close', 'Close')
+        OPEN: t(i18n, 'open', 'Open'),
+        HIGH: t(i18n, 'high', 'High'),
+        LOW: t(i18n, 'low', 'Low'),
+        CLOSE: t(i18n, 'close', 'Close')
       },
       visible: {
         capType: { eq: 'SMA' }
@@ -398,8 +398,8 @@ const getUIDef = ({ i18n } = {}) => ({
 
     capIndicatorPeriodEMA: {
       component: 'input.number',
-      label: t(i18n, 'orderForm.emaPeriod', 'EMA Period'),
-      customHelp: t(i18n, 'orderForm.emaPeriod.help', 'Period for exponential moving average indicator'),
+      label: t(i18n, 'emaPeriod', 'EMA Period'),
+      customHelp: t(i18n, 'emaPeriod.help', 'Period for exponential moving average indicator'),
       visible: {
         capType: { eq: 'EMA' }
       }
@@ -407,13 +407,13 @@ const getUIDef = ({ i18n } = {}) => ({
 
     capIndicatorPriceEMA: {
       component: 'input.dropdown',
-      label: t(i18n, 'orderForm.emaCandlePrice', 'EMA Candle Price'),
+      label: t(i18n, 'emaCandlePrice', 'EMA Candle Price'),
       default: 'CLOSE',
       options: {
-        OPEN: t(i18n, 'orderForm.open', 'Open'),
-        HIGH: t(i18n, 'orderForm.high', 'High'),
-        LOW: t(i18n, 'orderForm.low', 'Low'),
-        CLOSE: t(i18n, 'orderForm.close', 'Close')
+        OPEN: t(i18n, 'open', 'Open'),
+        HIGH: t(i18n, 'high', 'High'),
+        LOW: t(i18n, 'low', 'Low'),
+        CLOSE: t(i18n, 'close', 'Close')
       },
       visible: {
         capType: { eq: 'EMA' }
@@ -422,21 +422,21 @@ const getUIDef = ({ i18n } = {}) => ({
 
     capIndicatorTFSMA: {
       component: 'input.dropdown',
-      label: t(i18n, 'orderForm.smaCandleTimeFrame', 'SMA Candle Time Frame'),
+      label: t(i18n, 'smaCandleTimeFrame', 'SMA Candle Time Frame'),
       default: 'ONE_HOUR',
       options: {
-        ONE_MINUTE: t(i18n, 'orderForm.m', '1m', { number: 1 }),
-        FIVE_MINUTES: t(i18n, 'orderForm.m', '5m', { number: 5 }),
-        FIFTEEN_MINUTES: t(i18n, 'orderForm.m', '15m', { number: 15 }),
-        THIRTY_MINUTES: t(i18n, 'orderForm.m', '30m', { number: 30 }),
-        ONE_HOUR: t(i18n, 'orderForm.h', '1h', { number: 1 }),
-        THREE_HOURS: t(i18n, 'orderForm.h', '3h', { number: 3 }),
-        SIX_HOURS: t(i18n, 'orderForm.h', '6h', { number: 6 }),
-        TWELVE_HOURS: t(i18n, 'orderForm.h', '12h', { number: 12 }),
-        ONE_DAY: t(i18n, 'orderForm.D', '1D', { number: 1 }),
-        SEVEN_DAYS: t(i18n, 'orderForm.D', '7D', { number: 7 }),
-        FOURTEEN_DAYS: t(i18n, 'orderForm.D', '14D', { number: 14 }),
-        ONE_MONTH: t(i18n, 'orderForm.M', '1M', { number: 1 })
+        ONE_MINUTE: t(i18n, 'm', '1m', { number: 1 }),
+        FIVE_MINUTES: t(i18n, 'm', '5m', { number: 5 }),
+        FIFTEEN_MINUTES: t(i18n, 'm', '15m', { number: 15 }),
+        THIRTY_MINUTES: t(i18n, 'm', '30m', { number: 30 }),
+        ONE_HOUR: t(i18n, 'h', '1h', { number: 1 }),
+        THREE_HOURS: t(i18n, 'h', '3h', { number: 3 }),
+        SIX_HOURS: t(i18n, 'h', '6h', { number: 6 }),
+        TWELVE_HOURS: t(i18n, 'h', '12h', { number: 12 }),
+        ONE_DAY: t(i18n, 'D', '1D', { number: 1 }),
+        SEVEN_DAYS: t(i18n, 'D', '7D', { number: 7 }),
+        FOURTEEN_DAYS: t(i18n, 'D', '14D', { number: 14 }),
+        ONE_MONTH: t(i18n, 'M', '1M', { number: 1 })
       },
       visible: {
         capType: { eq: 'SMA' }
@@ -445,21 +445,21 @@ const getUIDef = ({ i18n } = {}) => ({
 
     capIndicatorTFEMA: {
       component: 'input.dropdown',
-      label: t(i18n, 'orderForm.emaCandleTimeFrame', 'EMA Candle Time Frame'),
+      label: t(i18n, 'emaCandleTimeFrame', 'EMA Candle Time Frame'),
       default: 'ONE_HOUR',
       options: {
-        ONE_MINUTE: t(i18n, 'orderForm.m', '1m', { number: 1 }),
-        FIVE_MINUTES: t(i18n, 'orderForm.m', '5m', { number: 5 }),
-        FIFTEEN_MINUTES: t(i18n, 'orderForm.m', '15m', { number: 15 }),
-        THIRTY_MINUTES: t(i18n, 'orderForm.m', '30m', { number: 30 }),
-        ONE_HOUR: t(i18n, 'orderForm.h', '1h', { number: 1 }),
-        THREE_HOURS: t(i18n, 'orderForm.h', '3h', { number: 3 }),
-        SIX_HOURS: t(i18n, 'orderForm.h', '6h', { number: 6 }),
-        TWELVE_HOURS: t(i18n, 'orderForm.h', '12h', { number: 12 }),
-        ONE_DAY: t(i18n, 'orderForm.D', '1D', { number: 1 }),
-        SEVEN_DAYS: t(i18n, 'orderForm.D', '7D', { number: 7 }),
-        FOURTEEN_DAYS: t(i18n, 'orderForm.D', '14D', { number: 14 }),
-        ONE_MONTH: t(i18n, 'orderForm.M', '1M', { number: 1 })
+        ONE_MINUTE: t(i18n, 'm', '1m', { number: 1 }),
+        FIVE_MINUTES: t(i18n, 'm', '5m', { number: 5 }),
+        FIFTEEN_MINUTES: t(i18n, 'm', '15m', { number: 15 }),
+        THIRTY_MINUTES: t(i18n, 'm', '30m', { number: 30 }),
+        ONE_HOUR: t(i18n, 'h', '1h', { number: 1 }),
+        THREE_HOURS: t(i18n, 'h', '3h', { number: 3 }),
+        SIX_HOURS: t(i18n, 'h', '6h', { number: 6 }),
+        TWELVE_HOURS: t(i18n, 'h', '12h', { number: 12 }),
+        ONE_DAY: t(i18n, 'D', '1D', { number: 1 }),
+        SEVEN_DAYS: t(i18n, 'D', '7D', { number: 7 }),
+        FOURTEEN_DAYS: t(i18n, 'D', '14D', { number: 14 }),
+        ONE_MONTH: t(i18n, 'M', '1M', { number: 1 })
       },
       visible: {
         capType: { eq: 'EMA' }
@@ -476,10 +476,10 @@ const getUIDef = ({ i18n } = {}) => ({
 
     action: {
       component: 'input.radio',
-      label: t(i18n, 'orderForm.action', 'Action'),
-      options: [t(i18n, 'orderForm.buy', 'Buy'), t(i18n, 'orderForm.sell', 'Sell')],
+      label: t(i18n, 'action', 'Action'),
+      options: [t(i18n, 'buy', 'Buy'), t(i18n, 'sell', 'Sell')],
       inline: true,
-      default: t(i18n, 'orderForm.buy', 'Buy')
+      default: t(i18n, 'buy', 'Buy')
     }
   },
 

--- a/lib/accumulate_distribute/meta/validate_params.js
+++ b/lib/accumulate_distribute/meta/validate_params.js
@@ -6,6 +6,7 @@ const _isObject = require('lodash/isObject')
 const _isBoolean = require('lodash/isBoolean')
 const _includes = require('lodash/includes')
 const validationErrObj = require('../../util/validate_params_err')
+const { apply: applyI18N } = require('../../util/i18n')
 
 const ORDER_TYPES = ['MARKET', 'LIMIT', 'RELATIVE']
 
@@ -53,37 +54,92 @@ const validateParams = (args = {}, pairConfig = {}) => {
     relativeCap, catchUp, awaitFill, postonly, lev, _futures
   } = args
 
-  if (!_includes(ORDER_TYPES, orderType)) return validationErrObj('orderType', `Invalid order type: ${orderType}`)
-  if (!_isFinite(amount) || amount === 0) return validationErrObj('amount', 'Invalid amount')
-  if (!_isFinite(sliceAmount) || sliceAmount === 0) return validationErrObj('sliceAmount', 'Invalid slice amount')
-  if (!_isBoolean(catchUp)) return validationErrObj('catchUp', 'Bool catch up flag required')
-  if (!_isBoolean(awaitFill)) return validationErrObj('awaitFill', 'Bool await fill flag required')
-  if (!_isFinite(sliceInterval) || sliceInterval <= 0) return validationErrObj('sliceIntervalSec', 'Invalid slice interval')
-  if (!_isFinite(intervalDistortion)) return validationErrObj('intervalDistortion', 'Invalid interval distortion')
-  if (!_isFinite(amountDistortion)) return validationErrObj('amountDistortion', 'Invalid amount distortion')
+  if (!_includes(ORDER_TYPES, orderType)) {
+    return applyI18N(
+      validationErrObj('orderType', `Invalid order type: ${orderType}`),
+      'invalidOrderType', { orderType }
+    )
+  }
+  if (!_isFinite(amount) || amount === 0) {
+    return applyI18N(
+      validationErrObj('amount', 'Invalid amount'),
+      'invalidAmount'
+    )
+  }
+  if (!_isFinite(sliceAmount) || sliceAmount === 0) {
+    return applyI18N(
+      validationErrObj('sliceAmount', 'Invalid slice amount'),
+      'invalidSliceAmount'
+    )
+  }
+  if (!_isBoolean(catchUp)) {
+    return applyI18N(
+      validationErrObj('catchUp', 'Bool catch up flag required'),
+      'boolCatchUpFlagRequired'
+    )
+  }
+  if (!_isBoolean(awaitFill)) {
+    return applyI18N(
+      validationErrObj('awaitFill', 'Bool await fill flag required'),
+      'boolAwaitFillFlagRequired'
+    )
+  }
+  if (!_isFinite(sliceInterval) || sliceInterval <= 0) {
+    return applyI18N(
+      validationErrObj('sliceIntervalSec', 'Invalid slice interval'),
+      'invalidSliceInterval'
+    )
+  }
+  if (!_isFinite(intervalDistortion)) {
+    return applyI18N(
+      validationErrObj('intervalDistortion', 'Invalid interval distortion'),
+      'invalidIntervalDistortion'
+    )
+  }
+  if (!_isFinite(amountDistortion)) {
+    return applyI18N(
+      validationErrObj('amountDistortion', 'Invalid amount distortion'),
+      'invalidAmountDistortion'
+    )
+  }
 
   if (
     (amount < 0 && sliceAmount >= 0) ||
     (amount > 0 && sliceAmount <= 0)
   ) {
-    return validationErrObj('sliceAmount', 'Amount & slice amount must have same sign')
+    return applyI18N(
+      validationErrObj('sliceAmount', 'Amount & slice amount must have same sign'),
+      'amountSliceAmountMustHaveSameSign'
+    )
   }
 
   if (Math.abs(sliceAmount) > Math.abs(amount)) {
-    return validationErrObj('sliceAmount', 'Slice amount cannot be greater than amount')
+    return applyI18N(
+      validationErrObj('sliceAmount', 'Slice amount cannot be greater than amount'),
+      'sliceAmountCannotBeGreaterThanAmount'
+    )
   }
 
   if (orderType === 'LIMIT' && !_isFinite(limitPrice)) {
-    return validationErrObj('limitPrice', 'Limit price required for LIMIT order type')
+    return applyI18N(
+      validationErrObj('limitPrice', 'Limit price required for LIMIT order type'),
+      'limitPriceRequiredForLimitOrderType'
+    )
   }
 
   if (orderType === 'LIMIT' && !_isBoolean(postonly)) {
-    return validationErrObj('postonly', 'Post only flag required for LIMIT order type')
+    return applyI18N(
+      validationErrObj('postonly', 'Post only flag required for LIMIT order type'),
+      'postOnlyFlagRequiredForLimitOrderType'
+    )
   }
 
   if (_isObject(relativeCap)) {
     if (!_isFinite(relativeCap.delta)) {
-      return validationErrObj('capDelta', 'Invalid relative cap delta')
+      return applyI18N(
+        validationErrObj('capDelta', 'Invalid relative cap delta'),
+        'invalidRelativeCapDelta'
+      )
     }
 
     if ((relativeCap.type === 'sma') || (relativeCap.type === 'ema')) {
@@ -91,26 +147,47 @@ const validateParams = (args = {}, pairConfig = {}) => {
       const capitalizedType = type.toUpperCase()
 
       if (args.length !== 1) {
-        return validationErrObj(`capIndicatorPeriod${capitalizedType}`, `${capitalizedType} period required for relative cap indicator`)
+        return applyI18N(
+          validationErrObj(`capIndicatorPeriod${capitalizedType}`, `${capitalizedType} period required for relative cap indicator`),
+          'periodRequiredForRelativeCapIndicator', { capitalizedType }
+        )
       } else if (!_isFinite(args[0])) {
-        return validationErrObj(`capIndicatorPeriod${capitalizedType}`, `Invalid relative cap indicator period: ${relativeCap.args[0]}`)
+        return applyI18N(
+          validationErrObj(`capIndicatorPeriod${capitalizedType}`, `Invalid relative cap indicator period: ${relativeCap.args[0]}`),
+          'invalidRelativeCapIndicatorPeriod', { value: relativeCap.args[0] }
+        )
       } else if (args[0] <= 0) {
-        return validationErrObj(`capIndicatorPeriod${capitalizedType}`, 'Invalid relative cap indicator period, please set a positive value')
+        return applyI18N(
+          validationErrObj(`capIndicatorPeriod${capitalizedType}`, 'Invalid relative cap indicator period, please set a positive value'),
+          'invalidRelativeCapIndicatorPeriodPleaseSetAPositiveValue'
+        )
       }
 
       if (!relativeCap.candlePrice) {
-        return validationErrObj(`capIndicatorPrice${capitalizedType}`, 'Candle price required for relative cap indicator')
+        return applyI18N(
+          validationErrObj(`capIndicatorPrice${capitalizedType}`, 'Candle price required for relative cap indicator'),
+          'candlePriceRequiredForRelativeCapIndicator'
+        )
       } else if (!relativeCap.candleTimeFrame) {
-        return validationErrObj(`capIndicatorTF${capitalizedType}`, 'Candle time frame required for relative cap indicator')
+        return applyI18N(
+          validationErrObj(`capIndicatorTF${capitalizedType}`, 'Candle time frame required for relative cap indicator'),
+          'candleTimeFrameRequiredForRelativeCapIndicator'
+        )
       } else if (!TIME_FRAME_WIDTHS[relativeCap.candleTimeFrame]) {
-        return validationErrObj(`capIndicatorTF${capitalizedType}`, `Unrecognized relative cap candle time frame: ${relativeCap.candleTimeFrame}`)
+        return applyI18N(
+          validationErrObj(`capIndicatorTF${capitalizedType}`, `Unrecognized relative cap candle time frame: ${relativeCap.candleTimeFrame}`),
+          'unrecognizedRelativeCapCandleTimeFrame', { value: relativeCap.candleTimeFrame }
+        )
       }
     }
   }
 
   if (_isObject(relativeOffset)) {
     if (!_isFinite(relativeOffset.delta)) {
-      return validationErrObj('offsetDelta', 'Invalid relative offset delta')
+      return applyI18N(
+        validationErrObj('offsetDelta', 'Invalid relative offset delta'),
+        'invalidRelativeOffsetDelta'
+      )
     }
 
     if ((relativeOffset.type === 'sma') || (relativeOffset.type === 'ema')) {
@@ -118,37 +195,90 @@ const validateParams = (args = {}, pairConfig = {}) => {
       const capitalizedType = type.toUpperCase()
 
       if (args.length !== 1) {
-        return validationErrObj(`offsetIndicatorPeriod${capitalizedType}`, `${capitalizedType} period required for relative offset indicator`)
+        return applyI18N(
+          validationErrObj(`offsetIndicatorPeriod${capitalizedType}`, `${capitalizedType} period required for relative offset indicator`),
+          'periodRequiredForRelativeOffsetIndicator'
+        )
       } else if (!_isFinite(args[0])) {
-        return validationErrObj(`offsetIndicatorPeriod${capitalizedType}`, `Invalid relative offset indicator period: ${relativeOffset.args[0]}`)
+        return applyI18N(
+          validationErrObj(`offsetIndicatorPeriod${capitalizedType}`, `Invalid relative offset indicator period: ${relativeOffset.args[0]}`),
+          'invalidRelativeOffsetIndicatorPeriod', { value: relativeOffset.args[0] }
+        )
       } else if (args[0] <= 0) {
-        return validationErrObj(`offsetIndicatorPeriod${capitalizedType}`, 'Invalid relative offset indicator period, please set a positive value')
+        return applyI18N(
+          validationErrObj(`offsetIndicatorPeriod${capitalizedType}`, 'Invalid relative offset indicator period, please set a positive value'),
+          'invalidRelativeOffsetIndicatorPeriodPleaseSetAPositiveValue'
+        )
       }
 
       if (!relativeOffset.candlePrice) {
-        return validationErrObj(`offsetIndicatorPrice${capitalizedType}`, 'Candle price required for relative offset indicator')
+        return applyI18N(
+          validationErrObj(`offsetIndicatorPrice${capitalizedType}`, 'Candle price required for relative offset indicator'),
+          'candlePriceRequiredForRelativeOffsetIndicator'
+        )
       } else if (!relativeOffset.candleTimeFrame) {
-        return validationErrObj(`offsetIndicatorTF${capitalizedType}`, 'Candle time frame required for relative offset indicator')
+        return applyI18N(
+          validationErrObj(`offsetIndicatorTF${capitalizedType}`, 'Candle time frame required for relative offset indicator'),
+          'candleTimeFrameRequiredForRelativeOffsetIndicator'
+        )
       } else if (!TIME_FRAME_WIDTHS[relativeOffset.candleTimeFrame]) {
-        return validationErrObj(`offsetIndicatorTF${capitalizedType}`, `Unrecognized relative offset candle time frame: ${relativeOffset.candleTimeFrame}`)
+        return applyI18N(
+          validationErrObj(`offsetIndicatorTF${capitalizedType}`, `Unrecognized relative offset candle time frame: ${relativeOffset.candleTimeFrame}`),
+          'unrecognizedRelativeOffsetCandleTimeFrame', { value: relativeOffset.candleTimeFrame }
+        )
       }
     }
   }
 
   if (_isFinite(minSize)) {
-    if (Math.abs(amount) < minSize) return validationErrObj('amount', `Amount cannot be less than ${minSize}`)
-    if (Math.abs(sliceAmount) < minSize) return validationErrObj('sliceAmount', `Slice amount cannot be less than ${minSize}`)
+    if (Math.abs(amount) < minSize) {
+      return applyI18N(
+        validationErrObj('amount', `Amount cannot be less than ${minSize}`),
+        'amountCannotBeLessThan', { minSize }
+      )
+    }
+    if (Math.abs(sliceAmount) < minSize) {
+      return applyI18N(
+        validationErrObj('sliceAmount', `Slice amount cannot be less than ${minSize}`),
+        'sliceAmountCannotBeLessThan', { minSize }
+      )
+    }
   }
 
   if (_isFinite(maxSize)) {
-    if (Math.abs(amount) > maxSize) return validationErrObj('amount', `Amount cannot be greater than ${maxSize}`)
-    if (Math.abs(sliceAmount) > maxSize) return validationErrObj('sliceAmount', `Slice amount cannot be greater than ${maxSize}`)
+    if (Math.abs(amount) > maxSize) {
+      return applyI18N(
+        validationErrObj('amount', `Amount cannot be greater than ${maxSize}`),
+        'amountCannotBeGreaterThan', { maxSize }
+      )
+    }
+    if (Math.abs(sliceAmount) > maxSize) {
+      return applyI18N(
+        validationErrObj('sliceAmount', `Slice amount cannot be greater than ${maxSize}`),
+        'sliceAmountCannotBeGreaterThan', { maxSize }
+      )
+    }
   }
 
   if (_futures) {
-    if (!_isFinite(lev)) return validationErrObj('lev', 'Invalid leverage')
-    if (lev < 1) return validationErrObj('lev', 'Leverage cannot be less than 1')
-    if (_isFinite(maxLev) && (lev > maxLev)) return validationErrObj('lev', `Leverage cannot be greater than ${maxLev}`)
+    if (!_isFinite(lev)) {
+      return applyI18N(
+        validationErrObj('lev', 'Invalid leverage'),
+        'invalidLeverage'
+      )
+    }
+    if (lev < 1) {
+      return applyI18N(
+        validationErrObj('lev', 'Leverage cannot be less than 1'),
+        'leverageCannotBeLessThan', { minLev: 1 }
+      )
+    }
+    if (_isFinite(maxLev) && (lev > maxLev)) {
+      return applyI18N(
+        validationErrObj('lev', `Leverage cannot be greater than ${maxLev}`),
+        'leverageCannotBeGreaterThan', { maxLev }
+      )
+    }
   }
 
   return null

--- a/lib/accumulate_distribute/meta/validate_params.js
+++ b/lib/accumulate_distribute/meta/validate_params.js
@@ -197,7 +197,7 @@ const validateParams = (args = {}, pairConfig = {}) => {
       if (args.length !== 1) {
         return applyI18N(
           validationErrObj(`offsetIndicatorPeriod${capitalizedType}`, `${capitalizedType} period required for relative offset indicator`),
-          'periodRequiredForRelativeOffsetIndicator'
+          'periodRequiredForRelativeOffsetIndicator', { type: capitalizedType }
         )
       } else if (!_isFinite(args[0])) {
         return applyI18N(

--- a/lib/ao_host.js
+++ b/lib/ao_host.js
@@ -610,7 +610,7 @@ class AOHost extends AsyncEventEmitter {
    * @param {object} instance - algo order instance that has started
    */
   async _startAlgo (instance = {}) {
-    const { gid, name, label, args } = instance.state
+    const { gid, name, label, args, i18n } = instance.state
 
     instance.state.active = true
 
@@ -624,7 +624,7 @@ class AOHost extends AsyncEventEmitter {
 
     return [
       this.getSerializedAO(instance),
-      { gid, name, label, args }
+      { gid, name, label, args, i18n }
     ]
   }
 

--- a/lib/host/init_ao_state.js
+++ b/lib/host/init_ao_state.js
@@ -36,6 +36,7 @@ module.exports = (aoDef = {}, args = {}, pairConfig = {}) => {
     : {}
 
   const gid = clientID() + ''
+  const label = genOrderLabel ? genOrderLabel({ args: params }) : name
 
   // All AOs and the AO host + helpers depend on the structure below; as such
   // it should be modified with great care
@@ -47,11 +48,14 @@ module.exports = (aoDef = {}, args = {}, pairConfig = {}) => {
     ev: new AsyncEventEmitter(),
     active: false,
     headersForLogFile,
-    label: genOrderLabel ? genOrderLabel({ args: params }) : name,
+    label: _isString(label) ? label : label.origin,
     name,
     args,
     gid,
     id,
+    i18n: !_isString(label) && {
+      label: label.i18n
+    },
 
     ...initialState
   }

--- a/lib/host/init_ao_state.js
+++ b/lib/host/init_ao_state.js
@@ -24,7 +24,10 @@ module.exports = (aoDef = {}, args = {}, pairConfig = {}) => {
     const vError = validateParams(params, pairConfig)
 
     if (vError) {
-      throw new Error(_isString(vError) ? vError : vError.message)
+      const error = new Error(_isString(vError) ? vError : vError.message)
+
+      error.i18n = vError.i18n
+      throw error
     }
   }
 

--- a/lib/iceberg/meta/gen_order_label.js
+++ b/lib/iceberg/meta/gen_order_label.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const { nBN } = require('@bitfinex/lib-js-util-math')
+const { apply: applyI18N } = require('../../util/i18n')
 
 /**
  * Generates a label for an Iceberg instance for rendering in an UI.
@@ -16,16 +17,22 @@ const genOrderLabel = (state = {}) => {
   const { args = {} } = state
   const { amount, price, sliceAmount, excessAsHidden } = args
   const mul = amount < 0 ? -1 : 1
+  const excess = mul * nBN(amount).abs().minus(Math.abs(sliceAmount))
 
-  return [
-    'Iceberg',
-    ` | ${amount} @ ${price} `,
-    ` | slice ${mul * sliceAmount}`,
+  return applyI18N({
+    origin: [
+      'Iceberg',
+      ` | ${amount} @ ${price} `,
+      ` | slice ${mul * sliceAmount}`,
 
-    excessAsHidden
-      ? ` | excess ${mul * nBN(amount).abs().minus(Math.abs(sliceAmount))}`
-      : ''
-  ].join('')
+      excessAsHidden
+        ? ` | excess ${excess}`
+        : ''
+    ].join('')
+  },
+  `iceberg${excessAsHidden ? 'Hidden' : ''}.label`,
+  { amount, price, slice: mul * sliceAmount, excess }
+  )
 }
 
 module.exports = genOrderLabel

--- a/lib/iceberg/meta/get_ui_def.js
+++ b/lib/iceberg/meta/get_ui_def.js
@@ -10,11 +10,11 @@ const { t } = require('../../util/i18n')
  * @returns {AOUIDefinition} uiDef
  */
 const getUIDef = ({ i18n } = {}) => ({
-  label: t(i18n, 'orderForm.iceberg.title', 'Iceberg'),
+  label: t(i18n, 'iceberg.title', 'Iceberg'),
   id: 'bfx-iceberg',
 
   uiIcon: 'iceberg-active',
-  customHelp: t(i18n, 'orderForm.iceberg.help', [
+  customHelp: t(i18n, 'iceberg.help', [
     'Iceberg allows you to place a large order on the market while ensuring',
     'only a small part of it is ever filled at once.\n\nBy enabling the',
     '\'Excess As Hidden\' option, it is possible to offer up the remainder as',
@@ -56,24 +56,24 @@ const getUIDef = ({ i18n } = {}) => ({
   fields: {
     excessAsHidden: {
       component: 'input.checkbox',
-      label: t(i18n, 'orderForm.excessAsHidden', 'Excess as hidden'),
+      label: t(i18n, 'excessAsHidden', 'Excess as hidden'),
       default: true,
-      customHelp: t(i18n, 'orderForm.excessAsHidden.help', 'Create a hidden order for the non-slice amount')
+      customHelp: t(i18n, 'excessAsHidden.help', 'Create a hidden order for the non-slice amount')
     },
 
     orderType: {
       component: 'input.dropdown',
-      label: t(i18n, 'orderForm.orderType', 'Order Type'),
+      label: t(i18n, 'orderType', 'Order Type'),
       default: 'LIMIT',
       options: {
-        LIMIT: t(i18n, 'orderForm.limit', 'Limit'),
-        MARKET: t(i18n, 'orderForm.market', 'Market')
+        LIMIT: t(i18n, 'limit', 'Limit'),
+        MARKET: t(i18n, 'market', 'Market')
       }
     },
 
     price: {
       component: 'input.price',
-      label: `${t(i18n, 'orderForm.price', 'Price')} $QUOTE`,
+      label: `${t(i18n, 'price', 'Price')} $QUOTE`,
       disabled: {
         orderType: { eq: 'MARKET' }
       }
@@ -81,15 +81,15 @@ const getUIDef = ({ i18n } = {}) => ({
 
     amount: {
       component: 'input.amount',
-      label: `${t(i18n, 'orderForm.amount', 'Amount')} $BASE`,
-      customHelp: t(i18n, 'orderForm.amount.help', 'Total order amount, to be executed slice-by-slice'),
+      label: `${t(i18n, 'amount', 'Amount')} $BASE`,
+      customHelp: t(i18n, 'amount.help', 'Total order amount, to be executed slice-by-slice'),
       priceField: 'price'
     },
 
     sliceAmount: {
       component: 'input.number',
-      label: `${t(i18n, 'orderForm.sliceAmount', 'Slice Amount')} $BASE`,
-      customHelp: t(i18n, 'orderForm.sliceAmount.help', 'Allows individual buy & sell amounts to be adjusted'),
+      label: `${t(i18n, 'sliceAmount', 'Slice Amount')} $BASE`,
+      customHelp: t(i18n, 'sliceAmount.help', 'Allows individual buy & sell amounts to be adjusted'),
       disabled: {
         sliceAmountPerc: { gt: 0 }
       }
@@ -97,8 +97,8 @@ const getUIDef = ({ i18n } = {}) => ({
 
     sliceAmountPerc: {
       component: 'input.percent',
-      label: t(i18n, 'orderForm.sliceAmountPerc', 'Slice Amount as %'),
-      customHelp: t(i18n, 'orderForm.sliceAmountPerc.help', 'Takes percentage of total order amount for individual buy & sell amounts'),
+      label: t(i18n, 'sliceAmountPerc', 'Slice Amount as %'),
+      customHelp: t(i18n, 'sliceAmountPerc.help', 'Takes percentage of total order amount for individual buy & sell amounts'),
       disabled: {
         sliceAmount: { gt: 0 }
       }
@@ -106,7 +106,7 @@ const getUIDef = ({ i18n } = {}) => ({
 
     lev: {
       component: 'input.range',
-      label: t(i18n, 'orderForm.leverage', 'Leverage'),
+      label: t(i18n, 'leverage', 'Leverage'),
       min: 1,
       max: 100,
       default: 10
@@ -114,10 +114,10 @@ const getUIDef = ({ i18n } = {}) => ({
 
     action: {
       component: 'input.radio',
-      label: t(i18n, 'orderForm.action', 'Action'),
-      options: [t(i18n, 'orderForm.buy', 'Buy'), t(i18n, 'orderForm.sell', 'Sell')],
+      label: t(i18n, 'action', 'Action'),
+      options: [t(i18n, 'buy', 'Buy'), t(i18n, 'sell', 'Sell')],
       inline: true,
-      default: t(i18n, 'orderForm.buy', 'Buy')
+      default: t(i18n, 'buy', 'Buy')
     }
   },
 

--- a/lib/iceberg/meta/get_ui_def.js
+++ b/lib/iceberg/meta/get_ui_def.js
@@ -1,3 +1,6 @@
+'use strict'
+const { t } = require('../../util/i18n')
+
 /**
  * Returns the UI layout definition for Iceberg, with a field for each parameter.
  *
@@ -6,18 +9,18 @@
  * @memberOf module:Iceberg
  * @returns {AOUIDefinition} uiDef
  */
-const getUIDef = () => ({
-  label: 'Iceberg',
+const getUIDef = ({ i18n } = {}) => ({
+  label: t(i18n, 'orderForm.iceberg.title', 'Iceberg'),
   id: 'bfx-iceberg',
 
   uiIcon: 'iceberg-active',
-  customHelp: [
+  customHelp: t(i18n, 'orderForm.iceberg.help', [
     'Iceberg allows you to place a large order on the market while ensuring',
     'only a small part of it is ever filled at once.\n\nBy enabling the',
     '\'Excess As Hidden\' option, it is possible to offer up the remainder as',
     'a hidden order, allowing for minimal market disruption when executing',
     'large trades.'
-  ].join(' '),
+  ].join(' ')),
 
   connectionTimeout: 10000,
   actionTimeout: 10000,
@@ -53,24 +56,24 @@ const getUIDef = () => ({
   fields: {
     excessAsHidden: {
       component: 'input.checkbox',
-      label: 'Excess as hidden',
+      label: t(i18n, 'orderForm.excessAsHidden', 'Excess as hidden'),
       default: true,
-      customHelp: 'Create a hidden order for the non-slice amount'
+      customHelp: t(i18n, 'orderForm.excessAsHidden.help', 'Create a hidden order for the non-slice amount')
     },
 
     orderType: {
       component: 'input.dropdown',
-      label: 'Order Type',
+      label: t(i18n, 'orderForm.orderType', 'Order Type'),
       default: 'LIMIT',
       options: {
-        LIMIT: 'Limit',
-        MARKET: 'Market'
+        LIMIT: t(i18n, 'orderForm.limit', 'Limit'),
+        MARKET: t(i18n, 'orderForm.market', 'Market')
       }
     },
 
     price: {
       component: 'input.price',
-      label: 'Price $QUOTE',
+      label: `${t(i18n, 'orderForm.price', 'Price')} $QUOTE`,
       disabled: {
         orderType: { eq: 'MARKET' }
       }
@@ -78,15 +81,15 @@ const getUIDef = () => ({
 
     amount: {
       component: 'input.amount',
-      label: 'Amount $BASE',
-      customHelp: 'Total order amount, to be executed slice-by-slice',
+      label: `${t(i18n, 'orderForm.amount', 'Amount')} $BASE`,
+      customHelp: t(i18n, 'orderForm.amount.help', 'Total order amount, to be executed slice-by-slice'),
       priceField: 'price'
     },
 
     sliceAmount: {
       component: 'input.number',
-      label: 'Slice Amount $BASE',
-      customHelp: 'Allows individual buy & sell amounts to be adjusted',
+      label: `${t(i18n, 'orderForm.sliceAmount', 'Slice Amount')} $BASE`,
+      customHelp: t(i18n, 'orderForm.sliceAmount.help', 'Allows individual buy & sell amounts to be adjusted'),
       disabled: {
         sliceAmountPerc: { gt: 0 }
       }
@@ -94,8 +97,8 @@ const getUIDef = () => ({
 
     sliceAmountPerc: {
       component: 'input.percent',
-      label: 'Slice Amount as %',
-      customHelp: 'Takes percentage of total order amount for individual buy & sell amounts',
+      label: t(i18n, 'orderForm.sliceAmountPerc', 'Slice Amount as %'),
+      customHelp: t(i18n, 'orderForm.sliceAmountPerc.help', 'Takes percentage of total order amount for individual buy & sell amounts'),
       disabled: {
         sliceAmount: { gt: 0 }
       }
@@ -103,7 +106,7 @@ const getUIDef = () => ({
 
     lev: {
       component: 'input.range',
-      label: 'Leverage',
+      label: t(i18n, 'orderForm.leverage', 'Leverage'),
       min: 1,
       max: 100,
       default: 10
@@ -111,10 +114,10 @@ const getUIDef = () => ({
 
     action: {
       component: 'input.radio',
-      label: 'Action',
-      options: ['Buy', 'Sell'],
+      label: t(i18n, 'orderForm.action', 'Action'),
+      options: [t(i18n, 'orderForm.buy', 'Buy'), t(i18n, 'orderForm.sell', 'Sell')],
       inline: true,
-      default: 'Buy'
+      default: t(i18n, 'orderForm.buy', 'Buy')
     }
   },
 

--- a/lib/iceberg/meta/validate_params.js
+++ b/lib/iceberg/meta/validate_params.js
@@ -4,6 +4,7 @@ const { Order } = require('bfx-api-node-models')
 const _isFinite = require('lodash/isFinite')
 const _includes = require('lodash/includes')
 const validationErrObj = require('../../util/validate_params_err')
+const { apply: applyI18N } = require('../../util/i18n')
 
 /**
  * Verifies that a parameters Object is valid, and all parameters are within
@@ -29,34 +30,90 @@ const validateParams = (args = {}, pairConfig = {}) => {
   const { minSize, maxSize, lev: maxLev } = pairConfig
   const { price, amount, sliceAmount, orderType, lev, _futures } = args
 
-  if (!Order.type[orderType]) return validationErrObj('orderType', `Invalid order type: ${orderType}`)
-  if (!_isFinite(amount)) return validationErrObj('amount', 'Invalid amount')
-  if (!_isFinite(sliceAmount)) return validationErrObj('sliceAmount', 'Invalid slice amount')
+  if (!Order.type[orderType]) {
+    return applyI18N(
+      validationErrObj('orderType', `Invalid order type: ${orderType}`),
+      'invalidOrderType', { orderType }
+    )
+  }
+  if (!_isFinite(amount)) {
+    return applyI18N(
+      validationErrObj('amount', 'Invalid amount'),
+      'invalidAmount'
+    )
+  }
+  if (!_isFinite(sliceAmount)) {
+    return applyI18N(
+      validationErrObj('sliceAmount', 'Invalid slice amount'),
+      'invalidSliceAmount'
+    )
+  }
   if (!_includes(orderType, 'MARKET') && (isNaN(price) || price <= 0)) {
-    return validationErrObj('price', 'Invalid price')
+    return applyI18N(
+      validationErrObj('price', 'Invalid price'),
+      'invalidPrice'
+    )
   }
 
   if (
     (amount < 0 && sliceAmount >= 0) ||
     (amount > 0 && sliceAmount <= 0)
   ) {
-    return validationErrObj('sliceAmount', 'Amount & slice amount must have same sign')
+    return applyI18N(
+      validationErrObj('sliceAmount', 'Amount & slice amount must have same sign'),
+      'Amount & sliceAmountMustHaveSameSign'
+    )
   }
 
   if (_isFinite(minSize)) {
-    if (Math.abs(amount) < minSize) return validationErrObj('amount', `Amount cannot be less than ${minSize}`)
-    if (Math.abs(sliceAmount) < minSize) return validationErrObj('sliceAmount', `Slice amount cannot be less than ${minSize}`)
+    if (Math.abs(amount) < minSize) {
+      return applyI18N(
+        validationErrObj('amount', `Amount cannot be less than ${minSize}`),
+        'amountCannotBeLessThan', { minSize }
+      )
+    }
+    if (Math.abs(sliceAmount) < minSize) {
+      return applyI18N(
+        validationErrObj('sliceAmount', `Slice amount cannot be less than ${minSize}`),
+        'sliceAmountCannotBeLessThan', { minSize }
+      )
+    }
   }
 
   if (_isFinite(maxSize)) {
-    if (Math.abs(amount) > maxSize) return validationErrObj('amount', `Amount cannot be greater than ${maxSize}`)
-    if (Math.abs(sliceAmount) > maxSize) return validationErrObj('sliceAmount', `Slice amount cannot be greater than ${maxSize}`)
+    if (Math.abs(amount) > maxSize) {
+      return applyI18N(
+        validationErrObj('amount', `Amount cannot be greater than ${maxSize}`),
+        'amountCannotBeGreaterThan', { maxSize }
+      )
+    }
+    if (Math.abs(sliceAmount) > maxSize) {
+      return applyI18N(
+        validationErrObj('sliceAmount', `Slice amount cannot be greater than ${maxSize}`),
+        'sliceAmountCannotBeGreaterThan', { maxSize }
+      )
+    }
   }
 
   if (_futures) {
-    if (!_isFinite(lev)) return validationErrObj('lev', 'Invalid leverage')
-    if (lev < 1) return validationErrObj('lev', 'Leverage cannot be less than 1')
-    if (_isFinite(maxLev) && (lev > maxLev)) return validationErrObj('lev', `Leverage cannot be greater than ${maxLev}`)
+    if (!_isFinite(lev)) {
+      return applyI18N(
+        validationErrObj('lev', 'Invalid leverage'),
+        'invalidLeverage'
+      )
+    }
+    if (lev < 1) {
+      return applyI18N(
+        validationErrObj('lev', 'Leverage cannot be less than 1'),
+        'leverageCannotBeLessThan', { minLev: 1 }
+      )
+    }
+    if (_isFinite(maxLev) && (lev > maxLev)) {
+      return applyI18N(
+        validationErrObj('lev', `Leverage cannot be greater than ${maxLev}`),
+        'leverageCannotBeGreaterThan', { maxLev }
+      )
+    }
   }
 
   return null

--- a/lib/ma_crossover/meta/gen_order_label.js
+++ b/lib/ma_crossover/meta/gen_order_label.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { apply: applyI18N } = require('../../util/i18n')
+
 /**
  * Generates a label for an MACrossver instance for rendering in an UI.
  *
@@ -15,12 +17,17 @@ const genOrderLabel = (state = {}) => {
   const { orderType, orderPrice, amount, long, short } = args
   const priceShouldBeDisplayed = orderType === 'LIMIT'
 
-  return [
-    'MA Crossover',
-    ` | ${amount} @ ${priceShouldBeDisplayed ? orderPrice : orderType} `,
-    ` | long ${long.type.toUpperCase()}(${long.args[0]})`,
-    ` | short ${short.type.toUpperCase()}(${short.args[0]})`
-  ].join('')
+  return applyI18N({
+    origin: [
+      'MA Crossover',
+      ` | ${amount} @ ${priceShouldBeDisplayed ? orderPrice : orderType} `,
+      ` | long ${long.type.toUpperCase()}(${long.args[0]})`,
+      ` | short ${short.type.toUpperCase()}(${short.args[0]})`
+    ].join('')
+  },
+  `maCrossover${priceShouldBeDisplayed ? 'Limit' : ''}.label`,
+  { amount, orderPrice, orderType, long, short }
+  )
 }
 
 module.exports = genOrderLabel

--- a/lib/ma_crossover/meta/get_ui_def.js
+++ b/lib/ma_crossover/meta/get_ui_def.js
@@ -20,14 +20,14 @@ const getUIDef = ({ timeframes, i18n }) => {
   })
 
   return {
-    label: t(i18n, 'orderForm.crossover.title', 'MA Crossover'),
+    label: t(i18n, 'crossover.title', 'MA Crossover'),
     id: 'bfx-ma_crossover',
 
     uiIcon: 'ma-crossover-active',
     connectionTimeout: 10000,
     actionTimeout: 10000,
 
-    customHelp: t(i18n, 'orderForm.crossover.help', [
+    customHelp: t(i18n, 'crossover.help', [
       'Schedules either a LIMIT or MARKET order to execute when two moving averages cross.',
       '',
       'Both moving averages can be either exponential or smoothed, and can have differing',
@@ -43,7 +43,7 @@ const getUIDef = ({ timeframes, i18n }) => {
         ['orderType', 'orderPrice']
       ]
     }, {
-      title: t(i18n, 'orderForm.shortEmaSettings', 'Short EMA Settings'),
+      title: t(i18n, 'shortEmaSettings', 'Short EMA Settings'),
       name: 'shortEMASettings',
       fixed: true,
       visible: {
@@ -56,7 +56,7 @@ const getUIDef = ({ timeframes, i18n }) => {
       ]
     }, {
       name: 'shortMASettings',
-      title: t(i18n, 'orderForm.shortMaSettings', 'Short MA Settings'),
+      title: t(i18n, 'shortMaSettings', 'Short MA Settings'),
       fixed: true,
       visible: {
         shortType: { eq: 'MA' }
@@ -67,7 +67,7 @@ const getUIDef = ({ timeframes, i18n }) => {
       ]
     }, {
       name: 'longEMASettings',
-      title: t(i18n, 'orderForm.longEmaSettings', 'Long EMA Settings'),
+      title: t(i18n, 'longEmaSettings', 'Long EMA Settings'),
       fixed: true,
       visible: {
         longType: { eq: 'EMA' }
@@ -77,7 +77,7 @@ const getUIDef = ({ timeframes, i18n }) => {
         ['longEMAPrice', null]
       ]
     }, {
-      title: t(i18n, 'orderForm.longMaSettings', 'Long MA Settings'),
+      title: t(i18n, 'longMaSettings', 'Long MA Settings'),
       name: 'longMASettings',
       fixed: true,
       visible: {
@@ -109,35 +109,35 @@ const getUIDef = ({ timeframes, i18n }) => {
     fields: {
       shortType: {
         component: 'input.dropdown',
-        label: t(i18n, 'orderForm.shortEmaMaType', 'Short EMA/MA Type'),
+        label: t(i18n, 'shortEmaMaType', 'Short EMA/MA Type'),
         default: 'EMA',
         options: {
-          EMA: t(i18n, 'orderForm.ema', 'EMA'),
-          MA: t(i18n, 'orderForm.ma', 'MA')
+          EMA: t(i18n, 'ema', 'EMA'),
+          MA: t(i18n, 'ma', 'MA')
         }
       },
 
       longType: {
         component: 'input.dropdown',
-        label: t(i18n, 'orderForm.longEmaMaType', 'Long EMA/MA Type'),
+        label: t(i18n, 'longEmaMaType', 'Long EMA/MA Type'),
         default: 'EMA',
         options: {
-          EMA: t(i18n, 'orderForm.ema', 'EMA'),
-          MA: t(i18n, 'orderForm.ma', 'MA')
+          EMA: t(i18n, 'ema', 'EMA'),
+          MA: t(i18n, 'ma', 'MA')
         }
       },
 
       amount: {
         component: 'input.amount',
-        label: `${t(i18n, 'orderForm.amount', 'Amount')} $BASE`,
-        customHelp: t(i18n, 'orderForm.totalOrderAmount', 'Total order amount'),
+        label: `${t(i18n, 'amount', 'Amount')} $BASE`,
+        customHelp: t(i18n, 'totalOrderAmount', 'Total order amount'),
         priceField: 'limitPrice'
       },
 
       shortMAPeriod: {
         component: 'input.number',
-        label: t(i18n, 'orderForm.shortMaPeriod', 'Short MA Period'),
-        customHelp: t(i18n, 'orderForm.shortMaPeriod.help', 'Period for short moving average'),
+        label: t(i18n, 'shortMaPeriod', 'Short MA Period'),
+        customHelp: t(i18n, 'shortMaPeriod.help', 'Period for short moving average'),
         visible: {
           shortType: { eq: 'MA' }
         }
@@ -145,8 +145,8 @@ const getUIDef = ({ timeframes, i18n }) => {
 
       longMAPeriod: {
         component: 'input.number',
-        label: t(i18n, 'orderForm.longMaPeriod', 'Long MA Period'),
-        customHelp: t(i18n, 'orderForm.longMaPeriod.help', 'Period for long moving average'),
+        label: t(i18n, 'longMaPeriod', 'Long MA Period'),
+        customHelp: t(i18n, 'longMaPeriod.help', 'Period for long moving average'),
         visible: {
           longType: { eq: 'MA' }
         }
@@ -154,8 +154,8 @@ const getUIDef = ({ timeframes, i18n }) => {
 
       shortEMAPeriod: {
         component: 'input.number',
-        label: t(i18n, 'orderForm.shortEmaPeriod', 'Short EMA Period'),
-        customHelp: t(i18n, 'orderForm.shortEmaPeriod.help', 'Period for short exponential moving average'),
+        label: t(i18n, 'shortEmaPeriod', 'Short EMA Period'),
+        customHelp: t(i18n, 'shortEmaPeriod.help', 'Period for short exponential moving average'),
         visible: {
           shortType: { eq: 'EMA' }
         }
@@ -163,8 +163,8 @@ const getUIDef = ({ timeframes, i18n }) => {
 
       longEMAPeriod: {
         component: 'input.number',
-        label: t(i18n, 'orderForm.longEmaPeriod', 'Long EMA Period'),
-        customHelp: t(i18n, 'orderForm.longEmaPeriod.help', 'Period for long exponential moving average'),
+        label: t(i18n, 'longEmaPeriod', 'Long EMA Period'),
+        customHelp: t(i18n, 'longEmaPeriod.help', 'Period for long exponential moving average'),
         visible: {
           longType: { eq: 'EMA' }
         }
@@ -172,13 +172,13 @@ const getUIDef = ({ timeframes, i18n }) => {
 
       shortMAPrice: {
         component: 'input.dropdown',
-        label: t(i18n, 'orderForm.shortMaCandlePrice', 'Short MA Candle Price'),
+        label: t(i18n, 'shortMaCandlePrice', 'Short MA Candle Price'),
         default: 'CLOSE',
         options: {
-          OPEN: t(i18n, 'orderForm.open', 'Open'),
-          HIGH: t(i18n, 'orderForm.high', 'High'),
-          LOW: t(i18n, 'orderForm.low', 'Low'),
-          CLOSE: t(i18n, 'orderForm.close', 'Close')
+          OPEN: t(i18n, 'open', 'Open'),
+          HIGH: t(i18n, 'high', 'High'),
+          LOW: t(i18n, 'low', 'Low'),
+          CLOSE: t(i18n, 'close', 'Close')
         },
 
         visible: {
@@ -188,13 +188,13 @@ const getUIDef = ({ timeframes, i18n }) => {
 
       shortEMAPrice: {
         component: 'input.dropdown',
-        label: t(i18n, 'orderForm.shortEmaCandlePrice', 'Short EMA Candle Price'),
+        label: t(i18n, 'shortEmaCandlePrice', 'Short EMA Candle Price'),
         default: 'CLOSE',
         options: {
-          OPEN: t(i18n, 'orderForm.open', 'Open'),
-          HIGH: t(i18n, 'orderForm.high', 'High'),
-          LOW: t(i18n, 'orderForm.low', 'Low'),
-          CLOSE: t(i18n, 'orderForm.close', 'Close')
+          OPEN: t(i18n, 'open', 'Open'),
+          HIGH: t(i18n, 'high', 'High'),
+          LOW: t(i18n, 'low', 'Low'),
+          CLOSE: t(i18n, 'close', 'Close')
         },
 
         visible: {
@@ -204,13 +204,13 @@ const getUIDef = ({ timeframes, i18n }) => {
 
       longMAPrice: {
         component: 'input.dropdown',
-        label: t(i18n, 'orderForm.longMaCandlePrice', 'Long MA Candle Price'),
+        label: t(i18n, 'longMaCandlePrice', 'Long MA Candle Price'),
         default: 'CLOSE',
         options: {
-          OPEN: t(i18n, 'orderForm.open', 'Open'),
-          HIGH: t(i18n, 'orderForm.high', 'High'),
-          LOW: t(i18n, 'orderForm.low', 'Low'),
-          CLOSE: t(i18n, 'orderForm.close', 'Close')
+          OPEN: t(i18n, 'open', 'Open'),
+          HIGH: t(i18n, 'high', 'High'),
+          LOW: t(i18n, 'low', 'Low'),
+          CLOSE: t(i18n, 'close', 'Close')
         },
 
         visible: {
@@ -220,13 +220,13 @@ const getUIDef = ({ timeframes, i18n }) => {
 
       longEMAPrice: {
         component: 'input.dropdown',
-        label: t(i18n, 'orderForm.longEmaCandlePrice', 'Long EMA Candle Price'),
+        label: t(i18n, 'longEmaCandlePrice', 'Long EMA Candle Price'),
         default: 'CLOSE',
         options: {
-          OPEN: t(i18n, 'orderForm.open', 'Open'),
-          HIGH: t(i18n, 'orderForm.high', 'High'),
-          LOW: t(i18n, 'orderForm.low', 'Low'),
-          CLOSE: t(i18n, 'orderForm.close', 'Close')
+          OPEN: t(i18n, 'open', 'Open'),
+          HIGH: t(i18n, 'high', 'High'),
+          LOW: t(i18n, 'low', 'Low'),
+          CLOSE: t(i18n, 'close', 'Close')
         },
 
         visible: {
@@ -236,7 +236,7 @@ const getUIDef = ({ timeframes, i18n }) => {
 
       shortMATF: {
         component: 'input.dropdown',
-        label: t(i18n, 'orderForm.shortMaTimeFrame', 'Short MA Time Frame'),
+        label: t(i18n, 'shortMaTimeFrame', 'Short MA Time Frame'),
         default: timeframes[0],
         options: tfDropdownOptions,
 
@@ -247,7 +247,7 @@ const getUIDef = ({ timeframes, i18n }) => {
 
       longMATF: {
         component: 'input.dropdown',
-        label: t(i18n, 'orderForm.longMaTimeFrame', 'Long MA Time Frame'),
+        label: t(i18n, 'longMaTimeFrame', 'Long MA Time Frame'),
         default: timeframes[0],
         options: tfDropdownOptions,
 
@@ -258,7 +258,7 @@ const getUIDef = ({ timeframes, i18n }) => {
 
       shortEMATF: {
         component: 'input.dropdown',
-        label: t(i18n, 'orderForm.shortEmaTimeFrame', 'Short EMA Time Frame'),
+        label: t(i18n, 'shortEmaTimeFrame', 'Short EMA Time Frame'),
         default: timeframes[0],
         options: tfDropdownOptions,
 
@@ -269,7 +269,7 @@ const getUIDef = ({ timeframes, i18n }) => {
 
       longEMATF: {
         component: 'input.dropdown',
-        label: t(i18n, 'orderForm.longEmaTimeFrame', 'Long EMA Time Frame'),
+        label: t(i18n, 'longEmaTimeFrame', 'Long EMA Time Frame'),
         default: timeframes[0],
         options: tfDropdownOptions,
 
@@ -280,17 +280,17 @@ const getUIDef = ({ timeframes, i18n }) => {
 
       orderType: {
         component: 'input.dropdown',
-        label: t(i18n, 'orderForm.orderType', 'Order Type'),
+        label: t(i18n, 'orderType', 'Order Type'),
         default: 'MARKET',
         options: {
-          MARKET: t(i18n, 'orderForm.market', 'Market'),
-          LIMIT: t(i18n, 'orderForm.limit', 'Limit')
+          MARKET: t(i18n, 'market', 'Market'),
+          LIMIT: t(i18n, 'limit', 'Limit')
         }
       },
 
       orderPrice: {
         component: 'input.price',
-        label: `${t(i18n, 'orderForm.orderPrice', 'Order Price')} $QUOTE`,
+        label: `${t(i18n, 'orderPrice', 'Order Price')} $QUOTE`,
 
         disabled: {
           orderType: { eq: 'MARKET' }
@@ -299,7 +299,7 @@ const getUIDef = ({ timeframes, i18n }) => {
 
       lev: {
         component: 'input.range',
-        label: t(i18n, 'orderForm.leverage', 'Leverage'),
+        label: t(i18n, 'leverage', 'Leverage'),
         min: 1,
         max: 100,
         default: 10
@@ -308,10 +308,10 @@ const getUIDef = ({ timeframes, i18n }) => {
       // Action section
       action: {
         component: 'input.radio',
-        label: t(i18n, 'orderForm.action', 'Action'),
-        options: [t(i18n, 'orderForm.buy', 'Buy'), t(i18n, 'orderForm.sell', 'Sell')],
+        label: t(i18n, 'action', 'Action'),
+        options: [t(i18n, 'buy', 'Buy'), t(i18n, 'sell', 'Sell')],
         inline: true,
-        default: t(i18n, 'orderForm.buy', 'Buy')
+        default: t(i18n, 'buy', 'Buy')
       }
     },
 

--- a/lib/ma_crossover/meta/get_ui_def.js
+++ b/lib/ma_crossover/meta/get_ui_def.js
@@ -1,3 +1,6 @@
+'use strict'
+const { t } = require('../../util/i18n')
+
 /**
  * Returns the UI layout definition for MACrossver, with a field for each
  * parameter.
@@ -9,7 +12,7 @@
  * @param {string[]} data.timeframes - array of timeframes to show in dropdowns
  * @returns {AOUIDefinition} uiDef
  */
-const getUIDef = ({ timeframes }) => {
+const getUIDef = ({ timeframes, i18n }) => {
   const tfDropdownOptions = {}
 
   timeframes.forEach(tf => {
@@ -17,19 +20,19 @@ const getUIDef = ({ timeframes }) => {
   })
 
   return {
-    label: 'MA Crossover',
+    label: t(i18n, 'orderForm.crossover.title', 'MA Crossover'),
     id: 'bfx-ma_crossover',
 
     uiIcon: 'ma-crossover-active',
     connectionTimeout: 10000,
     actionTimeout: 10000,
 
-    customHelp: [
+    customHelp: t(i18n, 'orderForm.crossover.help', [
       'Schedules either a LIMIT or MARKET order to execute when two moving averages cross.',
       '',
       'Both moving averages can be either exponential or smoothed, and can have differing',
       'time frames and candle keys (close, open, etc)'
-    ].join('\n'),
+    ].join('\n')),
 
     sections: [{
       title: '',
@@ -40,7 +43,7 @@ const getUIDef = ({ timeframes }) => {
         ['orderType', 'orderPrice']
       ]
     }, {
-      title: 'Short EMA Settings',
+      title: t(i18n, 'orderForm.shortEmaSettings', 'Short EMA Settings'),
       name: 'shortEMASettings',
       fixed: true,
       visible: {
@@ -53,7 +56,7 @@ const getUIDef = ({ timeframes }) => {
       ]
     }, {
       name: 'shortMASettings',
-      title: 'Short MA Settings',
+      title: t(i18n, 'orderForm.shortMaSettings', 'Short MA Settings'),
       fixed: true,
       visible: {
         shortType: { eq: 'MA' }
@@ -64,7 +67,7 @@ const getUIDef = ({ timeframes }) => {
       ]
     }, {
       name: 'longEMASettings',
-      title: 'Long EMA Settings',
+      title: t(i18n, 'orderForm.longEmaSettings', 'Long EMA Settings'),
       fixed: true,
       visible: {
         longType: { eq: 'EMA' }
@@ -74,7 +77,7 @@ const getUIDef = ({ timeframes }) => {
         ['longEMAPrice', null]
       ]
     }, {
-      title: 'Long MA Settings',
+      title: t(i18n, 'orderForm.longMaSettings', 'Long MA Settings'),
       name: 'longMASettings',
       fixed: true,
       visible: {
@@ -106,35 +109,35 @@ const getUIDef = ({ timeframes }) => {
     fields: {
       shortType: {
         component: 'input.dropdown',
-        label: 'Short EMA/MA Type',
+        label: t(i18n, 'orderForm.shortEmaMaType', 'Short EMA/MA Type'),
         default: 'EMA',
         options: {
-          EMA: 'EMA',
-          MA: 'MA'
+          EMA: t(i18n, 'orderForm.ema', 'EMA'),
+          MA: t(i18n, 'orderForm.ma', 'MA')
         }
       },
 
       longType: {
         component: 'input.dropdown',
-        label: 'Long EMA/MA Type',
+        label: t(i18n, 'orderForm.longEmaMaType', 'Long EMA/MA Type'),
         default: 'EMA',
         options: {
-          EMA: 'EMA',
-          MA: 'MA'
+          EMA: t(i18n, 'orderForm.ema', 'EMA'),
+          MA: t(i18n, 'orderForm.ma', 'MA')
         }
       },
 
       amount: {
         component: 'input.amount',
-        label: 'Amount $BASE',
-        customHelp: 'Total order amount',
+        label: `${t(i18n, 'orderForm.amount', 'Amount')} $BASE`,
+        customHelp: t(i18n, 'orderForm.totalOrderAmount', 'Total order amount'),
         priceField: 'limitPrice'
       },
 
       shortMAPeriod: {
         component: 'input.number',
-        label: 'Short MA Period',
-        customHelp: 'Period for short moving average',
+        label: t(i18n, 'orderForm.shortMaPeriod', 'Short MA Period'),
+        customHelp: t(i18n, 'orderForm.shortMaPeriod.help', 'Period for short moving average'),
         visible: {
           shortType: { eq: 'MA' }
         }
@@ -142,8 +145,8 @@ const getUIDef = ({ timeframes }) => {
 
       longMAPeriod: {
         component: 'input.number',
-        label: 'Long MA Period',
-        customHelp: 'Period for long moving average',
+        label: t(i18n, 'orderForm.longMaPeriod', 'Long MA Period'),
+        customHelp: t(i18n, 'orderForm.longMaPeriod.help', 'Period for long moving average'),
         visible: {
           longType: { eq: 'MA' }
         }
@@ -151,8 +154,8 @@ const getUIDef = ({ timeframes }) => {
 
       shortEMAPeriod: {
         component: 'input.number',
-        label: 'Short EMA Period',
-        customHelp: 'Period for short exponential moving average',
+        label: t(i18n, 'orderForm.shortEmaPeriod', 'Short EMA Period'),
+        customHelp: t(i18n, 'orderForm.shortEmaPeriod.help', 'Period for short exponential moving average'),
         visible: {
           shortType: { eq: 'EMA' }
         }
@@ -160,8 +163,8 @@ const getUIDef = ({ timeframes }) => {
 
       longEMAPeriod: {
         component: 'input.number',
-        label: 'Long EMA Period',
-        customHelp: 'Period for long exponential moving average',
+        label: t(i18n, 'orderForm.longEmaPeriod', 'Long EMA Period'),
+        customHelp: t(i18n, 'orderForm.longEmaPeriod.help', 'Period for long exponential moving average'),
         visible: {
           longType: { eq: 'EMA' }
         }
@@ -169,13 +172,13 @@ const getUIDef = ({ timeframes }) => {
 
       shortMAPrice: {
         component: 'input.dropdown',
-        label: 'Short MA Candle Price',
+        label: t(i18n, 'orderForm.shortMaCandlePrice', 'Short MA Candle Price'),
         default: 'CLOSE',
         options: {
-          OPEN: 'Open',
-          HIGH: 'High',
-          LOW: 'Low',
-          CLOSE: 'Close'
+          OPEN: t(i18n, 'orderForm.open', 'Open'),
+          HIGH: t(i18n, 'orderForm.high', 'High'),
+          LOW: t(i18n, 'orderForm.low', 'Low'),
+          CLOSE: t(i18n, 'orderForm.close', 'Close')
         },
 
         visible: {
@@ -185,13 +188,13 @@ const getUIDef = ({ timeframes }) => {
 
       shortEMAPrice: {
         component: 'input.dropdown',
-        label: 'Short EMA Candle Price',
+        label: t(i18n, 'orderForm.shortEmaCandlePrice', 'Short EMA Candle Price'),
         default: 'CLOSE',
         options: {
-          OPEN: 'Open',
-          HIGH: 'High',
-          LOW: 'Low',
-          CLOSE: 'Close'
+          OPEN: t(i18n, 'orderForm.open', 'Open'),
+          HIGH: t(i18n, 'orderForm.high', 'High'),
+          LOW: t(i18n, 'orderForm.low', 'Low'),
+          CLOSE: t(i18n, 'orderForm.close', 'Close')
         },
 
         visible: {
@@ -201,13 +204,13 @@ const getUIDef = ({ timeframes }) => {
 
       longMAPrice: {
         component: 'input.dropdown',
-        label: 'Long MA Candle Price',
+        label: t(i18n, 'orderForm.longMaCandlePrice', 'Long MA Candle Price'),
         default: 'CLOSE',
         options: {
-          OPEN: 'Open',
-          HIGH: 'High',
-          LOW: 'Low',
-          CLOSE: 'Close'
+          OPEN: t(i18n, 'orderForm.open', 'Open'),
+          HIGH: t(i18n, 'orderForm.high', 'High'),
+          LOW: t(i18n, 'orderForm.low', 'Low'),
+          CLOSE: t(i18n, 'orderForm.close', 'Close')
         },
 
         visible: {
@@ -217,13 +220,13 @@ const getUIDef = ({ timeframes }) => {
 
       longEMAPrice: {
         component: 'input.dropdown',
-        label: 'Long EMA Candle Price',
+        label: t(i18n, 'orderForm.longEmaCandlePrice', 'Long EMA Candle Price'),
         default: 'CLOSE',
         options: {
-          OPEN: 'Open',
-          HIGH: 'High',
-          LOW: 'Low',
-          CLOSE: 'Close'
+          OPEN: t(i18n, 'orderForm.open', 'Open'),
+          HIGH: t(i18n, 'orderForm.high', 'High'),
+          LOW: t(i18n, 'orderForm.low', 'Low'),
+          CLOSE: t(i18n, 'orderForm.close', 'Close')
         },
 
         visible: {
@@ -233,7 +236,7 @@ const getUIDef = ({ timeframes }) => {
 
       shortMATF: {
         component: 'input.dropdown',
-        label: 'Short MA Time Frame',
+        label: t(i18n, 'orderForm.shortMaTimeFrame', 'Short MA Time Frame'),
         default: timeframes[0],
         options: tfDropdownOptions,
 
@@ -244,7 +247,7 @@ const getUIDef = ({ timeframes }) => {
 
       longMATF: {
         component: 'input.dropdown',
-        label: 'Long MA Time Frame',
+        label: t(i18n, 'orderForm.longMaTimeFrame', 'Long MA Time Frame'),
         default: timeframes[0],
         options: tfDropdownOptions,
 
@@ -255,7 +258,7 @@ const getUIDef = ({ timeframes }) => {
 
       shortEMATF: {
         component: 'input.dropdown',
-        label: 'Short EMA Time Frame',
+        label: t(i18n, 'orderForm.shortEmaTimeFrame', 'Short EMA Time Frame'),
         default: timeframes[0],
         options: tfDropdownOptions,
 
@@ -266,7 +269,7 @@ const getUIDef = ({ timeframes }) => {
 
       longEMATF: {
         component: 'input.dropdown',
-        label: 'Long EMA Time Frame',
+        label: t(i18n, 'orderForm.longEmaTimeFrame', 'Long EMA Time Frame'),
         default: timeframes[0],
         options: tfDropdownOptions,
 
@@ -277,17 +280,17 @@ const getUIDef = ({ timeframes }) => {
 
       orderType: {
         component: 'input.dropdown',
-        label: 'Order Type',
+        label: t(i18n, 'orderForm.orderType', 'Order Type'),
         default: 'MARKET',
         options: {
-          MARKET: 'Market',
-          LIMIT: 'Limit'
+          MARKET: t(i18n, 'orderForm.market', 'Market'),
+          LIMIT: t(i18n, 'orderForm.limit', 'Limit')
         }
       },
 
       orderPrice: {
         component: 'input.price',
-        label: 'Order Price $QUOTE',
+        label: `${t(i18n, 'orderForm.orderPrice', 'Order Price')} $QUOTE`,
 
         disabled: {
           orderType: { eq: 'MARKET' }
@@ -296,7 +299,7 @@ const getUIDef = ({ timeframes }) => {
 
       lev: {
         component: 'input.range',
-        label: 'Leverage',
+        label: t(i18n, 'orderForm.leverage', 'Leverage'),
         min: 1,
         max: 100,
         default: 10
@@ -305,10 +308,10 @@ const getUIDef = ({ timeframes }) => {
       // Action section
       action: {
         component: 'input.radio',
-        label: 'Action',
-        options: ['Buy', 'Sell'],
+        label: t(i18n, 'orderForm.action', 'Action'),
+        options: [t(i18n, 'orderForm.buy', 'Buy'), t(i18n, 'orderForm.sell', 'Sell')],
         inline: true,
-        default: 'Buy'
+        default: t(i18n, 'orderForm.buy', 'Buy')
       }
     },
 

--- a/lib/ma_crossover/meta/validate_params.js
+++ b/lib/ma_crossover/meta/validate_params.js
@@ -4,6 +4,7 @@ const _isFinite = require('lodash/isFinite')
 const _isObject = require('lodash/isObject')
 const _includes = require('lodash/includes')
 const validationErrObj = require('../../util/validate_params_err')
+const { apply: applyI18N } = require('../../util/i18n')
 
 const ORDER_TYPES = ['MARKET', 'LIMIT']
 
@@ -43,38 +44,132 @@ const validateParams = (args = {}, pairConfig = {}) => {
   const { minSize, maxSize, lev: maxLev } = pairConfig
   const { orderPrice, amount, orderType, long, short, lev, _futures } = args
 
-  if (!_includes(ORDER_TYPES, orderType)) return validationErrObj('orderType', `Invalid order type: ${orderType}`)
-  if (!_isFinite(amount) || amount === 0) return validationErrObj('amount', 'Invalid amount')
+  if (!_includes(ORDER_TYPES, orderType)) {
+    return applyI18N(
+      validationErrObj('orderType', `Invalid order type: ${orderType}`),
+      'invalidOrderType', { orderType }
+    )
+  }
+  if (!_isFinite(amount) || amount === 0) {
+    return applyI18N(
+      validationErrObj('amount', 'Invalid amount'),
+      'invalidAmount'
+    )
+  }
   if (orderType === 'LIMIT' && !_isFinite(orderPrice)) {
-    return validationErrObj('orderPrice', 'Limit price required for LIMIT order type')
+    return applyI18N(
+      validationErrObj('orderPrice', 'Limit price required for LIMIT order type'),
+      'limitPriceRequiredForLimitOrderType'
+    )
   }
 
-  if (!_isObject(long)) return validationErrObj('longType', 'Invalid long indicator type')
-  if (long.args.length !== 1) return validationErrObj(`long${long.type.toUpperCase()}Period`, 'Invalid args for long ma indicator')
-  if (!_isFinite(long.args[0])) return validationErrObj(`long${long.type.toUpperCase()}Period`, `Invalid long indicator period: ${long.args[0]}`)
-  if (long.args[0] <= 0) return validationErrObj(`long${long.type.toUpperCase()}Period`, 'Invalid long period, please set a positive value')
-  if (!long.candlePrice) return validationErrObj(`long${long.type.toUpperCase()}Price`, 'Candle price required for long indicator')
-  if (!long.candleTimeFrame) return validationErrObj(`long${long.type.toUpperCase()}TF`, 'Candle time frame required for long indicator')
+  if (!_isObject(long)) {
+    return applyI18N(
+      validationErrObj('longType', 'Invalid long indicator type'),
+      'invalidLongIndicatorType'
+    )
+  }
+  if (long.args.length !== 1) {
+    return applyI18N(
+      validationErrObj(`long${long.type.toUpperCase()}Period`, 'Invalid args for long ma indicator'),
+      'invalidArgsForLongMaIndicator'
+    )
+  }
+  if (!_isFinite(long.args[0])) {
+    return applyI18N(
+      validationErrObj(`long${long.type.toUpperCase()}Period`, `Invalid long indicator period: ${long.args[0]}`),
+      'invalidLongIndicatorPeriod', { value: long.args[0] }
+    )
+  }
+  if (long.args[0] <= 0) {
+    return applyI18N(
+      validationErrObj(`long${long.type.toUpperCase()}Period`, 'Invalid long period, please set a positive value'),
+      'invalidLongPeriodPleaseSetAPositiveValue'
+    )
+  }
+  if (!long.candlePrice) {
+    return applyI18N(
+      validationErrObj(`long${long.type.toUpperCase()}Price`, 'Candle price required for long indicator'),
+      'candlePriceRequiredForLongIndicator'
+    )
+  }
+  if (!long.candleTimeFrame) {
+    return applyI18N(
+      validationErrObj(`long${long.type.toUpperCase()}TF`, 'Candle time frame required for long indicator'),
+      'candleTimeFrameRequiredForLongIndicator'
+    )
+  }
 
-  if (!_isObject(short)) return validationErrObj('shortType', 'Invalid short indicator type')
-  if (short.args.length !== 1) return validationErrObj(`short${short.type.toUpperCase()}Period`, 'Invalid args for short ma indicator ')
-  if (!_isFinite(short.args[0])) return validationErrObj(`short${short.type.toUpperCase()}Period`, `Invalid short indicator period: ${short.args[0]}`)
-  if (short.args[0] <= 0) return validationErrObj(`short${short.type.toUpperCase()}Period`, 'Invalid short period, please set a positive value')
-  if (!short.candlePrice) return validationErrObj(`short${short.type.toUpperCase()}Price`, 'Candle price required for short indicator')
-  if (!short.candleTimeFrame) return validationErrObj(`short${short.type.toUpperCase()}TF`, 'Candle time frame required for short indicator')
+  if (!_isObject(short)) {
+    return applyI18N(
+      validationErrObj('shortType', 'Invalid short indicator type'),
+      'invalidShortIndicatorType'
+    )
+  }
+  if (short.args.length !== 1) {
+    return applyI18N(
+      validationErrObj(`short${short.type.toUpperCase()}Period`, 'Invalid args for short ma indicator'),
+      'invalidArgsForShortMaIndicator'
+    )
+  }
+  if (!_isFinite(short.args[0])) {
+    return applyI18N(
+      validationErrObj(`short${short.type.toUpperCase()}Period`, `Invalid short indicator period: ${short.args[0]}`),
+      'invalidShortIndicatorPeriod', { value: short.args[0] }
+    )
+  }
+  if (short.args[0] <= 0) {
+    return applyI18N(
+      validationErrObj(`short${short.type.toUpperCase()}Period`, 'Invalid short period, please set a positive value'),
+      'invalidShortPeriodPleaseSetAPositiveValue'
+    )
+  }
+  if (!short.candlePrice) {
+    return applyI18N(
+      validationErrObj(`short${short.type.toUpperCase()}Price`, 'Candle price required for short indicator'),
+      'candlePriceRequiredForShortIndicator'
+    )
+  }
+  if (!short.candleTimeFrame) {
+    return applyI18N(
+      validationErrObj(`short${short.type.toUpperCase()}TF`, 'Candle time frame required for short indicator'),
+      'candleTimeFrameRequiredForShortIndicator'
+    )
+  }
 
   if (_isFinite(minSize) && Math.abs(amount) < minSize) {
-    return validationErrObj('amount', `Amount cannot be less than ${minSize}`)
+    return applyI18N(
+      validationErrObj('amount', `Amount cannot be less than ${minSize}`),
+      'amountCannotBeLessThan', { minSize }
+    )
   }
 
   if (_isFinite(maxSize) && Math.abs(amount) > maxSize) {
-    return validationErrObj('amount', `Amount cannot be greater than ${maxSize}`)
+    return applyI18N(
+      validationErrObj('amount', `Amount cannot be greater than ${maxSize}`),
+      'amountCannotBeGreaterThan', { maxSize }
+    )
   }
 
   if (_futures) {
-    if (!_isFinite(lev)) return validationErrObj('lev', 'Invalid leverage')
-    if (lev < 1) return validationErrObj('lev', 'Leverage cannot be less than 1')
-    if (_isFinite(maxLev) && (lev > maxLev)) return validationErrObj('lev', `Leverage cannot be greater than ${maxLev}`)
+    if (!_isFinite(lev)) {
+      return applyI18N(
+        validationErrObj('lev', 'Invalid leverage'),
+        'invalidLeverage'
+      )
+    }
+    if (lev < 1) {
+      return applyI18N(
+        validationErrObj('lev', 'Leverage cannot be less than 1'),
+        'leverageCannotBeLessThan', { minLev: 1 }
+      )
+    }
+    if (_isFinite(maxLev) && (lev > maxLev)) {
+      return applyI18N(
+        validationErrObj('lev', `Leverage cannot be greater than ${maxLev}`),
+        'leverageCannotBeGreaterThan', { maxLev }
+      )
+    }
   }
 
   return null

--- a/lib/ococo/meta/gen_order_label.js
+++ b/lib/ococo/meta/gen_order_label.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { apply: applyI18N } = require('../../util/i18n')
+
 /**
  * Generates a label for an OCOCO instance for rendering in an UI.
  *
@@ -16,11 +18,16 @@ const genOrderLabel = (state = {}) => {
     orderType, orderPrice, amount, ocoAmount, limitPrice, stopPrice
   } = args
 
-  return [
-    'OCOCO',
-    ` | ${amount} @ ${orderPrice || orderType} `,
-    ` | triggers ${ocoAmount} @ ${limitPrice} (stop ${stopPrice})`
-  ].join('')
+  return applyI18N({
+    origin: [
+      'OCOCO',
+      ` | ${amount} @ ${orderPrice || orderType} `,
+      ` | triggers ${ocoAmount} @ ${limitPrice} (stop ${stopPrice})`
+    ].join('')
+  },
+  'ococo.label',
+  { amount, orderPrice, orderType, ocoAmount, limitPrice, stopPrice }
+  )
 }
 
 module.exports = genOrderLabel

--- a/lib/ococo/meta/get_ui_def.js
+++ b/lib/ococo/meta/get_ui_def.js
@@ -1,3 +1,6 @@
+'use strict'
+const { t } = require('../../util/i18n')
+
 /**
  * Returns the UI layout definition for OCOCO, with a field for each parameter.
  *
@@ -6,19 +9,19 @@
  * @memberOf module:OCOCO
  * @returns {object} uiDef
  */
-const getUIDef = () => ({
-  label: 'Order Creates OcO',
+const getUIDef = ({ i18n } = {}) => ({
+  label: t(i18n, 'orderForm.ococo.title', 'Order Creates OcO'),
   id: 'bfx-ococo',
 
   uiIcon: 'ma-crossover-active',
   connectionTimeout: 10000,
   actionTimeout: 10000,
 
-  customHelp: [
+  customHelp: t(i18n, 'orderForm.ococo.help', [
     'Creates a standard LIMIT or MARKET order, and schedules an OcO order to be',
     'submitted after the initial order fills. All of the normal LIMIT/MARKET',
     'parameters are available on both orders.'
-  ].join('\n'),
+  ].join('\n')),
 
   header: {
     component: 'ui.checkbox_group',
@@ -33,7 +36,7 @@ const getUIDef = () => ({
       ['amount', 'action']
     ]
   }, {
-    title: 'OcO Settings',
+    title: t(i18n, 'orderForm.ocoSettings', 'OcO Settings'),
     name: 'shortEMASettings',
     fixed: true,
 
@@ -57,30 +60,30 @@ const getUIDef = () => ({
   fields: {
     orderType: {
       component: 'input.dropdown',
-      label: 'Order Type',
-      default: 'LIMIT',
+      label: t(i18n, 'orderForm.orderType', 'Order Type'),
+      default: t(i18n, 'orderForm.limit', 'LIMIT'),
       options: {
-        LIMIT: 'Limit',
-        MARKET: 'Market'
+        LIMIT: t(i18n, 'orderForm.limit', 'Limit'),
+        MARKET: t(i18n, 'orderForm.limit', 'Market')
       }
     },
 
     amount: {
       component: 'input.amount',
-      label: 'Amount $BASE',
-      customHelp: 'Initial Order amount',
+      label: `${t(i18n, 'orderForm.amount', 'Amount')} $BASE`,
+      customHelp: t(i18n, 'orderForm.initialOrderAmount', 'Initial Order amount'),
       priceField: 'orderPrice'
     },
 
     ocoAmount: {
       component: 'input.amount',
-      label: 'Amount $BASE',
-      customHelp: 'OcO Order amount'
+      label: `${t(i18n, 'orderForm.amount', 'Amount')} $BASE`,
+      customHelp: t(i18n, 'orderForm.ocoOrderAmount', 'OcO Order amount')
     },
 
     orderPrice: {
       component: 'input.price',
-      label: 'Initial Order Price $QUOTE',
+      label: `${t(i18n, 'orderForm.initialOrderPrice', 'Initial Order Price')} $QUOTE`,
 
       disabled: {
         orderType: { eq: 'MARKET' }
@@ -89,17 +92,17 @@ const getUIDef = () => ({
 
     limitPrice: {
       component: 'input.price',
-      label: 'OcO Limit Price $QUOTE'
+      label: `${t(i18n, 'orderForm.ocoLimitPrice', 'OcO Limit Price')} $QUOTE`
     },
 
     stopPrice: {
       component: 'input.price',
-      label: 'OcO Stop Price $QUOTE'
+      label: `${t(i18n, 'orderForm.ocoStopPrice', 'OcO Stop Price')} $QUOTE`
     },
 
     lev: {
       component: 'input.range',
-      label: 'Leverage',
+      label: t(i18n, 'orderForm.leverage', 'Leverage'),
       min: 1,
       max: 100,
       default: 10
@@ -107,20 +110,20 @@ const getUIDef = () => ({
 
     hidden: {
       component: 'input.checkbox',
-      label: 'HIDDEN',
+      label: t(i18n, 'orderForm.hidden', 'HIDDEN'),
       default: false,
-      customHelp: `This option allows you to place an order into the book but not have it displayed to
+      customHelp: t(i18n, 'orderForm.hidden.help', `This option allows you to place an order into the book but not have it displayed to
       other traders. Price/time priority is the same as a displayed order, but the hidden order will
-      always pay the "taker" fee while those trading against a hidden order will pay the "maker" fee`
+      always pay the "taker" fee while those trading against a hidden order will pay the "maker" fee`)
     },
 
     postonly: {
       component: 'input.checkbox',
-      label: 'POST-ONLY',
+      label: t(i18n, 'orderForm.postOnly', 'POST-ONLY'),
       default: false,
-      customHelp: `"Post Only" limit orders are orders that allow you to be sure to always pay the maker fee.
+      customHelp: t(i18n, 'orderForm.postOnly.help', `"Post Only" limit orders are orders that allow you to be sure to always pay the maker fee.
       When placed, a "Post Only" limit order is either inserted into the orderbook or cancelled and not matched
-      with a pre-existing order`,
+      with a pre-existing order`),
       disabled: {
         orderType: { neq: 'LIMIT' }
       }
@@ -128,18 +131,18 @@ const getUIDef = () => ({
 
     action: {
       component: 'input.radio',
-      label: 'Action',
-      options: ['Buy', 'Sell'],
+      label: t(i18n, 'orderForm.action', 'Action'),
+      options: [t(i18n, 'orderForm.buy', 'Buy'), t(i18n, 'orderForm.sell', 'Sell')],
       inline: true,
-      default: 'Buy'
+      default: t(i18n, 'orderForm.buy', 'Buy')
     },
 
     ocoAction: {
       component: 'input.radio',
-      label: 'Action',
-      options: ['Buy', 'Sell'],
+      label: t(i18n, 'orderForm.action', 'Action'),
+      options: [t(i18n, 'orderForm.buy', 'Buy'), t(i18n, 'orderForm.sell', 'Sell')],
       inline: true,
-      default: 'Buy'
+      default: t(i18n, 'orderForm.buy', 'Buy')
     }
   },
 

--- a/lib/ococo/meta/get_ui_def.js
+++ b/lib/ococo/meta/get_ui_def.js
@@ -61,7 +61,7 @@ const getUIDef = ({ i18n } = {}) => ({
     orderType: {
       component: 'input.dropdown',
       label: t(i18n, 'orderType', 'Order Type'),
-      default: t(i18n, 'limit', 'LIMIT'),
+      default: 'LIMIT',
       options: {
         LIMIT: t(i18n, 'limit', 'Limit'),
         MARKET: t(i18n, 'limit', 'Market')

--- a/lib/ococo/meta/get_ui_def.js
+++ b/lib/ococo/meta/get_ui_def.js
@@ -64,7 +64,7 @@ const getUIDef = ({ i18n } = {}) => ({
       default: 'LIMIT',
       options: {
         LIMIT: t(i18n, 'limit', 'Limit'),
-        MARKET: t(i18n, 'limit', 'Market')
+        MARKET: t(i18n, 'market', 'Market')
       }
     },
 

--- a/lib/ococo/meta/get_ui_def.js
+++ b/lib/ococo/meta/get_ui_def.js
@@ -10,14 +10,14 @@ const { t } = require('../../util/i18n')
  * @returns {object} uiDef
  */
 const getUIDef = ({ i18n } = {}) => ({
-  label: t(i18n, 'orderForm.ococo.title', 'Order Creates OcO'),
+  label: t(i18n, 'ococo.title', 'Order Creates OcO'),
   id: 'bfx-ococo',
 
   uiIcon: 'ma-crossover-active',
   connectionTimeout: 10000,
   actionTimeout: 10000,
 
-  customHelp: t(i18n, 'orderForm.ococo.help', [
+  customHelp: t(i18n, 'ococo.help', [
     'Creates a standard LIMIT or MARKET order, and schedules an OcO order to be',
     'submitted after the initial order fills. All of the normal LIMIT/MARKET',
     'parameters are available on both orders.'
@@ -36,7 +36,7 @@ const getUIDef = ({ i18n } = {}) => ({
       ['amount', 'action']
     ]
   }, {
-    title: t(i18n, 'orderForm.ocoSettings', 'OcO Settings'),
+    title: t(i18n, 'ocoSettings', 'OcO Settings'),
     name: 'shortEMASettings',
     fixed: true,
 
@@ -60,30 +60,30 @@ const getUIDef = ({ i18n } = {}) => ({
   fields: {
     orderType: {
       component: 'input.dropdown',
-      label: t(i18n, 'orderForm.orderType', 'Order Type'),
-      default: t(i18n, 'orderForm.limit', 'LIMIT'),
+      label: t(i18n, 'orderType', 'Order Type'),
+      default: t(i18n, 'limit', 'LIMIT'),
       options: {
-        LIMIT: t(i18n, 'orderForm.limit', 'Limit'),
-        MARKET: t(i18n, 'orderForm.limit', 'Market')
+        LIMIT: t(i18n, 'limit', 'Limit'),
+        MARKET: t(i18n, 'limit', 'Market')
       }
     },
 
     amount: {
       component: 'input.amount',
-      label: `${t(i18n, 'orderForm.amount', 'Amount')} $BASE`,
-      customHelp: t(i18n, 'orderForm.initialOrderAmount', 'Initial Order amount'),
+      label: `${t(i18n, 'amount', 'Amount')} $BASE`,
+      customHelp: t(i18n, 'initialOrderAmount', 'Initial Order amount'),
       priceField: 'orderPrice'
     },
 
     ocoAmount: {
       component: 'input.amount',
-      label: `${t(i18n, 'orderForm.amount', 'Amount')} $BASE`,
-      customHelp: t(i18n, 'orderForm.ocoOrderAmount', 'OcO Order amount')
+      label: `${t(i18n, 'amount', 'Amount')} $BASE`,
+      customHelp: t(i18n, 'ocoOrderAmount', 'OcO Order amount')
     },
 
     orderPrice: {
       component: 'input.price',
-      label: `${t(i18n, 'orderForm.initialOrderPrice', 'Initial Order Price')} $QUOTE`,
+      label: `${t(i18n, 'initialOrderPrice', 'Initial Order Price')} $QUOTE`,
 
       disabled: {
         orderType: { eq: 'MARKET' }
@@ -92,17 +92,17 @@ const getUIDef = ({ i18n } = {}) => ({
 
     limitPrice: {
       component: 'input.price',
-      label: `${t(i18n, 'orderForm.ocoLimitPrice', 'OcO Limit Price')} $QUOTE`
+      label: `${t(i18n, 'ocoLimitPrice', 'OcO Limit Price')} $QUOTE`
     },
 
     stopPrice: {
       component: 'input.price',
-      label: `${t(i18n, 'orderForm.ocoStopPrice', 'OcO Stop Price')} $QUOTE`
+      label: `${t(i18n, 'ocoStopPrice', 'OcO Stop Price')} $QUOTE`
     },
 
     lev: {
       component: 'input.range',
-      label: t(i18n, 'orderForm.leverage', 'Leverage'),
+      label: t(i18n, 'leverage', 'Leverage'),
       min: 1,
       max: 100,
       default: 10
@@ -110,18 +110,18 @@ const getUIDef = ({ i18n } = {}) => ({
 
     hidden: {
       component: 'input.checkbox',
-      label: t(i18n, 'orderForm.hidden', 'HIDDEN'),
+      label: t(i18n, 'hidden', 'HIDDEN'),
       default: false,
-      customHelp: t(i18n, 'orderForm.hidden.help', `This option allows you to place an order into the book but not have it displayed to
+      customHelp: t(i18n, 'hidden.help', `This option allows you to place an order into the book but not have it displayed to
       other traders. Price/time priority is the same as a displayed order, but the hidden order will
       always pay the "taker" fee while those trading against a hidden order will pay the "maker" fee`)
     },
 
     postonly: {
       component: 'input.checkbox',
-      label: t(i18n, 'orderForm.postOnly', 'POST-ONLY'),
+      label: t(i18n, 'postOnly', 'POST-ONLY'),
       default: false,
-      customHelp: t(i18n, 'orderForm.postOnly.help', `"Post Only" limit orders are orders that allow you to be sure to always pay the maker fee.
+      customHelp: t(i18n, 'postOnly.help', `"Post Only" limit orders are orders that allow you to be sure to always pay the maker fee.
       When placed, a "Post Only" limit order is either inserted into the orderbook or cancelled and not matched
       with a pre-existing order`),
       disabled: {
@@ -131,18 +131,18 @@ const getUIDef = ({ i18n } = {}) => ({
 
     action: {
       component: 'input.radio',
-      label: t(i18n, 'orderForm.action', 'Action'),
-      options: [t(i18n, 'orderForm.buy', 'Buy'), t(i18n, 'orderForm.sell', 'Sell')],
+      label: t(i18n, 'action', 'Action'),
+      options: [t(i18n, 'buy', 'Buy'), t(i18n, 'sell', 'Sell')],
       inline: true,
-      default: t(i18n, 'orderForm.buy', 'Buy')
+      default: t(i18n, 'buy', 'Buy')
     },
 
     ocoAction: {
       component: 'input.radio',
-      label: t(i18n, 'orderForm.action', 'Action'),
-      options: [t(i18n, 'orderForm.buy', 'Buy'), t(i18n, 'orderForm.sell', 'Sell')],
+      label: t(i18n, 'action', 'Action'),
+      options: [t(i18n, 'buy', 'Buy'), t(i18n, 'sell', 'Sell')],
       inline: true,
-      default: t(i18n, 'orderForm.buy', 'Buy')
+      default: t(i18n, 'buy', 'Buy')
     }
   },
 

--- a/lib/ococo/meta/validate_params.js
+++ b/lib/ococo/meta/validate_params.js
@@ -3,6 +3,7 @@
 const _isFinite = require('lodash/isFinite')
 const _includes = require('lodash/includes')
 const validationErrObj = require('../../util/validate_params_err')
+const { apply: applyI18N } = require('../../util/i18n')
 
 const ORDER_TYPES = ['MARKET', 'LIMIT']
 
@@ -37,33 +38,106 @@ const validateParams = (args = {}, pairConfig = {}) => {
     stopPrice, ocoAmount, lev, _futures, action, ocoAction
   } = args
 
-  if (!_includes(ORDER_TYPES, orderType)) return validationErrObj('orderType', `Invalid order type: ${orderType}`)
-  if (!_isFinite(amount) || amount === 0) return validationErrObj('amount', 'Invalid amount')
+  if (!_includes(ORDER_TYPES, orderType)) {
+    return applyI18N(
+      validationErrObj('orderType', `Invalid order type: ${orderType}`),
+      'invalidOrderType', { orderType }
+    )
+  }
+  if (!_isFinite(amount) || amount === 0) {
+    return applyI18N(
+      validationErrObj('amount', 'Invalid amount'),
+      'invalidAmount'
+    )
+  }
   if (orderType === 'LIMIT' && !_isFinite(orderPrice)) {
-    return validationErrObj('orderPrice', 'Limit price required for LIMIT order type')
+    return applyI18N(
+      validationErrObj('orderPrice', 'Limit price required for LIMIT order type'),
+      'limitPriceRequiredForLimitOrderType'
+    )
   }
 
-  if (!_isFinite(limitPrice)) return validationErrObj('limitPrice', 'Invalid OCO limit price')
-  if (!_isFinite(stopPrice)) return validationErrObj('stopPrice', 'Invalid OCO stop price')
-  if (!_isFinite(ocoAmount) || ocoAmount === 0) return validationErrObj('ocoAmount', 'Invalid OCO amount')
+  if (!_isFinite(limitPrice)) {
+    return applyI18N(
+      validationErrObj('limitPrice', 'Invalid OCO limit price'),
+      'invalidOcoLimitPrice'
+    )
+  }
+  if (!_isFinite(stopPrice)) {
+    return applyI18N(
+      validationErrObj('stopPrice', 'Invalid OCO stop price'),
+      'invalidOcoStopPrice'
+    )
+  }
+  if (!_isFinite(ocoAmount) || ocoAmount === 0) {
+    return applyI18N(
+      validationErrObj('ocoAmount', 'Invalid OCO amount'),
+      'invalidOcoAmount'
+    )
+  }
 
-  if (action !== 'Buy' && action !== 'Sell') return validationErrObj('action', `Invalid action: ${action}`)
-  if (ocoAction !== 'Buy' && ocoAction !== 'Sell') return validationErrObj('ocoAction', `Invalid OCO action: ${ocoAction}`)
+  if (action !== 'Buy' && action !== 'Sell') {
+    return applyI18N(
+      validationErrObj('action', `Invalid action: ${action}`),
+      'invalidAction', { action }
+    )
+  }
+  if (ocoAction !== 'Buy' && ocoAction !== 'Sell') {
+    return applyI18N(
+      validationErrObj('ocoAction', `Invalid OCO action: ${ocoAction}`),
+      'invalidOcoAction', { ocoAction }
+    )
+  }
 
   if (_isFinite(minSize)) {
-    if (Math.abs(amount) < minSize) return validationErrObj('amount', `Amount cannot be less than ${minSize}`)
-    if (Math.abs(ocoAmount) < minSize) return validationErrObj('ocoAmount', `Slice amount cannot be less than ${minSize}`)
+    if (Math.abs(amount) < minSize) {
+      return applyI18N(
+        validationErrObj('amount', `Amount cannot be less than ${minSize}`),
+        'amountCannotBeLessThan', { minSize }
+      )
+    }
+    if (Math.abs(ocoAmount) < minSize) {
+      return applyI18N(
+        validationErrObj('ocoAmount', `Slice amount cannot be less than ${minSize}`),
+        'sliceAmountCannotBeLessThan', { minSize }
+      )
+    }
   }
 
   if (_isFinite(maxSize)) {
-    if (Math.abs(amount) > maxSize) return validationErrObj('amount', `Amount cannot be greater than ${maxSize}`)
-    if (Math.abs(ocoAmount) > maxSize) return validationErrObj('ocoAmount', `Slice amount cannot be greater than ${maxSize}`)
+    if (Math.abs(amount) > maxSize) {
+      return applyI18N(
+        validationErrObj('amount', `Amount cannot be greater than ${maxSize}`),
+        'amountCannotBeGreaterThan', { maxSize }
+      )
+    }
+    if (Math.abs(ocoAmount) > maxSize) {
+      return applyI18N(
+        validationErrObj('ocoAmount', `Slice amount cannot be greater than ${maxSize}`),
+        'sliceAmountCannotBeGreaterThan', { maxSize }
+      )
+    }
   }
 
   if (_futures) {
-    if (!_isFinite(lev)) return validationErrObj('lev', 'Invalid leverage')
-    if (lev < 1) return validationErrObj('lev', 'Leverage cannot be less than 1')
-    if (_isFinite(maxLev) && (lev > maxLev)) return validationErrObj('lev', `Leverage cannot be greater than ${maxLev}`)
+    if (!_isFinite(lev)) {
+      return applyI18N(
+        validationErrObj('lev', 'Invalid leverage'),
+        'invalidLeverage'
+      )
+    }
+    if (lev < 1) {
+      return applyI18N(
+        validationErrObj('lev', 'Leverage cannot be less than 1'),
+        'leverageCannotBeLessThan', { minLev: 1 }
+      )
+    }
+    if (_isFinite(maxLev) && (lev > maxLev)) {
+      return applyI18N(
+        validationErrObj('lev', `Leverage cannot be greater than ${maxLev}`),
+        'leverageCannotBeGreaterThan', { maxLev }
+      )
+    }
   }
 
   return null

--- a/lib/ping_pong/meta/gen_order_label.js
+++ b/lib/ping_pong/meta/gen_order_label.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { apply: applyI18N } = require('../../util/i18n')
+
 /**
  * Generates a label for a PingPong instance for rendering in an UI.
  *
@@ -18,11 +20,19 @@ const genOrderLabel = (state = {}) => {
   } = args
 
   if (orderCount === 1) {
-    return `Ping/Pong | ${pingAmount}:${pongAmount} @ ${pingPrice} -> ${pongPrice} `
+    return applyI18N(
+      { origin: `Ping/Pong | ${pingAmount}:${pongAmount} @ ${pingPrice} -> ${pongPrice} ` },
+      'pingPongSingle.label',
+      { pingAmount, pongAmount, pingPrice, pongPrice }
+    )
   } else {
     const sign = pongAmount < 0 ? '-' : '+'
     const spread = `[${pingMinPrice}..${pingMaxPrice}]`
-    return `Ping/Pong | ${pingAmount}:${pongAmount} @ ${spread} -> ${sign}${pongDistance} `
+    return applyI18N(
+      { origin: `Ping/Pong | ${pingAmount}:${pongAmount} @ ${spread} -> ${sign}${pongDistance} ` },
+      'pingPong.label',
+      { pingAmount, pongAmount, spread, sign, pongDistance }
+    )
   }
 }
 

--- a/lib/ping_pong/meta/get_ui_def.js
+++ b/lib/ping_pong/meta/get_ui_def.js
@@ -11,11 +11,11 @@ const { t } = require('../../util/i18n')
  * @returns {AOUIDefinition} uiDef
  */
 const getUIDef = ({ i18n } = {}) => ({
-  label: t(i18n, 'orderForm.pingpong.title', 'Ping/Pong'),
+  label: t(i18n, 'pingpong.title', 'Ping/Pong'),
   id: 'bfx-ping_pong',
 
   uiIcon: 'ping-pong-active',
-  customHelp: t(i18n, 'orderForm.pingpong.help', [
+  customHelp: t(i18n, 'pingpong.help', [
     'Ping/pong submits multiple \'ping\' orders; once a ping order fills, an',
     'associated \'pong\' order is submitted.\n\nMultiple ping/pong pairs can',
     'be created by specifying an order count greater than 1, a suitable',
@@ -86,9 +86,9 @@ const getUIDef = ({ i18n } = {}) => ({
   fields: {
     hidden: {
       component: 'input.checkbox',
-      label: t(i18n, 'orderForm.hidden', 'HIDDEN'),
+      label: t(i18n, 'hidden', 'HIDDEN'),
       default: false,
-      customHelp: t(i18n, 'orderForm.hidden.help',
+      customHelp: t(i18n, 'hidden.help',
       `This option allows you to place an order into the book but not have it displayed to
       other traders. Price/time priority is the same as a displayed order, but the hidden order will
       always pay the "taker" fee while those trading against a hidden order will pay the "maker" fee`)
@@ -96,47 +96,47 @@ const getUIDef = ({ i18n } = {}) => ({
 
     splitPingPongAmount: {
       component: 'input.checkbox',
-      label: t(i18n, 'orderForm.splitAmount', 'SPLIT AMOUNT'),
+      label: t(i18n, 'splitAmount', 'SPLIT AMOUNT'),
       default: false,
-      customHelp: t(i18n, 'orderForm.pingpong.splitAmount.help', 'Provide seperate ping/pong amounts')
+      customHelp: t(i18n, 'pingpong.splitAmount.help', 'Provide seperate ping/pong amounts')
     },
 
     endless: {
       component: 'input.checkbox',
-      label: t(i18n, 'orderForm.endless', 'ENDLESS'),
+      label: t(i18n, 'endless', 'ENDLESS'),
       default: false,
-      customHelp: t(i18n, 'orderForm.pingpong.endless.help', 'If true, pings will be recreated once their associated pongs fill')
+      customHelp: t(i18n, 'pingpong.endless.help', 'If true, pings will be recreated once their associated pongs fill')
     },
 
     pingPrice: {
       component: 'input.price',
-      label: `${t(i18n, 'orderForm.pingpong.pingPrice', 'Ping Price')} $QUOTE`
+      label: `${t(i18n, 'pingpong.pingPrice', 'Ping Price')} $QUOTE`
     },
 
     pongPrice: {
       component: 'input.price',
-      label: `${t(i18n, 'orderForm.pingpong.pongPrice', 'Pong Price')} $QUOTE`
+      label: `${t(i18n, 'pingpong.pongPrice', 'Pong Price')} $QUOTE`
     },
 
     pongDistance: {
       component: 'input.number',
-      label: t(i18n, 'orderForm.pingpong.pongDistance', 'Pong Distance')
+      label: t(i18n, 'pingpong.pongDistance', 'Pong Distance')
     },
 
     pingMinPrice: {
       component: 'input.price',
-      label: `${t(i18n, 'orderForm.pingpong.pingMinPrice', 'Ping Min Price')} $QUOTE`
+      label: `${t(i18n, 'pingpong.pingMinPrice', 'Ping Min Price')} $QUOTE`
     },
 
     pingMaxPrice: {
       component: 'input.price',
-      label: `${t(i18n, 'orderForm.pingpong.pingMaxPrice', 'Ping Max Price')} $QUOTE`
+      label: `${t(i18n, 'pingpong.pingMaxPrice', 'Ping Max Price')} $QUOTE`
     },
 
     amount: {
       component: 'input.amount',
-      label: `${t(i18n, 'orderForm.amount', 'Amount')} $BASE`,
-      customHelp: t(i18n, 'orderForm.totalOrderAmount', 'Total order amount'),
+      label: `${t(i18n, 'amount', 'Amount')} $BASE`,
+      customHelp: t(i18n, 'totalOrderAmount', 'Total order amount'),
 
       visible: {
         splitPingPongAmount: { eq: false }
@@ -145,25 +145,25 @@ const getUIDef = ({ i18n } = {}) => ({
 
     pingAmount: {
       component: 'input.amount',
-      label: `${t(i18n, 'orderForm.pingpong.pingAmount', 'Ping Amount')} $BASE`,
-      customHelp: t(i18n, 'orderForm.pingpong.pingOrderSize', 'Ping order size')
+      label: `${t(i18n, 'pingpong.pingAmount', 'Ping Amount')} $BASE`,
+      customHelp: t(i18n, 'pingpong.pingOrderSize', 'Ping order size')
     },
 
     pongAmount: {
       component: 'input.amount',
-      label: `${t(i18n, 'orderForm.pingpong.pongAmount', 'Pong Amount')} $BASE`,
-      customHelp: t(i18n, 'orderForm.pingpong.pongOrderSize', 'Pong order size')
+      label: `${t(i18n, 'pingpong.pongAmount', 'Pong Amount')} $BASE`,
+      customHelp: t(i18n, 'pingpong.pongOrderSize', 'Pong order size')
     },
 
     orderCount: {
       component: 'input.number',
-      label: t(i18n, 'orderForm.orderCount', 'Order Count'),
+      label: t(i18n, 'orderCount', 'Order Count'),
       default: '1'
     },
 
     lev: {
       component: 'input.range',
-      label: t(i18n, 'orderForm.leverage', 'Leverage'),
+      label: t(i18n, 'leverage', 'Leverage'),
       min: 1,
       max: 100,
       default: 10
@@ -171,10 +171,10 @@ const getUIDef = ({ i18n } = {}) => ({
 
     action: {
       component: 'input.radio',
-      label: t(i18n, 'orderForm.action', 'Action'),
-      options: [t(i18n, 'orderForm.buy', 'Buy'), t(i18n, 'orderForm.sell', 'Sell')],
+      label: t(i18n, 'action', 'Action'),
+      options: [t(i18n, 'buy', 'Buy'), t(i18n, 'sell', 'Sell')],
       inline: true,
-      default: t(i18n, 'orderForm.buy', 'Buy')
+      default: t(i18n, 'buy', 'Buy')
     }
   },
 

--- a/lib/ping_pong/meta/get_ui_def.js
+++ b/lib/ping_pong/meta/get_ui_def.js
@@ -1,4 +1,5 @@
 'use strict'
+const { t } = require('../../util/i18n')
 
 /**
  * Returns the UI layout definition for PingPong, with a field for each
@@ -9,19 +10,19 @@
  * @memberOf module:PingPong
  * @returns {AOUIDefinition} uiDef
  */
-const getUIDef = () => ({
-  label: 'Ping/Pong',
+const getUIDef = ({ i18n } = {}) => ({
+  label: t(i18n, 'orderForm.pingpong.title', 'Ping/Pong'),
   id: 'bfx-ping_pong',
 
   uiIcon: 'ping-pong-active',
-  customHelp: [
+  customHelp: t(i18n, 'orderForm.pingpong.help', [
     'Ping/pong submits multiple \'ping\' orders; once a ping order fills, an',
     'associated \'pong\' order is submitted.\n\nMultiple ping/pong pairs can',
     'be created by specifying an order count greater than 1, a suitable',
     'min/max ping price, and a pong distance. Multiple ping orders will be',
     'created between the specified min/max prices, with the associated pongs',
     'offset by the pong distance from the ping price'
-  ].join(' '),
+  ].join(' ')),
 
   connectionTimeout: 10000,
   actionTimeout: 10000,
@@ -85,56 +86,57 @@ const getUIDef = () => ({
   fields: {
     hidden: {
       component: 'input.checkbox',
-      label: 'HIDDEN',
+      label: t(i18n, 'orderForm.hidden', 'HIDDEN'),
       default: false,
-      customHelp: `This option allows you to place an order into the book but not have it displayed to
+      customHelp: t(i18n, 'orderForm.hidden.help',
+      `This option allows you to place an order into the book but not have it displayed to
       other traders. Price/time priority is the same as a displayed order, but the hidden order will
-      always pay the "taker" fee while those trading against a hidden order will pay the "maker" fee`
+      always pay the "taker" fee while those trading against a hidden order will pay the "maker" fee`)
     },
 
     splitPingPongAmount: {
       component: 'input.checkbox',
-      label: 'SPLIT AMOUNT',
+      label: t(i18n, 'orderForm.splitAmount', 'SPLIT AMOUNT'),
       default: false,
-      customHelp: 'Provide seperate ping/pong amounts'
+      customHelp: t(i18n, 'orderForm.pingpong.splitAmount.help', 'Provide seperate ping/pong amounts')
     },
 
     endless: {
       component: 'input.checkbox',
-      label: 'ENDLESS',
+      label: t(i18n, 'orderForm.endless', 'ENDLESS'),
       default: false,
-      customHelp: 'If true, pings will be recreated once their associated pongs fill'
+      customHelp: t(i18n, 'orderForm.pingpong.endless.help', 'If true, pings will be recreated once their associated pongs fill')
     },
 
     pingPrice: {
       component: 'input.price',
-      label: 'Ping Price $QUOTE'
+      label: `${t(i18n, 'orderForm.pingpong.pingPrice', 'Ping Price')} $QUOTE`
     },
 
     pongPrice: {
       component: 'input.price',
-      label: 'Pong Price $QUOTE'
+      label: `${t(i18n, 'orderForm.pingpong.pongPrice', 'Pong Price')} $QUOTE`
     },
 
     pongDistance: {
       component: 'input.number',
-      label: 'Pong Distance'
+      label: t(i18n, 'orderForm.pingpong.pongDistance', 'Pong Distance')
     },
 
     pingMinPrice: {
       component: 'input.price',
-      label: 'Ping Min Price $QUOTE'
+      label: `${t(i18n, 'orderForm.pingpong.pingMinPrice', 'Ping Min Price')} $QUOTE`
     },
 
     pingMaxPrice: {
       component: 'input.price',
-      label: 'Ping Max Price $QUOTE'
+      label: `${t(i18n, 'orderForm.pingpong.pingMaxPrice', 'Ping Max Price')} $QUOTE`
     },
 
     amount: {
       component: 'input.amount',
-      label: 'Amount $BASE',
-      customHelp: 'Total order amount',
+      label: `${t(i18n, 'orderForm.amount', 'Amount')} $BASE`,
+      customHelp: t(i18n, 'orderForm.totalOrderAmount', 'Total order amount'),
 
       visible: {
         splitPingPongAmount: { eq: false }
@@ -143,25 +145,25 @@ const getUIDef = () => ({
 
     pingAmount: {
       component: 'input.amount',
-      label: 'Ping Amount $BASE',
-      customHelp: 'Ping order size'
+      label: `${t(i18n, 'orderForm.pingpong.pingAmount', 'Ping Amount')} $BASE`,
+      customHelp: t(i18n, 'orderForm.pingpong.pingOrderSize', 'Ping order size')
     },
 
     pongAmount: {
       component: 'input.amount',
-      label: 'Pong Amount $BASE',
-      customHelp: 'Pong order size'
+      label: `${t(i18n, 'orderForm.pingpong.pongAmount', 'Pong Amount')} $BASE`,
+      customHelp: t(i18n, 'orderForm.pingpong.pongOrderSize', 'Pong order size')
     },
 
     orderCount: {
       component: 'input.number',
-      label: 'Order Count',
+      label: t(i18n, 'orderForm.orderCount', 'Order Count'),
       default: '1'
     },
 
     lev: {
       component: 'input.range',
-      label: 'Leverage',
+      label: t(i18n, 'orderForm.leverage', 'Leverage'),
       min: 1,
       max: 100,
       default: 10
@@ -169,10 +171,10 @@ const getUIDef = () => ({
 
     action: {
       component: 'input.radio',
-      label: 'Action',
-      options: ['Buy', 'Sell'],
+      label: t(i18n, 'orderForm.action', 'Action'),
+      options: [t(i18n, 'orderForm.buy', 'Buy'), t(i18n, 'orderForm.sell', 'Sell')],
       inline: true,
-      default: 'Buy'
+      default: t(i18n, 'orderForm.buy', 'Buy')
     }
   },
 

--- a/lib/ping_pong/meta/validate_params.js
+++ b/lib/ping_pong/meta/validate_params.js
@@ -76,7 +76,7 @@ const validateParams = (args = {}, pairConfig = {}) => {
     if (pingAmount < 0 && pongPrice > pingPrice) {
       return applyI18N(
         validationErrObj('pongPrice', 'Pong price must be less than ping price for sell orders'),
-        ['pongPriceMustBeLessThanPingForSellOrders']
+        'pongPriceMustBeLessThanPingForSellOrders'
       )
     }
   }

--- a/lib/ping_pong/meta/validate_params.js
+++ b/lib/ping_pong/meta/validate_params.js
@@ -2,6 +2,7 @@
 
 const _isFinite = require('lodash/isFinite')
 const validationErrObj = require('../../util/validate_params_err')
+const { apply: applyI18N } = require('../../util/i18n')
 
 /**
  * Verifies that a parameters Object is valid, and all parameters are within
@@ -33,90 +34,139 @@ const validateParams = (args = {}, pairConfig = {}) => {
   } = args
 
   if (!_isFinite(orderCount) || orderCount < 1) {
-    return validationErrObj('orderCount', `Invalid order count: ${orderCount}`)
+    return applyI18N(
+      validationErrObj('orderCount', `Invalid order count: ${orderCount}`),
+      'invalidOrderCount', { orderCount }
+    )
   }
 
   if (!_isFinite(pingAmount) || pingAmount === 0) {
-    return validationErrObj(
+    return applyI18N(validationErrObj(
       splitPingPongAmount ? 'pingAmount' : 'amount',
       splitPingPongAmount ? 'Invalid ping amount' : 'Invalid amount'
-    )
+    ), splitPingPongAmount ? 'invalidPingAmount' : 'invalidAmount')
   }
 
   if (!_isFinite(pongAmount) || pongAmount === 0) {
-    return validationErrObj(
+    return applyI18N(validationErrObj(
       splitPingPongAmount ? 'pongAmount' : 'amount',
       splitPingPongAmount ? 'Invalid pong amount' : 'Invalid amount'
-    )
+    ), splitPingPongAmount ? 'invalidPongAmount' : 'invalidAmount')
   }
 
   if (orderCount === 1) {
-    if (!_isFinite(pingPrice) || pingPrice <= 0) return validationErrObj('pingPrice', 'Invalid ping price')
-    if (!_isFinite(pongPrice) || pongPrice <= 0) return validationErrObj('pongPrice', 'Invalid pong price')
+    if (!_isFinite(pingPrice) || pingPrice <= 0) {
+      return applyI18N(
+        validationErrObj('pingPrice', 'Invalid ping price'),
+        'invalidPingPrice'
+      )
+    }
+    if (!_isFinite(pongPrice) || pongPrice <= 0) {
+      return applyI18N(
+        validationErrObj('pongPrice', 'Invalid pong price'),
+        'invalidPongPrice'
+      )
+    }
     if (pingAmount > 0 && pongPrice < pingPrice) {
-      return validationErrObj('pongPrice', 'Pong price must be greater than ping price for buy orders')
+      return applyI18N(
+        validationErrObj('pongPrice', 'Pong price must be greater than ping price for buy orders'),
+        'pongPriceMustBeGreaterThanPingForBuyOrders'
+      )
     }
     if (pingAmount < 0 && pongPrice > pingPrice) {
-      return validationErrObj('pongPrice', 'Pong price must be less than ping price for sell orders')
+      return applyI18N(
+        validationErrObj('pongPrice', 'Pong price must be less than ping price for sell orders'),
+        ['pongPriceMustBeLessThanPingForSellOrders']
+      )
     }
   }
 
   if (orderCount > 1) {
     if (!_isFinite(pingMinPrice) || pingMinPrice <= 0) {
-      return validationErrObj('pingMinPrice', `Invalid ping min price: ${pingMinPrice}`)
+      return applyI18N(
+        validationErrObj('pingMinPrice', `Invalid ping min price: ${pingMinPrice}`),
+        'invalidPingMinPrice', { pingMinPrice }
+      )
     }
 
     if (!_isFinite(pingMaxPrice) || pingMaxPrice <= 0) {
-      return validationErrObj('pingMaxPrice', `Invalid ping max price: ${pingMaxPrice}`)
+      return applyI18N(
+        validationErrObj('pingMaxPrice', `Invalid ping max price: ${pingMaxPrice}`),
+        'invalidPingMaxPrice', { pingMaxPrice }
+      )
     }
 
     if (!_isFinite(pongDistance)) {
-      return validationErrObj('pongDistance', `Invalid pong distance: ${pongDistance}`)
+      return applyI18N(
+        validationErrObj('pongDistance', `Invalid pong distance: ${pongDistance}`),
+        'invalidPongDistance', { pongDistance }
+      )
     }
 
     if (pingMaxPrice < pingMinPrice) {
-      return validationErrObj('pingMaxPrice', 'Ping max price must be greater than min price')
+      return applyI18N(
+        validationErrObj('pingMaxPrice', 'Ping max price must be greater than min price'),
+        'pingMaxPriceGreaterThanMinPrice'
+      )
     }
 
     if (pongDistance <= 0) {
-      return validationErrObj('pongDistance', 'Pong distance must be positive')
+      return applyI18N(
+        validationErrObj('pongDistance', 'Pong distance must be positive'),
+        'pongDistancePositive'
+      )
     }
   }
 
   if (_isFinite(minSize)) {
     if (Math.abs(pingAmount) < minSize) {
-      return validationErrObj(
+      return applyI18N(validationErrObj(
         splitPingPongAmount ? 'pingAmount' : 'amount',
         `${splitPingPongAmount ? 'Ping amount' : 'Amount'} cannot be less than ${minSize}`
-      )
+      ), splitPingPongAmount ? 'pingAmountCannotBeLessThan' : 'amountCannotBeLessThan', { minSize })
     }
     if (Math.abs(pongAmount) < minSize) {
-      return validationErrObj(
+      return applyI18N(validationErrObj(
         splitPingPongAmount ? 'pongAmount' : 'amount',
         `${splitPingPongAmount ? 'Pong amount' : 'Amount'} cannot be less than ${minSize}`
-      )
+      ), splitPingPongAmount ? 'pongAmountCannotBeLessThan' : 'amountCannotBeLessThan', { minSize })
     }
   }
 
   if (_isFinite(maxSize)) {
     if (Math.abs(pingAmount) > maxSize) {
-      return validationErrObj(
+      return applyI18N(validationErrObj(
         splitPingPongAmount ? 'pingAmount' : 'amount',
         `${splitPingPongAmount ? 'Ping amount' : 'Amount'} cannot be greater than ${maxSize}`
-      )
+      ), splitPingPongAmount ? 'pingAmountCannotBeGreaterThan' : 'amountCannotBeGreaterThan', { maxSize })
     }
     if (Math.abs(pongAmount) > maxSize) {
-      return validationErrObj(
+      return applyI18N(validationErrObj(
         splitPingPongAmount ? 'pongAmount' : 'amount',
         `${splitPingPongAmount ? 'Pong amount' : 'Amount'} cannot be greater than ${maxSize}`
-      )
+      ), splitPingPongAmount ? 'pongAmountCannotBeGreaterThan' : 'amountCannotBeGreaterThan', { maxSize })
     }
   }
 
   if (_futures) {
-    if (!_isFinite(lev)) return validationErrObj('lev', 'Invalid leverage')
-    if (lev < 1) return validationErrObj('lev', 'Leverage cannot be less than 1')
-    if (_isFinite(maxLev) && (lev > maxLev)) return validationErrObj('lev', `Leverage cannot be greater than ${maxLev}`)
+    if (!_isFinite(lev)) {
+      return applyI18N(
+        validationErrObj('lev', 'Invalid leverage'),
+        'invalidLeverage'
+      )
+    }
+    if (lev < 1) {
+      return applyI18N(
+        validationErrObj('lev', 'Leverage cannot be less than 1'),
+        'leverageCannotBeLessThan', { minLev: 1 }
+      )
+    }
+    if (_isFinite(maxLev) && (lev > maxLev)) {
+      return applyI18N(
+        validationErrObj('lev', `Leverage cannot be greater than ${maxLev}`),
+        'leverageCannotBeGreaterThan', { maxLev }
+      )
+    }
   }
 
   return null

--- a/lib/twap/meta/gen_order_label.js
+++ b/lib/twap/meta/gen_order_label.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { apply: applyI18N } = require('../../util/i18n')
+
 /**
  * Generates a label for a TWAP instance for rendering in an UI.
  *
@@ -16,16 +18,22 @@ const genOrderLabel = (state = {}) => {
     sliceAmount, sliceInterval, amount, priceTarget, priceCondition,
     tradeBeyondEnd
   } = args
+  const interval = Math.floor(sliceInterval / 1000)
 
-  return [
-    'TWAP',
-    ' | slice ', sliceAmount,
-    ' | total ', amount,
-    ' | interval ', Math.floor(sliceInterval / 1000), 's',
-    ' | target ', priceTarget,
-    ' | target == ', priceCondition,
-    ' | TBE ', tradeBeyondEnd
-  ].join('')
+  return applyI18N({
+    origin: [
+      'TWAP',
+      ' | slice ', sliceAmount,
+      ' | total ', amount,
+      ' | interval ', interval, 's',
+      ' | target ', priceTarget,
+      ' | target == ', priceCondition,
+      ' | TBE ', tradeBeyondEnd
+    ].join('')
+  },
+  'twap.label',
+  { sliceAmount, amount, interval, priceTarget, priceCondition, tradeBeyondEnd }
+  )
 }
 
 module.exports = genOrderLabel

--- a/lib/twap/meta/get_ui_def.js
+++ b/lib/twap/meta/get_ui_def.js
@@ -1,3 +1,6 @@
+'use strict'
+const { t } = require('../../util/i18n')
+
 /**
  * Returns the UI layout definition for TWAP, with a field for each parameter.
  *
@@ -6,12 +9,12 @@
  * @memberOf module:TWAP
  * @returns {AOUIDefinition} uiDef
  */
-const getUIDef = () => ({
-  label: 'TWAP',
+const getUIDef = ({ i18n } = {}) => ({
+  label: t(i18n, 'orderForm.twap.title', 'TWAP'),
   id: 'bfx-twap',
 
   uiIcon: 'twap-active',
-  customHelp: [
+  customHelp: t(i18n, 'orderForm.twap.help', [
     'TWAP spreads an order out through time in order to fill at the',
     'time-weighted average price, calculated between the time the order is',
     'submitted to the final atomic order close.\n\nThe price target may be set',
@@ -22,7 +25,7 @@ const getUIDef = () => ({
     'target must be within the delta in order to match.',
     '\n\nNote: If amount distortion is provided, the total order amounts will',
     'not exceed the total amount but may be slightly less than the total amount specified.'
-  ].join(' '),
+  ].join(' ')),
 
   connectionTimeout: 10000,
   actionTimeout: 10000,
@@ -71,52 +74,52 @@ const getUIDef = () => ({
   fields: {
     tradeBeyondEnd: {
       component: 'input.checkbox',
-      label: 'Trade Beyond End',
-      customHelp: 'Continue trading beyond slice interval',
+      label: t(i18n, 'orderForm.tradeBeyondEnd', 'Trade Beyond End'),
+      customHelp: t(i18n, 'orderForm.tradeBeyondEnd.help', 'Continue trading beyond slice interval'),
       default: false
     },
 
     orderType: {
       component: 'input.dropdown',
-      label: 'Order Type',
+      label: t(i18n, 'orderForm.orderType', 'Order Type'),
       default: 'LIMIT',
       options: {
-        LIMIT: 'Limit',
-        MARKET: 'Market'
+        LIMIT: t(i18n, 'orderForm.limit', 'Limit'),
+        MARKET: t(i18n, 'orderForm.market', 'Market')
       }
     },
 
     amount: {
       component: 'input.amount',
-      label: 'Amount $BASE',
-      customHelp: 'Total order amount',
+      label: `${t(i18n, 'orderForm.amount', 'Amount')} $BASE`,
+      customHelp: t(i18n, 'orderForm.amount.help', 'Total order amount'),
       priceField: 'price'
     },
 
     amountDistortion: {
       component: 'input.percent',
       default: 0,
-      label: 'Amount Distortion %',
-      customHelp: 'Amount to distort individual order sizes to prevent detection, in percent'
+      label: t(i18n, 'orderForm.amountDistortionPerc', 'Amount Distortion %'),
+      customHelp: t(i18n, 'orderForm.amountDistortionPerc.help', 'Amount to distort individual order sizes to prevent detection, in percent')
     },
 
     sliceAmount: {
       component: 'input.number',
-      label: 'Slice Amount $BASE',
-      customHelp: 'Allows individual buy & sell amounts to be adjusted'
+      label: `${t(i18n, 'orderForm.sliceAmount', 'Slice Amount')} $BASE`,
+      customHelp: t(i18n, 'orderForm.sliceAmount.help', 'Allows individual buy & sell amounts to be adjusted')
     },
 
     sliceInterval: {
       component: 'input.number',
       default: 2,
-      label: 'Slice Interval (sec)',
-      customHelp: 'Duration over which to trade slice'
+      label: t(i18n, 'orderForm.sliceIntervalSec', 'Slice Interval (sec)'),
+      customHelp: t(i18n, 'orderForm.sliceIntervalSec.help', 'Duration over which to trade slice')
     },
 
     priceDelta: {
       component: 'input.number',
-      label: 'Target Delta',
-      customHelp: '± Distance from price target for match',
+      label: t(i18n, 'orderForm.targetDelta', 'Target Delta'),
+      customHelp: t(i18n, 'orderForm.twap.targetDelta.help', '± Distance from price target for match'),
       disabled: {
         priceTarget: { neq: 'CUSTOM' }
       }
@@ -124,8 +127,8 @@ const getUIDef = () => ({
 
     price: {
       component: 'input.price',
-      label: 'Price $QUOTE',
-      customHelp: 'Requires \'custom\' price target',
+      label: `${t(i18n, 'orderForm.price', 'Price')} $QUOTE`,
+      customHelp: t(i18n, 'orderForm.twap.price.help', 'Requires \'custom\' price target'),
       disabled: {
         priceTarget: { neq: 'CUSTOM' }
       }
@@ -133,35 +136,35 @@ const getUIDef = () => ({
 
     priceTarget: {
       component: 'input.dropdown',
-      label: 'Price Target',
+      label: t(i18n, 'orderForm.priceTarget', 'Price Target'),
       default: 'OB_MID',
       options: {
-        OB_MID: 'OB mid price',
-        OB_SIDE: 'OB side price',
-        LAST: 'Last trade price',
-        CUSTOM: 'Custom'
+        OB_MID: t(i18n, 'orderForm.obMidPrice', 'OB mid price'),
+        OB_SIDE: t(i18n, 'orderForm.obSidePrice', 'OB side price'),
+        LAST: t(i18n, 'orderForm.lastTradePrice', 'Last trade price'),
+        CUSTOM: t(i18n, 'orderForm.custom', 'Custom')
       }
     },
 
     priceCondition: {
       component: 'input.dropdown',
-      label: 'Price Condition',
+      label: t(i18n, 'orderForm.priceCondition', 'Price Condition'),
       default: 'MATCH_MIDPOINT',
-      customHelp: 'Match point for custom price targets',
+      customHelp: t(i18n, 'orderForm.priceCondition.help', 'Match point for custom price targets'),
       visible: {
         priceTarget: { eq: 'CUSTOM' }
       },
 
       options: {
-        MATCH_MIDPOINT: 'Match OB mid price',
-        MATCH_SIDE: 'Match OB side',
-        MATCH_LAST: 'Match last trade price'
+        MATCH_MIDPOINT: t(i18n, 'orderForm.matchObMidPrice', 'Match OB mid price'),
+        MATCH_SIDE: t(i18n, 'orderForm.matchObSidePrice', 'Match OB side'),
+        MATCH_LAST: t(i18n, 'orderForm.matchLastTrade', 'Match last trade price')
       }
     },
 
     lev: {
       component: 'input.range',
-      label: 'Leverage',
+      label: t(i18n, 'orderForm.leverage', 'Leverage'),
       min: 1,
       max: 100,
       default: 10
@@ -169,10 +172,10 @@ const getUIDef = () => ({
 
     action: {
       component: 'input.radio',
-      label: 'Action',
-      options: ['Buy', 'Sell'],
+      label: t(i18n, 'orderForm.action', 'Action'),
+      options: [t(i18n, 'orderForm.buy', 'Buy'), t(i18n, 'orderForm.sell', 'Sell')],
       inline: true,
-      default: 'Buy'
+      default: t(i18n, 'orderForm.buy', 'Buy')
     }
   },
 

--- a/lib/twap/meta/get_ui_def.js
+++ b/lib/twap/meta/get_ui_def.js
@@ -10,11 +10,11 @@ const { t } = require('../../util/i18n')
  * @returns {AOUIDefinition} uiDef
  */
 const getUIDef = ({ i18n } = {}) => ({
-  label: t(i18n, 'orderForm.twap.title', 'TWAP'),
+  label: t(i18n, 'twap.title', 'TWAP'),
   id: 'bfx-twap',
 
   uiIcon: 'twap-active',
-  customHelp: t(i18n, 'orderForm.twap.help', [
+  customHelp: t(i18n, 'twap.help', [
     'TWAP spreads an order out through time in order to fill at the',
     'time-weighted average price, calculated between the time the order is',
     'submitted to the final atomic order close.\n\nThe price target may be set',
@@ -74,52 +74,52 @@ const getUIDef = ({ i18n } = {}) => ({
   fields: {
     tradeBeyondEnd: {
       component: 'input.checkbox',
-      label: t(i18n, 'orderForm.tradeBeyondEnd', 'Trade Beyond End'),
-      customHelp: t(i18n, 'orderForm.tradeBeyondEnd.help', 'Continue trading beyond slice interval'),
+      label: t(i18n, 'tradeBeyondEnd', 'Trade Beyond End'),
+      customHelp: t(i18n, 'tradeBeyondEnd.help', 'Continue trading beyond slice interval'),
       default: false
     },
 
     orderType: {
       component: 'input.dropdown',
-      label: t(i18n, 'orderForm.orderType', 'Order Type'),
+      label: t(i18n, 'orderType', 'Order Type'),
       default: 'LIMIT',
       options: {
-        LIMIT: t(i18n, 'orderForm.limit', 'Limit'),
-        MARKET: t(i18n, 'orderForm.market', 'Market')
+        LIMIT: t(i18n, 'limit', 'Limit'),
+        MARKET: t(i18n, 'market', 'Market')
       }
     },
 
     amount: {
       component: 'input.amount',
-      label: `${t(i18n, 'orderForm.amount', 'Amount')} $BASE`,
-      customHelp: t(i18n, 'orderForm.amount.help', 'Total order amount'),
+      label: `${t(i18n, 'amount', 'Amount')} $BASE`,
+      customHelp: t(i18n, 'amount.help', 'Total order amount'),
       priceField: 'price'
     },
 
     amountDistortion: {
       component: 'input.percent',
       default: 0,
-      label: t(i18n, 'orderForm.amountDistortionPerc', 'Amount Distortion %'),
-      customHelp: t(i18n, 'orderForm.amountDistortionPerc.help', 'Amount to distort individual order sizes to prevent detection, in percent')
+      label: t(i18n, 'amountDistortionPerc', 'Amount Distortion %'),
+      customHelp: t(i18n, 'amountDistortionPerc.help', 'Amount to distort individual order sizes to prevent detection, in percent')
     },
 
     sliceAmount: {
       component: 'input.number',
-      label: `${t(i18n, 'orderForm.sliceAmount', 'Slice Amount')} $BASE`,
-      customHelp: t(i18n, 'orderForm.sliceAmount.help', 'Allows individual buy & sell amounts to be adjusted')
+      label: `${t(i18n, 'sliceAmount', 'Slice Amount')} $BASE`,
+      customHelp: t(i18n, 'sliceAmount.help', 'Allows individual buy & sell amounts to be adjusted')
     },
 
     sliceInterval: {
       component: 'input.number',
       default: 2,
-      label: t(i18n, 'orderForm.sliceIntervalSec', 'Slice Interval (sec)'),
-      customHelp: t(i18n, 'orderForm.sliceIntervalSec.help', 'Duration over which to trade slice')
+      label: t(i18n, 'sliceIntervalSec', 'Slice Interval (sec)'),
+      customHelp: t(i18n, 'sliceIntervalSec.help', 'Duration over which to trade slice')
     },
 
     priceDelta: {
       component: 'input.number',
-      label: t(i18n, 'orderForm.targetDelta', 'Target Delta'),
-      customHelp: t(i18n, 'orderForm.twap.targetDelta.help', '± Distance from price target for match'),
+      label: t(i18n, 'targetDelta', 'Target Delta'),
+      customHelp: t(i18n, 'twap.targetDelta.help', '± Distance from price target for match'),
       disabled: {
         priceTarget: { neq: 'CUSTOM' }
       }
@@ -127,8 +127,8 @@ const getUIDef = ({ i18n } = {}) => ({
 
     price: {
       component: 'input.price',
-      label: `${t(i18n, 'orderForm.price', 'Price')} $QUOTE`,
-      customHelp: t(i18n, 'orderForm.twap.price.help', 'Requires \'custom\' price target'),
+      label: `${t(i18n, 'price', 'Price')} $QUOTE`,
+      customHelp: t(i18n, 'twap.price.help', 'Requires \'custom\' price target'),
       disabled: {
         priceTarget: { neq: 'CUSTOM' }
       }
@@ -136,35 +136,35 @@ const getUIDef = ({ i18n } = {}) => ({
 
     priceTarget: {
       component: 'input.dropdown',
-      label: t(i18n, 'orderForm.priceTarget', 'Price Target'),
+      label: t(i18n, 'priceTarget', 'Price Target'),
       default: 'OB_MID',
       options: {
-        OB_MID: t(i18n, 'orderForm.obMidPrice', 'OB mid price'),
-        OB_SIDE: t(i18n, 'orderForm.obSidePrice', 'OB side price'),
-        LAST: t(i18n, 'orderForm.lastTradePrice', 'Last trade price'),
-        CUSTOM: t(i18n, 'orderForm.custom', 'Custom')
+        OB_MID: t(i18n, 'obMidPrice', 'OB mid price'),
+        OB_SIDE: t(i18n, 'obSidePrice', 'OB side price'),
+        LAST: t(i18n, 'lastTradePrice', 'Last trade price'),
+        CUSTOM: t(i18n, 'custom', 'Custom')
       }
     },
 
     priceCondition: {
       component: 'input.dropdown',
-      label: t(i18n, 'orderForm.priceCondition', 'Price Condition'),
+      label: t(i18n, 'priceCondition', 'Price Condition'),
       default: 'MATCH_MIDPOINT',
-      customHelp: t(i18n, 'orderForm.priceCondition.help', 'Match point for custom price targets'),
+      customHelp: t(i18n, 'priceCondition.help', 'Match point for custom price targets'),
       visible: {
         priceTarget: { eq: 'CUSTOM' }
       },
 
       options: {
-        MATCH_MIDPOINT: t(i18n, 'orderForm.matchObMidPrice', 'Match OB mid price'),
-        MATCH_SIDE: t(i18n, 'orderForm.matchObSidePrice', 'Match OB side'),
-        MATCH_LAST: t(i18n, 'orderForm.matchLastTrade', 'Match last trade price')
+        MATCH_MIDPOINT: t(i18n, 'matchObMidPrice', 'Match OB mid price'),
+        MATCH_SIDE: t(i18n, 'matchObSidePrice', 'Match OB side'),
+        MATCH_LAST: t(i18n, 'matchLastTrade', 'Match last trade price')
       }
     },
 
     lev: {
       component: 'input.range',
-      label: t(i18n, 'orderForm.leverage', 'Leverage'),
+      label: t(i18n, 'leverage', 'Leverage'),
       min: 1,
       max: 100,
       default: 10
@@ -172,10 +172,10 @@ const getUIDef = ({ i18n } = {}) => ({
 
     action: {
       component: 'input.radio',
-      label: t(i18n, 'orderForm.action', 'Action'),
-      options: [t(i18n, 'orderForm.buy', 'Buy'), t(i18n, 'orderForm.sell', 'Sell')],
+      label: t(i18n, 'action', 'Action'),
+      options: [t(i18n, 'buy', 'Buy'), t(i18n, 'sell', 'Sell')],
       inline: true,
-      default: t(i18n, 'orderForm.buy', 'Buy')
+      default: t(i18n, 'buy', 'Buy')
     }
   },
 

--- a/lib/twap/meta/validate_params.js
+++ b/lib/twap/meta/validate_params.js
@@ -6,6 +6,7 @@ const _isString = require('lodash/isString')
 const _isUndefined = require('lodash/isUndefined')
 const Config = require('../config')
 const validationErrObj = require('../../util/validate_params_err')
+const { apply: applyI18N } = require('../../util/i18n')
 
 /**
  * Verifies that a parameters Object is valid, and all parameters are within
@@ -30,52 +31,135 @@ const validationErrObj = require('../../util/validate_params_err')
  * @returns {string} error - null if parameters are valid, otherwise a
  *   description of which parameter is invalid.
  */
-const validateParams = (args = {}, pairConfig = {}) => {
+const validateParams = (args = {}, pairConfig = {}) => { // TODO
   const { minSize, maxSize, lev: maxLev } = pairConfig
   const {
     orderType, amount, sliceAmount, sliceInterval, amountDistortion, priceTarget, priceCondition,
     priceDelta, lev, _futures
   } = args
 
-  if (!Order.type[orderType]) return validationErrObj('orderType', `Invalid order type: ${orderType}`)
-  if (!_isFinite(amount)) return validationErrObj('amount', 'Invalid amount')
-  if (!_isFinite(sliceAmount)) return validationErrObj('sliceAmount', 'Invalid slice amount')
-  if (!_isFinite(sliceInterval) || sliceInterval <= 0) return validationErrObj('sliceInterval', 'Invalid slice interval')
-  if (!_isFinite(amountDistortion)) return validationErrObj('amountDistortion', 'Invalid amount distortion')
-  if (Math.abs(sliceAmount) > Math.abs(amount)) return validationErrObj('sliceAmount', 'Slice amount cannot be greater than total amount')
+  if (!Order.type[orderType]) {
+    return applyI18N(
+      validationErrObj('orderType', `Invalid order type: ${orderType}`),
+      'invalidOrderType', { orderType }
+    )
+  }
+  if (!_isFinite(amount)) {
+    return applyI18N(
+      validationErrObj('amount', 'Invalid amount'),
+      'invalidAmount'
+    )
+  }
+  if (!_isFinite(sliceAmount)) {
+    return applyI18N(
+      validationErrObj('sliceAmount', 'Invalid slice amount'),
+      'invalidSliceAmount'
+    )
+  }
+  if (!_isFinite(sliceInterval) || sliceInterval <= 0) {
+    return applyI18N(
+      validationErrObj('sliceInterval', 'Invalid slice interval'),
+      'invalidSliceInterval'
+    )
+  }
+  if (!_isFinite(amountDistortion)) {
+    return applyI18N(
+      validationErrObj('amountDistortion', 'Invalid amount distortion'),
+      'invalidAmountDistortion'
+    )
+  }
+  if (Math.abs(sliceAmount) > Math.abs(amount)) {
+    return applyI18N(
+      validationErrObj('sliceAmount', 'Slice amount cannot be greater than total amount'),
+      'sliceAmountCannotBeGreaterThanTotalAmount'
+    )
+  }
   if (!_isString(priceTarget) && !_isFinite(priceTarget)) {
-    return validationErrObj('priceTarget', 'Invalid price target')
+    return applyI18N(
+      validationErrObj('priceTarget', 'Invalid price target'),
+      'invalidPriceTarget'
+    )
   } else if (_isFinite(priceTarget) && priceTarget <= 0) {
-    return validationErrObj('priceTarget', 'Negative custom price target')
+    return applyI18N(
+      validationErrObj('priceTarget', 'Negative custom price target'),
+      'negativeCustomPriceTarget'
+    )
   } else if (_isFinite(priceTarget) && !Config.PRICE_COND[priceCondition]) {
-    return validationErrObj('priceTarget', 'Invalid condition for custom price target')
+    return applyI18N(
+      validationErrObj('priceTarget', 'Invalid condition for custom price target'),
+      'invalidConditionForCustomPriceTarget'
+    )
   } else if (_isString(priceTarget) && !Config.PRICE_TARGET[priceTarget]) {
-    return validationErrObj('priceTarget', 'Invalid matched price target')
+    return applyI18N(
+      validationErrObj('priceTarget', 'Invalid matched price target'),
+      'invalidMatchedPriceTarget'
+    )
   } else if (!_isUndefined(priceDelta) && !_isFinite(priceDelta)) {
-    return validationErrObj('priceDelta', 'Invalid price delta provided')
+    return applyI18N(
+      validationErrObj('priceDelta', 'Invalid price delta provided'),
+      'invalidPriceDeltaProvided'
+    )
   }
 
   if (
     (amount < 0 && sliceAmount >= 0) ||
     (amount > 0 && sliceAmount <= 0)
   ) {
-    return validationErrObj('sliceAmount', 'Amount & slice amount must have same sign')
+    return applyI18N(
+      validationErrObj('sliceAmount', 'Amount & slice amount must have same sign'),
+      'amountSliceAmountMustHaveSameSign'
+    )
   }
 
   if (_isFinite(minSize)) {
-    if (Math.abs(amount) < minSize) return validationErrObj('amount', `Amount cannot be less than ${minSize}`)
-    if (Math.abs(sliceAmount) < minSize) return validationErrObj('sliceAmount', `Slice amount cannot be less than ${minSize}`)
+    if (Math.abs(amount) < minSize) {
+      return applyI18N(
+        validationErrObj('amount', `Amount cannot be less than ${minSize}`),
+        'amountCannotBeLessThan', { minSize }
+      )
+    }
+    if (Math.abs(sliceAmount) < minSize) {
+      return applyI18N(
+        validationErrObj('sliceAmount', `Slice amount cannot be less than ${minSize}`),
+        'sliceAmountCannotBeLessThan', { minSize }
+      )
+    }
   }
 
   if (_isFinite(maxSize)) {
-    if (Math.abs(amount) > maxSize) return validationErrObj('amount', `Amount cannot be greater than ${maxSize}`)
-    if (Math.abs(sliceAmount) > maxSize) return validationErrObj('sliceAmount', `Slice amount cannot be greater than ${maxSize}`)
+    if (Math.abs(amount) > maxSize) {
+      return applyI18N(
+        validationErrObj('amount', `Amount cannot be greater than ${maxSize}`),
+        'amountCannotBeGreaterThan', { maxSize }
+      )
+    }
+    if (Math.abs(sliceAmount) > maxSize) {
+      return applyI18N(
+        validationErrObj('sliceAmount', `Slice amount cannot be greater than ${maxSize}`),
+        'sliceAmountCannotBeGreaterThan', { maxSize }
+      )
+    }
   }
 
   if (_futures) {
-    if (!_isFinite(lev)) return validationErrObj('lev', 'Invalid leverage')
-    if (lev < 1) return validationErrObj('lev', 'Leverage cannot be less than 1')
-    if (_isFinite(maxLev) && (lev > maxLev)) return validationErrObj('lev', `Leverage cannot be greater than ${maxLev}`)
+    if (!_isFinite(lev)) {
+      return applyI18N(
+        validationErrObj('lev', 'Invalid leverage'),
+        'invalidLeverage'
+      )
+    }
+    if (lev < 1) {
+      return applyI18N(
+        validationErrObj('lev', 'Leverage cannot be less than 1'),
+        'leverageCannotBeLessThan', { minLev: 1 }
+      )
+    }
+    if (_isFinite(maxLev) && (lev > maxLev)) {
+      return applyI18N(
+        validationErrObj('lev', `Leverage cannot be greater than ${maxLev}`),
+        'leverageCannotBeGreaterThan', { maxLev }
+      )
+    }
   }
 
   return null

--- a/lib/twap/meta/validate_params.js
+++ b/lib/twap/meta/validate_params.js
@@ -31,7 +31,7 @@ const { apply: applyI18N } = require('../../util/i18n')
  * @returns {string} error - null if parameters are valid, otherwise a
  *   description of which parameter is invalid.
  */
-const validateParams = (args = {}, pairConfig = {}) => { // TODO
+const validateParams = (args = {}, pairConfig = {}) => {
   const { minSize, maxSize, lev: maxLev } = pairConfig
   const {
     orderType, amount, sliceAmount, sliceInterval, amountDistortion, priceTarget, priceCondition,

--- a/lib/util/i18n.js
+++ b/lib/util/i18n.js
@@ -1,7 +1,11 @@
 'use strict'
 
 function t (options, key, original, props) {
-  return options ? (options.t(key, props) || original) : original
+  if (!options) return original
+
+  const fullKey = [options.prefix, key].join('')
+
+  return options.t(fullKey, props) || original
 }
 
 function apply (object, i18nKey, i18nProps) {

--- a/lib/util/i18n.js
+++ b/lib/util/i18n.js
@@ -1,5 +1,20 @@
 'use strict'
 
+/**
+ * @typedef {object} I18NOptions
+ * @property {function} t
+ * @property {string=} prefix
+ */
+
+/**
+ * Replaces `original` with a translation if options is provided
+ *
+ * @param {I18NOptions} options
+ * @param {string} key
+ * @param {string} original
+ * @param {object=} props
+ * @return {string}
+ */
 function t (options, key, original, props) {
   if (!options) return original
 
@@ -8,6 +23,14 @@ function t (options, key, original, props) {
   return options.t(fullKey, props) || original
 }
 
+/**
+ * Mix i18n property into object
+ *
+ * @param {object} object
+ * @param {string} i18nKey
+ * @param {object=} i18nProps
+ * @return {object}
+ */
 function apply (object, i18nKey, i18nProps) {
   return {
     ...object,

--- a/lib/util/i18n.js
+++ b/lib/util/i18n.js
@@ -1,0 +1,20 @@
+'use strict'
+
+function t (options, key, original, props) {
+  return options ? (options.t(key, props) || original) : original
+}
+
+function apply (object, i18nKey, i18nProps) {
+  return {
+    ...object,
+    i18n: i18nKey && {
+      key: i18nKey,
+      props: i18nProps
+    }
+  }
+}
+
+module.exports = {
+  t,
+  apply
+}


### PR DESCRIPTION
- Add i18n for labels (`gen_order_label.js` modules, saves 'i18n' property into AO state)
- Add i18n for validation messages (`validate_params.js` modules return `object with `i18n` property)
- Add i18n for UIDef
example: 
```js
// returns the same schema as before, but with translated labels and titles
getUIDef({ i18n: { t: <translate function>, prefix: <string> }}) 
```