### PR TITLE
Fix Ping/Pong fulfilling

### DIFF
--- a/lib/ping_pong/events/orders_order_fill.js
+++ b/lib/ping_pong/events/orders_order_fill.js
@@ -29,7 +29,7 @@ const onOrdersOrderFill = async (instance = {}, order) => {
     _margin, _futures
   } = args
 
-  if (order.amount > DUST) { // not fully filled
+  if (Math.abs(order.amount) > DUST) { // not fully filled
     return
   }
 


### PR DESCRIPTION
Asana ticket: https://app.asana.com/0/1125859137800433/1201105780176465

### Issue

Ping/Pong order treats partially filled SELL “ping” or “pong” orders as fully filled, so it submits the related ping or pong order without waiting for the pong or ping order to be executed

![screen-capture (12) (1)](https://user-images.githubusercontent.com/70510980/136560501-514f33e1-0c5c-4de7-a651-077426d01930.gif)

### Fixes

- Fix submiting of pong(ping) order if related SELL order isn't fully filled

### Result

![screen-capture (15)](https://user-images.githubusercontent.com/70510980/136561975-3a2da91b-7f88-488b-b973-d4e1c15b414c.gif)
