### PR TITLE
Forward order's meta

### DIFF
--- a/lib/accumulate_distribute/util/generate_order.js
+++ b/lib/accumulate_distribute/util/generate_order.js
@@ -26,7 +26,7 @@ const generateOrder = (instance = {}) => {
 
   const {
     symbol, orderType, relativeOffset, relativeCap, limitPrice, _margin, hidden, visibleOnHit, postonly,
-    lev, _futures
+    lev, _futures, meta
   } = args
 
   const scheduledAmount = orderAmounts[Math.min(currentOrder, orderAmounts.length - 1)]
@@ -50,7 +50,7 @@ const generateOrder = (instance = {}) => {
       ...sharedOrderParams,
       cid: genCID(),
       type: _margin || _futures ? 'MARKET' : 'EXCHANGE MARKET',
-      meta: { _HF: 1 }
+      meta
     })
   } else if (orderType === 'LIMIT') {
     return new Order({
@@ -59,7 +59,7 @@ const generateOrder = (instance = {}) => {
       postonly,
       cid: genCID(),
       type: _margin || _futures ? 'LIMIT' : 'EXCHANGE LIMIT',
-      meta: { _HF: 1 }
+      meta
     })
   } else if (orderType !== 'RELATIVE') {
     throw new Error(`unknown order type: ${orderType}`)
@@ -182,7 +182,7 @@ const generateOrder = (instance = {}) => {
     price: finalPrice,
     cid: genCID(),
     type: _margin || _futures ? 'LIMIT' : 'EXCHANGE LIMIT',
-    meta: { _HF: 1 }
+    meta
   })
 }
 

--- a/lib/host/events/submit_all_orders.js
+++ b/lib/host/events/submit_all_orders.js
@@ -72,8 +72,6 @@ module.exports = async (aoHost, gid, orders) => {
       }
     }
 
-    order.meta._HF = 1
-
     debug(
       'submitting order %s %f @ %s [gid %d]',
       order.type, order.amount, order.price || 'MARKET', order.cid, order.gid

--- a/lib/iceberg/util/generate_orders.js
+++ b/lib/iceberg/util/generate_orders.js
@@ -20,7 +20,7 @@ const { nBN } = require('@bitfinex/lib-js-util-math')
 const generateOrders = (state = {}) => {
   const { args = {}, remainingAmount } = state
   const {
-    sliceAmount, price, excessAsHidden, orderType, symbol, amount, lev, _futures
+    sliceAmount, price, excessAsHidden, orderType, symbol, amount, lev, _futures, meta
   } = args
 
   const m = amount < 0 ? -1 : 1
@@ -55,7 +55,7 @@ const generateOrders = (state = {}) => {
         type: orderType,
         amount: rem,
         hidden: true,
-        meta: { _HF: 1 }
+        meta
       }))
     }
   }
@@ -65,7 +65,7 @@ const generateOrders = (state = {}) => {
     cid: genCID(),
     type: orderType,
     amount: sliceOrderAmount,
-    meta: { _HF: 1 }
+    meta
   }))
 
   return orders

--- a/lib/ma_crossover/util/generate_order.js
+++ b/lib/ma_crossover/util/generate_order.js
@@ -16,7 +16,7 @@ const generateOrder = (instance = {}) => {
   const { state = {} } = instance
   const { args = {} } = state
   const {
-    amount, symbol, orderType, orderPrice, lev, _margin, _futures
+    amount, symbol, orderType, orderPrice, lev, _margin, _futures, meta
   } = args
 
   const sharedOrderParams = {
@@ -33,7 +33,7 @@ const generateOrder = (instance = {}) => {
       ...sharedOrderParams,
       cid: genCID(),
       type: _margin || _futures ? 'MARKET' : 'EXCHANGE MARKET',
-      meta: { _HF: 1 }
+      meta
     })
   } else if (orderType === 'LIMIT') {
     return new Order({
@@ -41,7 +41,7 @@ const generateOrder = (instance = {}) => {
       price: +orderPrice,
       cid: genCID(),
       type: _margin || _futures ? 'LIMIT' : 'EXCHANGE LIMIT',
-      meta: { _HF: 1 }
+      meta
     })
   } else {
     throw new Error(`unknown order type: ${orderType}`)

--- a/lib/ococo/util/generate_initial_order.js
+++ b/lib/ococo/util/generate_initial_order.js
@@ -18,7 +18,7 @@ const generateInitialOrder = (instance = {}) => {
   const { args = {} } = state
   const {
     amount, symbol, orderType, orderPrice, hidden, postonly, lev, _margin,
-    _futures, visibleOnHit
+    _futures, visibleOnHit, meta
   } = args
 
   const sharedOrderParams = {
@@ -38,7 +38,7 @@ const generateInitialOrder = (instance = {}) => {
       ...sharedOrderParams,
       cid: genCID(),
       type: _margin || _futures ? 'MARKET' : 'EXCHANGE MARKET',
-      meta: { _HF: 1 }
+      meta
     })
   } else if (orderType === 'LIMIT') {
     return new Order({
@@ -46,7 +46,7 @@ const generateInitialOrder = (instance = {}) => {
       price: +orderPrice,
       cid: genCID(),
       type: _margin || _futures ? 'LIMIT' : 'EXCHANGE LIMIT',
-      meta: { _HF: 1 }
+      meta
     })
   } else {
     throw new Error(`unknown order type: ${orderType}`)

--- a/lib/ococo/util/generate_oco_order.js
+++ b/lib/ococo/util/generate_oco_order.js
@@ -18,12 +18,12 @@ const generateOCOOrder = (instance = {}) => {
   const { args = {} } = state
   const {
     ocoAmount, symbol, limitPrice, stopPrice, hidden, postonly, lev,
-    _margin, _futures, visibleOnHit
+    _margin, _futures, visibleOnHit, meta
   } = args
 
   const cid = genCID()
   const sharedOrderParams = {
-    meta: { _HF: 1 },
+    meta,
     amount: ocoAmount,
     symbol
   }

--- a/lib/ping_pong/events/life_start.js
+++ b/lib/ping_pong/events/life_start.js
@@ -20,11 +20,11 @@ const onLifeStart = async (instance = {}) => {
   const { emit, debug } = h
   const { args = {}, gid, pingPongTable, activePongs } = state
   const {
-    pingAmount, pongAmount, symbol, hidden, visibleOnHit, lev, _margin, _futures
+    pingAmount, pongAmount, symbol, hidden, visibleOnHit, lev, _margin, _futures, meta
   } = args
 
   const sharedOrderParams = {
-    meta: { _HF: 1 },
+    meta,
     symbol,
     hidden,
     visibleOnHit,

--- a/lib/ping_pong/events/orders_order_fill.js
+++ b/lib/ping_pong/events/orders_order_fill.js
@@ -26,7 +26,7 @@ const onOrdersOrderFill = async (instance = {}, order) => {
   const { price } = order
   const {
     endless, symbol, pingAmount, pongAmount, hidden, visibleOnHit, lev,
-    _margin, _futures
+    _margin, _futures, meta
   } = args
 
   if (Math.abs(order.amount) > DUST) { // not fully filled
@@ -34,7 +34,7 @@ const onOrdersOrderFill = async (instance = {}, order) => {
   }
 
   const sharedOrderParams = {
-    meta: { _HF: 1 },
+    meta,
     symbol,
     hidden,
     visibleOnHit,

--- a/lib/twap/util/generate_order.js
+++ b/lib/twap/util/generate_order.js
@@ -22,7 +22,7 @@ const getRandomNumberInRange = require('../../util/get_random_number_in_range')
 const generateOrder = (state = {}, price) => {
   const { args = {}, remainingAmount, minDistortedAmount, maxDistortedAmount } = state
   const {
-    sliceAmount, orderType, symbol, amount, lev, _margin, _futures, amountDistortion
+    sliceAmount, orderType, symbol, amount, lev, _margin, _futures, amountDistortion, meta
   } = args
   let orderAmount = 0
 
@@ -54,7 +54,7 @@ const generateOrder = (state = {}, price) => {
     ...baseOrderParams,
     cid: genCID(),
     amount: rem,
-    meta: { _HF: 1 },
+    meta,
     type: _isString(orderType)
       ? orderType
       : _margin || _futures

--- a/test/lib/host/events/submit_all_orders.js
+++ b/test/lib/host/events/submit_all_orders.js
@@ -67,7 +67,7 @@ describe('host:events:submit_all_orders', () => {
   })
 
   it('sets the HF meta flag', (done) => {
-    const o = new Order()
+    const o = new Order({ meta: { _HF: 1 } })
     const host = {
       emit: () => {},
       getAO: (type) => {

--- a/test/lib/twap/util/generate_order.js
+++ b/test/lib/twap/util/generate_order.js
@@ -47,7 +47,7 @@ describe('twap:util:generate_order', () => {
   })
 
   it('sets the _HF flag', () => {
-    const o = generateOrder(getState({}), 42)
+    const o = generateOrder(getState({ argOverrides: { meta: { _HF: 1 } } }), 42)
     assert.strictEqual(o.meta._HF, 1)
   })
 


### PR DESCRIPTION
Receive a meta field from UI ([`algo_order.submit` action](https://github.com/bitfinexcom/bfx-hf-ui-core/blob/b3e84f6d9d69ca193b5c5a2229a5d11391500679/src/components/OrderForm/OrderForm.container.js#L81-L86)) and pass it as an Order parameter to API

