### PR TITLE
Add visible on hit for algo order

### DIFF
--- a/lib/accumulate_distribute/meta/gen_preview.js
+++ b/lib/accumulate_distribute/meta/gen_preview.js
@@ -19,7 +19,7 @@ const genOrderAmounts = require('../util/gen_order_amounts')
 const genPreview = (args = {}) => {
   const {
     symbol, sliceInterval, intervalDistortion, _margin, orderType, limitPrice,
-    hidden, postonly
+    hidden, visibleOnHit, postonly
   } = args
 
   const orderAmounts = genOrderAmounts(args)
@@ -31,6 +31,7 @@ const genPreview = (args = {}) => {
         symbol,
         amount,
         hidden,
+        visibleOnHit,
         cid: genCID(),
         type: _margin ? 'MARKET' : 'EXCHANGE MARKET'
       }))
@@ -39,6 +40,7 @@ const genPreview = (args = {}) => {
         symbol,
         amount,
         hidden,
+        visibleOnHit,
         postonly,
         price: limitPrice,
         cid: genCID(),
@@ -49,6 +51,7 @@ const genPreview = (args = {}) => {
         symbol,
         amount,
         hidden,
+        visibleOnHit,
         price: 'RELATIVE',
         cid: genCID(),
         type: _margin ? 'LIMIT' : 'EXCHANGE LIMIT'

--- a/lib/accumulate_distribute/meta/get_ui_def.js
+++ b/lib/accumulate_distribute/meta/get_ui_def.js
@@ -35,7 +35,7 @@ const getUIDef = ({ i18n } = {}) => ({
 
   header: {
     component: 'ui.checkbox_group',
-    fields: ['catchUp', 'awaitFill', 'hidden', 'postonly']
+    fields: ['catchUp', 'awaitFill', 'hidden', 'postonly', 'visibleOnHit']
   },
 
   sections: [{
@@ -170,6 +170,16 @@ const getUIDef = ({ i18n } = {}) => ({
       customHelp: t(i18n, 'hiddenHelp', `This option allows you to place an order into the book but not have it displayed to
       other traders. Price/time priority is the same as a displayed order, but the hidden order will
       always pay the "taker" fee while those trading against a hidden order will pay the "maker" fee`)
+    },
+
+    visibleOnHit: {
+      component: 'input.checkbox',
+      label: t(i18n, 'visibleOnHit', 'Visible on Hit'),
+      default: false,
+      customHelp: t(i18n, 'visibleOnHitHelp', 'The rest part of the hidden order will be visible after first hit(partial execution)'),
+      visible: {
+        hidden: { eq: true }
+      }
     },
 
     orderType: {

--- a/lib/accumulate_distribute/meta/process_params.js
+++ b/lib/accumulate_distribute/meta/process_params.js
@@ -25,6 +25,10 @@ const processParams = (data) => {
     delete params.lev
   }
 
+  if (!params.hidden) {
+    delete params.visibleOnHit
+  }
+
   if (params.sliceIntervalSec) {
     params.sliceInterval = (+params.sliceIntervalSec) * 1000
     delete params.sliceIntervalSec

--- a/lib/accumulate_distribute/meta/validate_params.js
+++ b/lib/accumulate_distribute/meta/validate_params.js
@@ -51,7 +51,8 @@ const validateParams = (args = {}, pairConfig = {}) => {
   const {
     limitPrice, amount, sliceAmount, orderType,
     intervalDistortion, amountDistortion, sliceInterval, relativeOffset,
-    relativeCap, catchUp, awaitFill, postonly, lev, _futures
+    relativeCap, catchUp, awaitFill, postonly, lev, _futures,
+    hidden, visibleOnHit
   } = args
 
   if (!_includes(ORDER_TYPES, orderType)) {
@@ -82,6 +83,18 @@ const validateParams = (args = {}, pairConfig = {}) => {
     return applyI18N(
       validationErrObj('awaitFill', 'Bool await fill flag required'),
       'boolAwaitFillFlagRequired'
+    )
+  }
+  if (!_isBoolean(hidden)) {
+    return applyI18N(
+      validationErrObj('hidden', 'Bool hidden flag required'),
+      'boolHiddenFlagRequired'
+    )
+  }
+  if (hidden && !_isBoolean(visibleOnHit)) {
+    return applyI18N(
+      validationErrObj('visibleOnHit', 'Bool visible on hit flag required'),
+      'boolVisibleOnHitFlagRequired'
     )
   }
   if (!_isFinite(sliceInterval) || sliceInterval <= 0) {

--- a/lib/accumulate_distribute/util/generate_order.js
+++ b/lib/accumulate_distribute/util/generate_order.js
@@ -25,7 +25,7 @@ const generateOrder = (instance = {}) => {
   } = state
 
   const {
-    symbol, orderType, relativeOffset, relativeCap, limitPrice, _margin, hidden, postonly,
+    symbol, orderType, relativeOffset, relativeCap, limitPrice, _margin, hidden, visibleOnHit, postonly,
     lev, _futures
   } = args
 
@@ -37,7 +37,8 @@ const generateOrder = (instance = {}) => {
   const sharedOrderParams = {
     symbol,
     amount,
-    hidden
+    hidden,
+    visibleOnHit
   }
 
   if (_futures) {
@@ -52,6 +53,14 @@ const generateOrder = (instance = {}) => {
       meta: { _HF: 1 }
     })
   } else if (orderType === 'LIMIT') {
+    console.log('ORDER------------------------->', new Order({
+      ...sharedOrderParams,
+      price: limitPrice,
+      postonly,
+      cid: genCID(),
+      type: _margin || _futures ? 'LIMIT' : 'EXCHANGE LIMIT',
+      meta: { _HF: 1 }
+    }))
     return new Order({
       ...sharedOrderParams,
       price: limitPrice,

--- a/lib/accumulate_distribute/util/generate_order.js
+++ b/lib/accumulate_distribute/util/generate_order.js
@@ -53,14 +53,6 @@ const generateOrder = (instance = {}) => {
       meta: { _HF: 1 }
     })
   } else if (orderType === 'LIMIT') {
-    console.log('ORDER------------------------->', new Order({
-      ...sharedOrderParams,
-      price: limitPrice,
-      postonly,
-      cid: genCID(),
-      type: _margin || _futures ? 'LIMIT' : 'EXCHANGE LIMIT',
-      meta: { _HF: 1 }
-    }))
     return new Order({
       ...sharedOrderParams,
       price: limitPrice,

--- a/lib/ococo/meta/get_ui_def.js
+++ b/lib/ococo/meta/get_ui_def.js
@@ -25,7 +25,7 @@ const getUIDef = ({ i18n } = {}) => ({
 
   header: {
     component: 'ui.checkbox_group',
-    fields: ['hidden', 'postonly']
+    fields: ['hidden', 'postonly', 'visibleOnHit']
   },
 
   sections: [{
@@ -115,6 +115,16 @@ const getUIDef = ({ i18n } = {}) => ({
       customHelp: t(i18n, 'hiddenHelp', `This option allows you to place an order into the book but not have it displayed to
       other traders. Price/time priority is the same as a displayed order, but the hidden order will
       always pay the "taker" fee while those trading against a hidden order will pay the "maker" fee`)
+    },
+
+    visibleOnHit: {
+      component: 'input.checkbox',
+      label: t(i18n, 'visibleOnHit', 'Visible on Hit'),
+      default: false,
+      customHelp: t(i18n, 'visibleOnHitHelp', 'The rest part of the hidden order will be visible after first hit(partial execution)'),
+      visible: {
+        hidden: { eq: true }
+      }
     },
 
     postonly: {

--- a/lib/ococo/meta/process_params.js
+++ b/lib/ococo/meta/process_params.js
@@ -26,6 +26,10 @@ const processParams = (data) => {
     delete params.lev
   }
 
+  if (!params.hidden) {
+    delete params.visibleOnHit
+  }
+
   if (params.action) {
     if (params.action === 'Sell') {
       params.amount = (+params.amount) * -1

--- a/lib/ococo/meta/validate_params.js
+++ b/lib/ococo/meta/validate_params.js
@@ -2,6 +2,7 @@
 
 const _isFinite = require('lodash/isFinite')
 const _includes = require('lodash/includes')
+const _isBoolean = require('lodash/isBoolean')
 const validationErrObj = require('../../util/validate_params_err')
 const { apply: applyI18N } = require('../../util/i18n')
 
@@ -35,8 +36,23 @@ const validateParams = (args = {}, pairConfig = {}) => {
   const { minSize, maxSize, lev: maxLev } = pairConfig
   const {
     orderPrice, amount, orderType, limitPrice,
-    stopPrice, ocoAmount, lev, _futures, action, ocoAction
+    stopPrice, ocoAmount, lev, _futures, action, ocoAction,
+    hidden, visibleOnHit
   } = args
+
+  if (!_isBoolean(hidden)) {
+    return applyI18N(
+      validationErrObj('hidden', 'Bool hidden flag required'),
+      'boolHiddenFlagRequired'
+    )
+  }
+
+  if (hidden && !_isBoolean(visibleOnHit)) {
+    return applyI18N(
+      validationErrObj('visibleOnHit', 'Bool visible on hit flag required'),
+      'boolVisibleOnHitFlagRequired'
+    )
+  }
 
   if (!_includes(ORDER_TYPES, orderType)) {
     return applyI18N(

--- a/lib/ococo/util/generate_initial_order.js
+++ b/lib/ococo/util/generate_initial_order.js
@@ -18,13 +18,14 @@ const generateInitialOrder = (instance = {}) => {
   const { args = {} } = state
   const {
     amount, symbol, orderType, orderPrice, hidden, postonly, lev, _margin,
-    _futures
+    _futures, visibleOnHit
   } = args
 
   const sharedOrderParams = {
     symbol,
     amount,
     hidden,
+    visibleOnHit,
     postonly
   }
 

--- a/lib/ococo/util/generate_oco_order.js
+++ b/lib/ococo/util/generate_oco_order.js
@@ -18,7 +18,7 @@ const generateOCOOrder = (instance = {}) => {
   const { args = {} } = state
   const {
     ocoAmount, symbol, limitPrice, stopPrice, hidden, postonly, lev,
-    _margin, _futures
+    _margin, _futures, visibleOnHit
   } = args
 
   const cid = genCID()
@@ -41,6 +41,7 @@ const generateOCOOrder = (instance = {}) => {
     cidOCO: cid,
     type: _margin || _futures ? 'LIMIT' : 'EXCHANGE LIMIT',
     hidden,
+    visibleOnHit,
     postonly
   })
 

--- a/lib/ping_pong/events/life_start.js
+++ b/lib/ping_pong/events/life_start.js
@@ -20,13 +20,14 @@ const onLifeStart = async (instance = {}) => {
   const { emit, debug } = h
   const { args = {}, gid, pingPongTable, activePongs } = state
   const {
-    pingAmount, pongAmount, symbol, hidden, lev, _margin, _futures
+    pingAmount, pongAmount, symbol, hidden, visibleOnHit, lev, _margin, _futures
   } = args
 
   const sharedOrderParams = {
     meta: { _HF: 1 },
     symbol,
     hidden,
+    visibleOnHit,
     gid
   }
 

--- a/lib/ping_pong/events/orders_order_fill.js
+++ b/lib/ping_pong/events/orders_order_fill.js
@@ -25,7 +25,7 @@ const onOrdersOrderFill = async (instance = {}, order) => {
   const { emit, debug, updateState } = h
   const { price } = order
   const {
-    endless, symbol, pingAmount, pongAmount, hidden, lev,
+    endless, symbol, pingAmount, pongAmount, hidden, visibleOnHit, lev,
     _margin, _futures
   } = args
 
@@ -37,6 +37,7 @@ const onOrdersOrderFill = async (instance = {}, order) => {
     meta: { _HF: 1 },
     symbol,
     hidden,
+    visibleOnHit,
     gid
   }
 

--- a/lib/ping_pong/meta/gen_preview.js
+++ b/lib/ping_pong/meta/gen_preview.js
@@ -16,7 +16,7 @@ const { getKeys, getValues } = require('../util/ping_pong_table')
  * @returns {object[]} previewOrders
  */
 const genPreview = (args = {}) => {
-  const { endless, hidden, pingAmount, pongAmount, symbol, _margin } = args
+  const { endless, hidden, visibleOnHit, pingAmount, pongAmount, symbol, _margin } = args
   const pingPongTable = genPingPongTable(args)
   const pings = getKeys(pingPongTable)
   const pongs = getValues(pingPongTable)
@@ -29,7 +29,8 @@ const genPreview = (args = {}) => {
       cid: genCID(),
       type: _margin ? Order.type.LIMIT : Order.type.EXCHANGE_LIMIT,
       amount: pingAmount,
-      hidden
+      hidden,
+      visibleOnHit
     }))
   })
 
@@ -42,7 +43,8 @@ const genPreview = (args = {}) => {
       cid: genCID(),
       type: _margin ? Order.type.LIMIT : Order.type.EXCHANGE_LIMIT,
       amount: -pongAmount,
-      hidden
+      hidden,
+      visibleOnHit
     }))
   })
 

--- a/lib/ping_pong/meta/get_ui_def.js
+++ b/lib/ping_pong/meta/get_ui_def.js
@@ -29,7 +29,7 @@ const getUIDef = ({ i18n } = {}) => ({
 
   header: {
     component: 'ui.checkbox_group',
-    fields: ['hidden', 'endless', 'splitPingPongAmount']
+    fields: ['hidden', 'endless', 'splitPingPongAmount', 'visibleOnHit']
   },
 
   sections: [{
@@ -92,6 +92,16 @@ const getUIDef = ({ i18n } = {}) => ({
         `This option allows you to place an order into the book but not have it displayed to
       other traders. Price/time priority is the same as a displayed order, but the hidden order will
       always pay the "taker" fee while those trading against a hidden order will pay the "maker" fee`)
+    },
+
+    visibleOnHit: {
+      component: 'input.checkbox',
+      label: t(i18n, 'visibleOnHit', 'Visible on Hit'),
+      default: false,
+      customHelp: t(i18n, 'visibleOnHitHelp', 'The rest part of the hidden order will be visible after first hit(partial execution)'),
+      visible: {
+        hidden: { eq: true }
+      }
     },
 
     splitPingPongAmount: {

--- a/lib/ping_pong/meta/process_params.js
+++ b/lib/ping_pong/meta/process_params.js
@@ -22,6 +22,10 @@ const processParams = (data) => {
     delete params.lev
   }
 
+  if (!params.hidden) {
+    delete params.visibleOnHit
+  }
+
   if (!params.splitPingPongAmount) {
     params.pingAmount = params.amount
     params.pongAmount = params.amount

--- a/lib/ping_pong/meta/validate_params.js
+++ b/lib/ping_pong/meta/validate_params.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const _isFinite = require('lodash/isFinite')
+const _isBoolean = require('lodash/isBoolean')
 const validationErrObj = require('../../util/validate_params_err')
 const { apply: applyI18N } = require('../../util/i18n')
 
@@ -30,7 +31,8 @@ const validateParams = (args = {}, pairConfig = {}) => {
   const { minSize, maxSize, lev: maxLev } = pairConfig
   const {
     pingAmount, pongAmount, pingPrice, pongPrice, pingMinPrice, pingMaxPrice,
-    orderCount, pongDistance, lev, _futures, splitPingPongAmount
+    orderCount, pongDistance, lev, _futures, splitPingPongAmount,
+    hidden, visibleOnHit
   } = args
 
   if (!_isFinite(orderCount) || orderCount < 1) {
@@ -52,6 +54,20 @@ const validateParams = (args = {}, pairConfig = {}) => {
       splitPingPongAmount ? 'pongAmount' : 'amount',
       splitPingPongAmount ? 'Invalid pong amount' : 'Invalid amount'
     ), splitPingPongAmount ? 'invalidPongAmount' : 'invalidAmount')
+  }
+
+  if (!_isBoolean(hidden)) {
+    return applyI18N(
+      validationErrObj('hidden', 'Bool hidden flag required'),
+      'boolHiddenFlagRequired'
+    )
+  }
+
+  if (hidden && !_isBoolean(visibleOnHit)) {
+    return applyI18N(
+      validationErrObj('visibleOnHit', 'Bool visible on hit flag required'),
+      'boolVisibleOnHitFlagRequired'
+    )
   }
 
   if (orderCount === 1) {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "dependencies": {
     "@bitfinex/lib-js-util-math": "git+https://github.com/bitfinexcom/lib-js-util-math.git",
     "bfx-api-node-core": "^1.5.5",
-    "bfx-api-node-models": "^1.4.1",
+    "bfx-api-node-models": "git+https://github.com/avsek477/bfx-api-node-models.git#add-visible-on-hit-hidden-orders",
     "bfx-api-node-plugin-managed-candles": "^1.0.2",
     "bfx-api-node-plugin-managed-ob": "^1.0.3",
     "bfx-api-node-plugin-wd": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   ],
   "dependencies": {
     "@bitfinex/lib-js-util-math": "git+https://github.com/bitfinexcom/lib-js-util-math.git",
-    "bfx-api-node-core": "^1.5.5",
+    "bfx-api-node-core": "git+https://github.com/avsek477/bfx-api-node-core.git#orders-models-update",
     "bfx-api-node-models": "git+https://github.com/avsek477/bfx-api-node-models.git#add-visible-on-hit-hidden-orders",
     "bfx-api-node-plugin-managed-candles": "^1.0.2",
     "bfx-api-node-plugin-managed-ob": "^1.0.3",

--- a/test/lib/accumulate_distribute/meta/validate_params.js
+++ b/test/lib/accumulate_distribute/meta/validate_params.js
@@ -31,7 +31,8 @@ const params = {
   postonly: false,
   awaitFill: true,
   lev: 3.3,
-  _futures: true
+  _futures: true,
+  hidden: false
 }
 
 const pairConfig = {
@@ -223,6 +224,20 @@ describe('accumulate_distribute:meta:validate_params', () => {
     it('returns error if leverage is greater than the allowed leverage', () => {
       const err = validateParams({ ...params, lev: 6 }, pairConfig)
       assert.deepStrictEqual(err.field, 'lev')
+      assert(_isString(err.message))
+    })
+  })
+
+  describe('Hidden option for orders', () => {
+    it('returns error if hidden option is not boolean', () => {
+      const err = validateParams({ ...params, hidden: 'hidden' }, pairConfig)
+      assert.deepStrictEqual(err.field, 'hidden')
+      assert(_isString(err.message))
+    })
+
+    it('returns error if visible on hit option is not boolean', () => {
+      const err = validateParams({ ...params, hidden: true, visibleOnHit: 'visibleOnHit' }, pairConfig)
+      assert.deepStrictEqual(err.field, 'visibleOnHit')
       assert(_isString(err.message))
     })
   })

--- a/test/lib/ococo/meta/validate_params.js
+++ b/test/lib/ococo/meta/validate_params.js
@@ -18,7 +18,8 @@ const params = {
   ocoAction: 'Sell',
 
   _futures: false,
-  lev: 3.3
+  lev: 3.3,
+  hidden: false
 }
 
 const pairConfig = {
@@ -132,6 +133,20 @@ describe('ococo:meta:validate_params', () => {
     it('returns error if leverage is greater than the allowed leverage', () => {
       const err = validateParams({ ...params, _futures: true, lev: 6 }, pairConfig)
       assert.deepStrictEqual(err.field, 'lev')
+      assert(_isString(err.message))
+    })
+  })
+
+  describe('Hidden option for orders', () => {
+    it('returns error if hidden option is not boolean', () => {
+      const err = validateParams({ ...params, hidden: 'hidden' }, pairConfig)
+      assert.deepStrictEqual(err.field, 'hidden')
+      assert(_isString(err.message))
+    })
+
+    it('returns error if visible on hit option is not boolean', () => {
+      const err = validateParams({ ...params, hidden: true, visibleOnHit: 'visibleOnHit' }, pairConfig)
+      assert.deepStrictEqual(err.field, 'visibleOnHit')
       assert(_isString(err.message))
     })
   })

--- a/test/lib/ping_pong/meta/validate_params.js
+++ b/test/lib/ping_pong/meta/validate_params.js
@@ -14,7 +14,8 @@ const params = {
   pingMinPrice: 400,
   pingPrice: 1400,
   pongPrice: 1500,
-  pongDistance: 10
+  pongDistance: 10,
+  hidden: false
 }
 
 const pairConfig = {
@@ -170,6 +171,20 @@ describe('ping_pong:meta:validate_params', () => {
     it('returns error if leverage is greater than the allowed leverage', () => {
       const err = validateParams({ ...params, _futures: true, lev: 6 }, pairConfig)
       assert.deepStrictEqual(err.field, 'lev')
+      assert(_isString(err.message))
+    })
+  })
+
+  describe('Hidden option for orders', () => {
+    it('returns error if hidden option is not boolean', () => {
+      const err = validateParams({ ...params, hidden: 'hidden' }, pairConfig)
+      assert.deepStrictEqual(err.field, 'hidden')
+      assert(_isString(err.message))
+    })
+
+    it('returns error if visible on hit option is not boolean', () => {
+      const err = validateParams({ ...params, hidden: true, visibleOnHit: 'visibleOnHit' }, pairConfig)
+      assert.deepStrictEqual(err.field, 'visibleOnHit')
       assert(_isString(err.message))
     })
   })


### PR DESCRIPTION
Task: https://app.asana.com/0/1125859137800433/1201518274330313

Depends on: 

- https://github.com/bitfinexcom/bfx-api-node-models/pull/77
- https://github.com/bitfinexcom/bfx-api-node-core/pull/29

Add visible on hit option for hidden orders placed by algo orders.
