### PR TITLE
fix slice amout percentage validation obj

### DIFF
--- a/lib/iceberg/meta/process_params.js
+++ b/lib/iceberg/meta/process_params.js
@@ -30,7 +30,6 @@ const processParams = (data) => {
 
   if (params.sliceAmountPerc) {
     params.sliceAmount = nBN(params.amount).multipliedBy(params.sliceAmountPerc).toNumber()
-    delete params.sliceAmountPerc
   }
 
   if (params.action) {

--- a/lib/iceberg/meta/validate_params.js
+++ b/lib/iceberg/meta/validate_params.js
@@ -28,7 +28,7 @@ const { apply: applyI18N } = require('../../util/i18n')
  */
 const validateParams = (args = {}, pairConfig = {}) => {
   const { minSize, maxSize, lev: maxLev } = pairConfig
-  const { price, amount, sliceAmount, orderType, lev, _futures } = args
+  const { price, amount, sliceAmount, sliceAmountPerc, orderType, lev, _futures } = args
 
   if (!Order.type[orderType]) {
     return applyI18N(
@@ -74,8 +74,14 @@ const validateParams = (args = {}, pairConfig = {}) => {
     }
     if (Math.abs(sliceAmount) < minSize) {
       return applyI18N(
-        validationErrObj('sliceAmount', `Slice amount cannot be less than ${minSize}`),
-        'sliceAmountCannotBeLessThan', { minSize }
+        validationErrObj(
+          sliceAmountPerc ? 'sliceAmountPerc' : 'sliceAmount',
+          sliceAmountPerc
+            ? `Slice percentage makes the slice amount to be less than the minimum order size(i.e. ${minSize})`
+            : `Slice amount cannot be less than ${minSize}`
+        ),
+        sliceAmountPerc ? 'sliceAmountPercCannotBeLessThan' : 'sliceAmountCannotBeLessThan',
+        { minSize }
       )
     }
   }
@@ -89,8 +95,14 @@ const validateParams = (args = {}, pairConfig = {}) => {
     }
     if (Math.abs(sliceAmount) > maxSize) {
       return applyI18N(
-        validationErrObj('sliceAmount', `Slice amount cannot be greater than ${maxSize}`),
-        'sliceAmountCannotBeGreaterThan', { maxSize }
+        validationErrObj(
+          sliceAmountPerc ? 'sliceAmountPerc' : 'sliceAmount',
+          sliceAmountPerc
+            ? `Slice percentage makes the slice amount to be greater than the maximum order size(i.e. ${maxSize})`
+            : `Slice amount cannot be greater than ${maxSize}`
+        ),
+        sliceAmountPerc ? 'sliceAmountPercCannotBeGreaterThan' : 'sliceAmountCannotBeGreaterThan',
+        { maxSize }
       )
     }
   }

--- a/test/lib/iceberg/meta/validate_params.js
+++ b/test/lib/iceberg/meta/validate_params.js
@@ -92,6 +92,16 @@ describe('iceberg:meta:validate_params', () => {
     assert(_isString(err.message))
   })
 
+  it('returns error if slice amount percent causes slice amount to be less than the minimum order size', () => {
+    const err = validateParams({
+      ...validParams,
+      sliceAmount: 0.001,
+      sliceAmountPerc: 0.02
+    }, pairConfig)
+    assert.deepStrictEqual(err.field, 'sliceAmountPerc')
+    assert(_isString(err.message))
+  })
+
   it('returns error if amount is greater than the maximum order size', () => {
     const err = validateParams({
       ...validParams,
@@ -107,6 +117,16 @@ describe('iceberg:meta:validate_params', () => {
       sliceAmount: 25
     }, pairConfig)
     assert.deepStrictEqual(err.field, 'sliceAmount')
+    assert(_isString(err.message))
+  })
+
+  it('returns error if slice amount percent causes slice amount to be greater than the maximum order size', () => {
+    const err = validateParams({
+      ...validParams,
+      sliceAmount: 25,
+      sliceAmountPerc: 0.5
+    }, pairConfig)
+    assert.deepStrictEqual(err.field, 'sliceAmountPerc')
     assert(_isString(err.message))
   })
 


### PR DESCRIPTION
Send slice amount percentage error message when slice amount calculated by slice amount percentage is greater or less than the allowed order sizes.

Task: https://app.asana.com/0/1125859137800433/1201077144837154/f