### PR TITLE
Trace AO signals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ tags
 .undodir
 Session.vim
 .benchmarks_reports
+/logs

--- a/lib/ao_host.js
+++ b/lib/ao_host.js
@@ -23,7 +23,7 @@ const onNotify = require('./host/events/notify')
 const onStop = require('./host/events/stop')
 const bindWS2Bus = require('./host/ws2/bind_bus')
 const initAO = require('./host/init_ao')
-const genHelpers = require('./host/gen_helpers')
+const initAOState = require('./host/init_ao_state')
 
 /**
  * @typedef {object} EventMetaInformation
@@ -83,14 +83,22 @@ class AOHost extends AsyncEventEmitter {
    * @param {number} [args.wsSettings.dms] - dead man switch, active 4 (default)
    * @param {string} [args.wsSettings.affiliateCode] - user's affiliate code
    * @param {boolean} [args.wsSettings.withHeartbeat] - option to enable/disable heartbeat
+   * @param {boolean} [args.signalTracerOpts.enabled]
+   * @param {string} [args.signalTracerOpts.dir]
    */
   constructor (args = {}) {
     super()
 
-    const { aos, logAlgoOpts, wsSettings } = args
+    const {
+      aos,
+      logAlgoOpts,
+      wsSettings,
+      signalTracerOpts = { enabled: false, dir: '' }
+    } = args
 
     this.aos = aos
     this.logAlgoOpts = logAlgoOpts
+    this.config = { signalTracerOpts }
     this.adapter = new WsAdapter(wsSettings)
 
     const { restURL } = wsSettings
@@ -154,7 +162,19 @@ class AOHost extends AsyncEventEmitter {
    * @returns {Promise} p - resolves on connection close
    */
   close () {
-    return this.adapter.disconnect()
+    this.adapter.disconnect()
+    return this._closeSignalTracers()
+  }
+
+  /**
+   * @returns {Promise<[]>}
+   * @private
+   */
+  _closeSignalTracers () {
+    return Promise.all(
+      this.getAOInstances()
+        .map(({ h: { tracer } }) => tracer.close())
+    )
   }
 
   /**
@@ -445,8 +465,6 @@ class AOHost extends AsyncEventEmitter {
     state.allOrders = {}
     state.ev = new AsyncEventEmitter()
 
-    const h = genHelpers(state, this.adapter)
-
     /**
      * @typedef {object} AOInstance
      * @property {object} state - instance state used during execution
@@ -462,7 +480,7 @@ class AOHost extends AsyncEventEmitter {
      * @property {AsyncEventEmitter} state.ev - internal event emitter
      * @property {module:Helpers} h - helpers bound to the instance
      */
-    const inst = { state, h }
+    const inst = initAO(this.adapter, state, this.config)
     return this.bootstrapAO(ao, inst)
   }
 
@@ -483,7 +501,8 @@ class AOHost extends AsyncEventEmitter {
     const { _symbol } = args
     const pairConfig = await this.getPairConfig(_symbol)
 
-    const inst = initAO(this.adapter, ao, args, pairConfig)
+    const state = initAOState(ao, args, pairConfig)
+    const inst = initAO(this.adapter, state, this.config)
 
     return this.bootstrapAO(ao, inst)
   }
@@ -612,12 +631,13 @@ class AOHost extends AsyncEventEmitter {
    * Handles init for an algo order instance; sets the 'active' flag, subscribes
    * to required channels, and triggers the life.start event.
    *
-   * @param {object} instance - algo order instance that has started
+   * @param {AoInstance} instance - algo order instance that has started
    */
   async _startAlgo (instance = {}) {
-    const { id, gid, name, label, args, i18n, createdAt } = instance.state
+    const { state } = instance
+    const { id, gid, name, label, args, i18n, createdAt } = state
 
-    instance.state.active = true
+    state.active = true
 
     /**
      * Triggered when an algorithmic order begins execution.
@@ -637,20 +657,20 @@ class AOHost extends AsyncEventEmitter {
    * Handles algo order teardown; disables the 'active' state flag, unsubscribes
    * from channels, emits the life.stop event, and saves the AO instance.
    *
-   * @param {object} instance - algo order instance to operate on
+   * @param {AoInstance} instance - algo order instance to operate on
    * @param {object} opts - options if required for algo order
    * @private
    */
   async _stopAlgo (instance = {}, opts = {}) {
-    const { h } = instance
+    const { h, state } = instance
     const {
       id, channels = [], gid, connection, ev, algoLogWriter,
       name, label, args
-    } = instance.state
+    } = state
 
     h.close()
 
-    instance.state.active = false
+    state.active = false
 
     if (!_isEmpty(channels)) {
       channels.forEach(ch => {
@@ -670,6 +690,8 @@ class AOHost extends AsyncEventEmitter {
     const serialized = this.getSerializedAO(instance)
 
     await this.emit('ao:stopped', [gid, serialized])
+
+    await h.tracer.close()
 
     if (algoLogWriter) {
       debug('closing log streams for [AO gid %d]', gid)

--- a/lib/host/gen_helpers.js
+++ b/lib/host/gen_helpers.js
@@ -4,10 +4,31 @@ const Debug = require('debug')
 const Promise = require('bluebird')
 const _omit = require('lodash/omit')
 const flatPromise = require('flat-promise')
+const LocalStorage = require('./signals/local_storage')
+const SignalTracer = require('./signals/signal_tracer')
 
 const MAX_SUBMIT_ATTEMPTS = 10
 const EVENT_SUBSCRIBED_CHANNEL = 'ws2:event:subscribed'
 const excludeOrderStatus = ['CANCELED', 'EXECUTED']
+
+/**
+ * @typedef AoHelpers
+ * @property {function} close
+ * @property {function} timeout
+ * @property {function} debug
+ * @property {function} emitSelf
+ * @property {function} emit
+ * @property {function} notifyUI
+ * @property {function} subscribeDataChannels
+ * @property {function} cancelOrder
+ * @property {function} cancelOrdersByGid
+ * @property {function} sendPing
+ * @property {function} submitOrder
+ * @property {function} declareEvent
+ * @property {function} declareChannel
+ * @property {function} updateState
+ * @property {SignalTracer} tracer
+ */
 
 /**
  * Generates a set of helpers to be used during algo order execution; these
@@ -15,11 +36,13 @@ const excludeOrderStatus = ['CANCELED', 'EXECUTED']
  *
  * @param {object} state - algo order instance state
  * @param {object} adapter - exchange adapter
- * @returns {object} helpers
+ * @param {object} config
+ * @returns {AoHelpers} helpers
  * @private
  */
-const genHelpers = (state = {}, adapter) => {
+const genHelpers = (state = {}, adapter, config) => {
   const { id, gid } = state
+  const { signalTracerOpts } = config
   const debug = Debug(`bfx:hf:algo:${id}:${gid}`)
   const logHelperCall = (fmt, ...data) => {
     const { DEBUG_TRACE } = process.env
@@ -56,6 +79,14 @@ const genHelpers = (state = {}, adapter) => {
     pendingSubscriptionResponses.delete(eid)
     resolve()
   })
+
+  let tracerStorage
+  const { enabled: tracerEnabled, dir: tracerDir } = signalTracerOpts
+  if (tracerEnabled) {
+    const fileName = `${state.id}-${state.gid}.txt`
+    tracerStorage = new LocalStorage(tracerDir, fileName)
+  }
+  const tracer = new SignalTracer(tracerEnabled, tracerStorage)
 
   /**
    * @module Helpers
@@ -95,6 +126,8 @@ const genHelpers = (state = {}, adapter) => {
    *   instance
    */
   const helpers = {
+    tracer,
+
     /**
      * Clear all timeouts for pending subscriptions and remove listeners
      * called automatically by the algo host on teardown.

--- a/lib/host/init_ao.js
+++ b/lib/host/init_ao.js
@@ -1,20 +1,23 @@
 'use strict'
 
-const initAOState = require('./init_ao_state')
 const genHelpers = require('./gen_helpers')
+
+/**
+ * @typedef {Object} AoInstance
+ * @property {AoHelpers} h
+ * @property {InitialAoState|Object} state
+ */
 
 /**
  * Creates a new algo order instance from the provided definition object &
  * arguments.
  *
  * @param {object} adapter - exchange connection adapter
- * @param {object} aoDef - algo order definition
- * @param {object} args - instance arguments
- * @returns {object} instance
+ * @param {object} state
+ * @param {object} config
+ * @returns {AoInstance} instance
  */
-module.exports = (adapter, aoDef = {}, args = {}, pairConfig = {}) => {
-  const state = initAOState(aoDef, args, pairConfig)
-  const h = genHelpers(state, adapter)
-
+module.exports = (adapter, state, config) => {
+  const h = genHelpers(state, adapter, config)
   return { state, h }
 }

--- a/lib/host/init_ao_state.js
+++ b/lib/host/init_ao_state.js
@@ -6,11 +6,30 @@ const _isString = require('lodash/isString')
 const AsyncEventEmitter = require('../async_event_emitter')
 
 /**
+ * @typedef {Object} InitialAoState
+ * @property {array} channels
+ * @property {Object} orders
+ * @property {Object} cancelledOrders
+ * @property {Object} allOrders
+ * @property {AsyncEventEmitter} ev
+ * @property {boolean} active
+ * @property {Object} headersForLogFile
+ * @property {number} createdAt
+ * @property {string} label
+ * @property {string} name
+ * @property {Object} args
+ * @property {string} gid
+ * @property {string} id
+ * @property {boolean|Object} i18n
+ */
+
+/**
  * Creates the initial state object for an algo order, after processing
  * and validating the provided arguments.
  *
  * @param {object} aoDef - algo order definition object
  * @param {object} args - instance arguments
+ * @param {object} pairConfig
  * @returns {object} initialState
  */
 module.exports = (aoDef = {}, args = {}, pairConfig = {}) => {
@@ -35,7 +54,7 @@ module.exports = (aoDef = {}, args = {}, pairConfig = {}) => {
     ? initState(params, pairConfig)
     : {}
 
-  const gid = clientID() + ''
+  const gid = String(clientID())
   const label = _isFunction(genOrderLabel) ? genOrderLabel({ args: params }) : name
 
   // All AOs and the AO host + helpers depend on the structure below; as such

--- a/lib/host/signals/local_storage.js
+++ b/lib/host/signals/local_storage.js
@@ -1,0 +1,54 @@
+'use strict'
+
+const { createWriteStream } = require('fs')
+const { stat, mkdir } = require('fs/promises')
+const path = require('path')
+const flatPromise = require('flat-promise')
+
+class LocalStorage {
+  constructor (dir, fileName) {
+    this.dir = dir
+    this.fileName = fileName
+    this.isOpen = false
+  }
+
+  async start () {
+    this.isOpen = true
+
+    await this._ensureDirExists()
+
+    const filePath = path.join(this.dir, this.fileName)
+    this.file = this._createWriteStream(filePath)
+  }
+
+  store (data) {
+    const { promise, resolve, reject } = flatPromise()
+    const chunk = JSON.stringify(data) + '\n'
+    this.file.write(chunk, (err) => {
+      err ? reject(err) : resolve()
+    })
+    return promise
+  }
+
+  close () {
+    this.isOpen = false
+
+    const { promise, resolve } = flatPromise()
+    this.file.end(resolve)
+    return promise
+  }
+
+  _createWriteStream (filePath) {
+    return createWriteStream(filePath, { flags: 'a' })
+  }
+
+  async _ensureDirExists () {
+    try {
+      await stat(this.dir)
+    } catch {
+      await mkdir(this.dir, { recursive: true })
+    }
+  }
+}
+
+module.exports = LocalStorage

--- a/lib/host/signals/signal.js
+++ b/lib/host/signals/signal.js
@@ -1,0 +1,31 @@
+'use strict'
+
+class Signal {
+  /**
+   * @param {number} id
+   * @param {string} name
+   * @param {Signal?} parent
+   * @param {object?} meta
+   */
+  constructor ({
+    id,
+    name,
+    parent = null,
+    meta
+  }) {
+    this.id = id
+    this.name = name
+    this.meta = meta || {}
+    this.parent = parent
+    this.started_at = Date.now()
+  }
+
+  end () {
+    if (this.ended_at) {
+      throw new Error('signal already closed')
+    }
+    this.ended_at = Date.now()
+  }
+}
+
+module.exports = Signal

--- a/lib/host/signals/signal_tracer.js
+++ b/lib/host/signals/signal_tracer.js
@@ -1,0 +1,73 @@
+'use strict'
+
+const Signal = require('./signal')
+
+/**
+ * @class SignalStorage
+ * @property {boolean} isOpen
+ * @property {function(): Promise} start
+ * @property {function(data: {}): Promise} store
+ * @property {function(): Promise} close
+ */
+
+class SignalTracer {
+  /**
+   * @param {boolean} isEnabled
+   * @param {SignalStorage?} storage
+   */
+  constructor (isEnabled, storage) {
+    this.isEnabled = isEnabled
+    this.storage = storage
+    this.sequencer = 0
+    this.signals = []
+  }
+
+  /**
+   * @param {string} name
+   * @param {Signal?} parent
+   * @param {object?} meta
+   * @returns {Signal}
+   */
+  createSignal (name, parent = null, meta = {}) {
+    const id = ++this.sequencer
+    const signal = new Signal({ id, name, parent, meta })
+
+    if (this.isEnabled) {
+      this.signals.push(signal)
+    }
+
+    return signal
+  }
+
+  async close () {
+    if (this.closed) return
+    this.closed = true
+
+    if (this.isEnabled) {
+      await this._flush()
+      await this.storage.close()
+    }
+  }
+
+  /**
+   * @returns {Promise}
+   * @private
+   */
+  async _flush () {
+    if (!this.storage.isOpen) {
+      await this.storage.start()
+    }
+
+    while (this.signals.length > 0) {
+      const signal = this.signals.shift()
+      const parent = signal.parent ? signal.parent.id : null
+
+      await this.storage.store({
+        ...signal,
+        parent
+      })
+    }
+  }
+}
+
+module.exports = SignalTracer

--- a/lib/iceberg/events/life_start.js
+++ b/lib/iceberg/events/life_start.js
@@ -12,7 +12,8 @@ const _debounce = require('lodash/debounce')
  * @returns {Promise} p - resolves on completion
  */
 const onLifeStart = async (instance = {}) => {
-  const { h = {} } = instance
+  const { state = {}, h = {} } = instance
+  const { args = {} } = state
   const { emitSelf, tracer } = h
 
   // Needs to be debounced, in case both orders are filled simultaneously,
@@ -21,7 +22,7 @@ const onLifeStart = async (instance = {}) => {
     emitSelf('submit_orders', origin)
   }, 500)
 
-  const startSignal = tracer.createSignal('start')
+  const startSignal = tracer.createSignal('start', null, { args })
 
   emitSelf('submit_orders', startSignal)
 }

--- a/lib/iceberg/events/life_start.js
+++ b/lib/iceberg/events/life_start.js
@@ -13,15 +13,17 @@ const _debounce = require('lodash/debounce')
  */
 const onLifeStart = async (instance = {}) => {
   const { h = {} } = instance
-  const { emitSelf } = h
+  const { emitSelf, tracer } = h
 
   // Needs to be debounced, in case both orders are filled simultaneously,
   // triggering two submits in a row
-  h.debouncedSubmitOrders = _debounce(() => {
-    emitSelf('submit_orders')
+  h.debouncedSubmitOrders = _debounce((origin) => {
+    emitSelf('submit_orders', origin)
   }, 500)
 
-  emitSelf('submit_orders')
+  const startSignal = tracer.createSignal('start')
+
+  emitSelf('submit_orders', startSignal)
 }
 
 module.exports = onLifeStart

--- a/lib/iceberg/events/life_stop.js
+++ b/lib/iceberg/events/life_stop.js
@@ -7,15 +7,17 @@
  * @listens AOHost~lifeStop
  *
  * @param {AOInstance} instance - AO instance
+ * @param {object} opts
  */
-const onLifeStop = async (instance = {}) => {
+const onLifeStop = async (instance = {}, opts = {}) => {
   const { state = {}, h = {} } = instance
   const { orders = {}, gid, timeout } = state
-  const { debouncedSubmitOrders, emit, debug, updateState } = h
+  const { debouncedSubmitOrders, emit, debug, updateState, tracer } = h
+  const { origin } = opts
 
   debouncedSubmitOrders.cancel()
 
-  debug('detected iceberg algo cancelation, stopping...')
+  debug('detected iceberg algo cancellation, stopping...')
 
   if (timeout !== null) {
     clearTimeout(timeout)
@@ -23,6 +25,9 @@ const onLifeStop = async (instance = {}) => {
     debug('cleared timeout')
   }
 
+  const stopSignal = tracer.createSignal('stop', origin)
+
+  tracer.createSignal('cancel_all', stopSignal)
   await emit('exec:order:cancel:all', gid, orders)
 }
 

--- a/lib/iceberg/events/orders_order_cancel.js
+++ b/lib/iceberg/events/orders_order_cancel.js
@@ -13,11 +13,16 @@
  */
 const onOrdersOrderCancel = async (instance = {}, order) => {
   const { h = {} } = instance
-  const { emit, debug } = h
+  const { emit, debug, tracer } = h
+  const { id, cid, gid } = order || {}
 
-  debug('detected atomic cancelation, stopping...')
+  debug('detected atomic cancellation, stopping...')
 
-  await emit('exec:stop')
+  const signal = tracer.createSignal('order_cancelled', null, {
+    order: { id, cid, gid }
+  })
+
+  await emit('exec:stop', null, { origin: signal })
 }
 
 module.exports = onOrdersOrderCancel

--- a/lib/iceberg/events/orders_order_fill.js
+++ b/lib/iceberg/events/orders_order_fill.js
@@ -22,8 +22,11 @@ const onOrdersOrderFill = async (instance = {}, order) => {
   const { emit, updateState, debug, debouncedSubmitOrders, tracer } = h
   const { amount } = args
   const m = amount < 0 ? -1 : 1
+  const { id, cid } = order
 
-  const fillSignal = tracer.createSignal('order_filled')
+  const fillSignal = tracer.createSignal('order_filled', null, {
+    order: { id, cid, gid }
+  })
 
   tracer.createSignal('cancel_all', fillSignal)
   await emit('exec:order:cancel:all', gid, orders)

--- a/lib/iceberg/events/orders_order_fill.js
+++ b/lib/iceberg/events/orders_order_fill.js
@@ -19,16 +19,21 @@ const { nBN } = require('@bitfinex/lib-js-util-math')
 const onOrdersOrderFill = async (instance = {}, order) => {
   const { state = {}, h = {} } = instance
   const { args = {}, orders = {}, gid } = state
-  const { emit, updateState, debug, debouncedSubmitOrders } = h
+  const { emit, updateState, debug, debouncedSubmitOrders, tracer } = h
   const { amount } = args
   const m = amount < 0 ? -1 : 1
 
-  await emit('exec:order:cancel:all', gid, orders, 0)
+  const fillSignal = tracer.createSignal('order_filled')
+
+  tracer.createSignal('cancel_all', fillSignal)
+  await emit('exec:order:cancel:all', gid, orders)
 
   const fillAmount = order.getLastFillAmount()
+  fillSignal.meta.fillAmount = fillAmount
 
   const remainingAmount = nBN(instance.state.remainingAmount).minus(fillAmount).toNumber()
   const absRem = m < 0 ? remainingAmount * -1 : remainingAmount
+  fillSignal.meta.remainingAmount = remainingAmount
 
   order.resetFilledAmount()
 
@@ -37,7 +42,7 @@ const onOrdersOrderFill = async (instance = {}, order) => {
   await updateState(instance, { remainingAmount })
 
   if (absRem > DUST) { // continue
-    debouncedSubmitOrders() // created in life.start
+    debouncedSubmitOrders(fillSignal) // created in life.start
     return
   }
 
@@ -45,7 +50,7 @@ const onOrdersOrderFill = async (instance = {}, order) => {
     debug('warning: overfill! %f', absRem)
   }
 
-  return emit('exec:stop')
+  return emit('exec:stop', null, { origin: fillSignal })
 }
 
 module.exports = onOrdersOrderFill

--- a/lib/iceberg/events/self_submit_orders.js
+++ b/lib/iceberg/events/self_submit_orders.js
@@ -10,17 +10,19 @@ const generateOrders = require('../util/generate_orders')
  * @listens module:Iceberg~selfSubmitOrders
  *
  * @param {AOInstance} instance - AO instance
+ * @param {Signal} origin - the signal that triggered order creation
  * @returns {Promise} p - resolves on completion
  * @see module:Iceberg~generateOrders
  */
-const onSelfSubmitOrders = async (instance = {}) => {
-  const { state = {}, h = {} } = instance
-  const { emit } = h
-  const { gid } = state
+const onSelfSubmitOrders = async (instance = {}, origin) => {
+  const {
+    state: { gid },
+    h: { emit }
+  } = instance
 
-  const orders = generateOrders(instance.state)
+  const orders = generateOrders(instance, origin)
 
-  return emit('exec:order:submit:all', gid, orders, 0)
+  return emit('exec:order:submit:all', gid, orders)
 }
 
 module.exports = onSelfSubmitOrders

--- a/lib/iceberg/util/generate_orders.js
+++ b/lib/iceberg/util/generate_orders.js
@@ -14,10 +14,13 @@ const { nBN } = require('@bitfinex/lib-js-util-math')
  * @name module:Iceberg.generateOrders
  * @see module:Iceberg.onSelfSubmitOrders
  *
- * @param {object} state - instance state
+ * @param {object} instance - instance state
+ * @param {Signal} origin
  * @returns {object[]} orders - order array
  */
-const generateOrders = (state = {}) => {
+const generateOrders = (instance, origin) => {
+  const { state, h } = instance
+  const { tracer } = h
   const { args = {}, remainingAmount } = state
   const {
     sliceAmount, price, excessAsHidden, orderType, symbol, amount, lev, _futures, meta
@@ -49,24 +52,32 @@ const generateOrders = (state = {}) => {
       (m === 1 && rem >= DUST) ||
       (m === -1 && rem <= DUST)
     ) {
-      orders.push(new Order({
+      const orderParams = {
         ...sharedOrderParams,
         cid: genCID(),
         type: orderType,
         amount: rem,
         hidden: true,
         meta
-      }))
+      }
+
+      tracer.createSignal('order', origin, orderParams)
+
+      orders.push(new Order(orderParams))
     }
   }
 
-  orders.push(new Order({
+  const orderParams = {
     ...sharedOrderParams,
     cid: genCID(),
     type: orderType,
     amount: sliceOrderAmount,
     meta
-  }))
+  }
+
+  tracer.createSignal('order', origin, orderParams)
+
+  orders.push(new Order(orderParams))
 
   return orders
 }

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "bfx-api-node-plugin-wd": "^1.0.4",
     "bfx-api-node-util": "^1.0.2",
     "bfx-hf-indicators": "git+https://github.com/bitfinexcom/bfx-hf-indicators.git#v2.1.1",
+    "bfx-api-node-rest": "git+https://github.com/bitfinexcom/bfx-api-node-rest.git#v4.6.0",
     "bfx-hf-util": "github:bitfinexcom/bfx-hf-util#v1.0.12",
     "bluebird": "^3.5.5",
     "debug": "^4.3.1",

--- a/test/lib/host/gen_helpers.js
+++ b/test/lib/host/gen_helpers.js
@@ -13,6 +13,7 @@ const sinon = require('sinon')
 const { assert: assertFn } = sinon
 
 const manager = new EventEmitter()
+const config = { signalTracerOpts: { enabled: false, dir: '' } }
 const H = (args = {}, adapter = {}) => {
   const state = {
     ev: new AsyncEventEmitter(),
@@ -20,7 +21,7 @@ const H = (args = {}, adapter = {}) => {
     gid: 42,
     ...args
   }
-  return genHelpers(state, { m: manager, ...adapter })
+  return genHelpers(state, { m: manager, ...adapter }, config)
 }
 
 describe('genHelpers', () => {

--- a/test/lib/host/signals/local_storage.js
+++ b/test/lib/host/signals/local_storage.js
@@ -1,0 +1,46 @@
+/* eslint-disable no-unused-expressions */
+/* eslint-env mocha */
+'use strict'
+
+const { expect } = require('chai')
+const { stub, assert } = require('sinon')
+
+const LocalStorage = require('../../../../lib/host/signals/local_storage')
+
+describe('LocalStorage', () => {
+  const dir = 'dir'
+  const fileName = 'file_name'
+  const fileStreamMock = {}
+
+  const storage = new LocalStorage(dir, fileName)
+  storage._createWriteStream = stub().returns(fileStreamMock)
+  storage._ensureDirExists = stub().resolves()
+
+  it('start', async () => {
+    expect(storage.isOpen).to.be.false
+
+    await storage.start()
+
+    assert.calledWithExactly(storage._ensureDirExists)
+    assert.calledWithExactly(storage._createWriteStream, 'dir/file_name')
+    expect(storage.file).to.eq(fileStreamMock)
+    expect(storage.isOpen).to.be.true
+  })
+
+  it('store', (done) => {
+    fileStreamMock.write = (chunk, cb) => {
+      expect(chunk).to.eq(JSON.stringify(data) + '\n')
+      cb(null)
+      done()
+    }
+
+    const data = { id: 10 }
+    storage.store(data)
+  })
+
+  it('close', async () => {
+    fileStreamMock.end = (cb) => cb()
+    await storage.close()
+    expect(storage.isOpen).to.be.false
+  })
+})

--- a/test/lib/host/signals/signal.js
+++ b/test/lib/host/signals/signal.js
@@ -1,0 +1,29 @@
+/* eslint-disable no-unused-expressions */
+/* eslint-env mocha */
+'use strict'
+
+const { expect } = require('chai')
+
+const Signal = require('../../../../lib/host/signals/signal')
+
+describe('Signal', () => {
+  const id = 10
+  const name = 'name'
+  const parent = { id: 1 }
+
+  it('construct', () => {
+    const signal = new Signal({ id, name, parent })
+    expect(signal.id).to.eq(id)
+    expect(signal.name).to.eq(name)
+    expect(signal.meta).to.eql({})
+    expect(signal.parent).to.eq(parent)
+    expect(signal.started_at).to.be.a('number')
+  })
+
+  it('end', () => {
+    const signal = new Signal({ id, name, parent })
+    expect(signal.ended_at).to.be.undefined
+    signal.end()
+    expect(signal.ended_at).to.be.a('number')
+  })
+})

--- a/test/lib/host/signals/signal_tracer.js
+++ b/test/lib/host/signals/signal_tracer.js
@@ -1,0 +1,80 @@
+/* eslint-disable no-unused-expressions */
+/* eslint-env mocha */
+'use strict'
+
+const { expect } = require('chai')
+const { stub, assert } = require('sinon')
+
+const SignalTracer = require('../../../../lib/host/signals/signal_tracer')
+
+describe('SignalTracer', () => {
+  const isEnabled = true
+  const storage = {
+    isOpen: false,
+    start: stub().resolves(),
+    store: stub().resolves(),
+    close: stub().resolves()
+  }
+  const tracer = new SignalTracer(isEnabled, storage)
+
+  let parent, now
+  const meta = { foo: 123 }
+
+  before(() => {
+    now = stub(Date, 'now').returns(0)
+  })
+
+  after(() => {
+    now.restore()
+  })
+
+  it('create signal', () => {
+    const signal = tracer.createSignal('parent', null, meta)
+
+    expect(signal.id).to.eq(1)
+    expect(tracer.signals).to.have.length(1)
+
+    parent = signal
+  })
+
+  it('close', async () => {
+    tracer.createSignal('child', parent)
+    await tracer.close()
+
+    expect(tracer.closed).to.be.true
+    assert.calledTwice(storage.store)
+    assert.calledWithExactly(storage.store, {
+      id: 1,
+      name: 'parent',
+      parent: null,
+      meta,
+      started_at: 0
+    })
+    assert.calledWithExactly(storage.store, {
+      id: 2,
+      name: 'child',
+      parent: 1,
+      meta: {},
+      started_at: 0
+    })
+    assert.calledWithExactly(storage.close)
+  })
+
+  describe('tracer is disabled', () => {
+    const isEnabled = false
+    const storage = undefined
+    const tracer = new SignalTracer(isEnabled, storage)
+
+    it('create signal', () => {
+      const signal = tracer.createSignal('parent', null, meta)
+
+      expect(signal.id).to.eq(1)
+      expect(tracer.signals).to.have.length(0)
+    })
+
+    it('close', async () => {
+      await tracer.close()
+      expect(tracer.closed).to.be.true
+    })
+  })
+})

--- a/test/lib/iceberg/events/life_start.js
+++ b/test/lib/iceberg/events/life_start.js
@@ -19,7 +19,7 @@ describe('iceberg:events:life_start', () => {
 
     await onLifeStart(instance)
 
-    assert.calledWithExactly(createSignal, 'start')
+    assert.calledWithExactly(createSignal, 'start', null, { args: {} })
     assert.calledWithExactly(emitSelf, 'submit_orders', fakeSignal)
   })
 })

--- a/test/lib/iceberg/events/life_start.js
+++ b/test/lib/iceberg/events/life_start.js
@@ -1,21 +1,25 @@
 /* eslint-env mocha */
 'use strict'
 
-const assert = require('assert')
-const Promise = require('bluebird')
+const { stub, assert } = require('sinon')
+
 const onLifeStart = require('../../../../lib/iceberg/events/life_start')
 
 describe('iceberg:events:life_start', () => {
-  it('submits orders on startup', (done) => {
-    onLifeStart({
-      h: {
-        emitSelf: (eName) => {
-          return new Promise((resolve) => {
-            assert.strictEqual(eName, 'submit_orders')
-            resolve()
-          }).then(done).catch(done)
-        }
-      }
-    })
+  const emitSelf = stub()
+  const createSignal = stub()
+
+  const tracer = { createSignal }
+  const h = { emitSelf, tracer }
+  const instance = { h }
+
+  it('submits orders on startup', async () => {
+    const fakeSignal = {}
+    createSignal.returns(fakeSignal)
+
+    await onLifeStart(instance)
+
+    assert.calledWithExactly(createSignal, 'start')
+    assert.calledWithExactly(emitSelf, 'submit_orders', fakeSignal)
   })
 })

--- a/test/lib/iceberg/events/life_stop.js
+++ b/test/lib/iceberg/events/life_stop.js
@@ -1,45 +1,43 @@
+/* eslint-disable no-unused-expressions */
 /* eslint-env mocha */
 'use strict'
 
-const assert = require('assert')
+const { expect } = require('chai')
+const { stub, assert } = require('sinon')
 const onLifeStop = require('../../../../lib/iceberg/events/life_stop')
 
 describe('iceberg:events:life_stop', () => {
-  it('cancels the debounce set to manage orders when received simultaneously', async () => {
-    let debounceCancelled = false
-    await onLifeStop({
-      h: {
-        updateState: () => {},
-        debug: () => {},
-        emit: () => {},
-        debouncedSubmitOrders: {
-          cancel: () => {
-            debounceCancelled = true
-          }
-        }
-      }
-    })
-    assert.ok(debounceCancelled, 'did not cancel the debounce method set on startup')
-  })
+  const state = {
+    orders: {},
+    gid: 123,
+    timeout: setTimeout(() => {}, 10000)
+  }
+  const tracer = {
+    createSignal: stub()
+  }
+  const h = {
+    tracer,
+    debouncedSubmitOrders: {
+      cancel: stub()
+    },
+    emit: stub(),
+    debug: stub(),
+    updateState: stub()
+  }
+  const instance = { state, h }
+  const opts = { origin: { id: 1 } }
 
   it('cancels all orders when iceberg algo stopped', async () => {
-    let cancelledOrders = false
+    const fakeSignal = { id: 2 }
+    tracer.createSignal.onCall(0).returns(fakeSignal)
 
-    await onLifeStop({
-      h: {
-        updateState: () => {},
-        debug: () => {},
-        debouncedSubmitOrders: {
-          cancel: () => {}
-        },
-        emit: (eventName) => {
-          if (eventName === 'exec:order:cancel:all') {
-            cancelledOrders = true
-          }
-        }
-      }
-    })
+    await onLifeStop(instance, opts)
 
-    assert.ok(cancelledOrders, 'did not cancel all orders set by iceberg algo')
+    assert.calledWithExactly(h.debouncedSubmitOrders.cancel)
+    expect(state.timeout._destroyed).to.be.true
+    assert.calledWithExactly(h.updateState, instance, { timeout: null })
+    assert.calledWithExactly(tracer.createSignal, 'stop', opts.origin)
+    assert.calledWithExactly(tracer.createSignal, 'cancel_all', fakeSignal)
+    assert.calledWithExactly(h.emit, 'exec:order:cancel:all', state.gid, state.orders)
   })
 })

--- a/test/lib/iceberg/events/orders_order_cancel.js
+++ b/test/lib/iceberg/events/orders_order_cancel.js
@@ -1,19 +1,28 @@
 /* eslint-env mocha */
 'use strict'
 
-const assert = require('assert')
+const { stub, assert } = require('sinon')
 const onOrderCancel = require('../../../../lib/iceberg/events/orders_order_cancel')
 
 describe('iceberg:events:orders_order_cancel', () => {
-  it('submits all known orders for cancellation & stops operation', (done) => {
-    onOrderCancel({
-      h: {
-        debug: () => {},
-        emit: async (eName) => {
-          assert.strictEqual(eName, 'exec:stop')
-          done()
-        }
-      }
-    })
+  const tracer = {
+    createSignal: stub()
+  }
+  const h = {
+    emit: stub(),
+    debug: stub(),
+    tracer
+  }
+  const instance = { h }
+  const order = { id: 1, cid: 2, gid: 3 }
+
+  it('submits all known orders for cancellation & stops operation', async () => {
+    const fakeSignal = { id: 10 }
+    tracer.createSignal.returns(fakeSignal)
+
+    await onOrderCancel(instance, order)
+
+    assert.calledWithExactly(tracer.createSignal, 'order_cancelled', null, { order: { ...order } })
+    assert.calledWithExactly(h.emit, 'exec:stop', null, { origin: fakeSignal })
   })
 })

--- a/test/lib/iceberg/events/orders_order_fill.js
+++ b/test/lib/iceberg/events/orders_order_fill.js
@@ -13,6 +13,8 @@ describe('iceberg:events:orders_order_fill', () => {
   })
 
   const order = {
+    id: 87,
+    cid: 4934,
     getLastFillAmount: sandbox.stub(),
     resetFilledAmount: sandbox.stub()
   }
@@ -44,7 +46,7 @@ describe('iceberg:events:orders_order_fill', () => {
 
     await onOrderFill(instance, order)
 
-    assert.calledWithExactly(tracer.createSignal, 'order_filled')
+    assert.calledWithExactly(tracer.createSignal, 'order_filled', null, { order: { gid: 123, id: 87, cid: 4934 } })
     assert.calledWithExactly(tracer.createSignal, 'cancel_all', fillSignal)
     assert.calledOnce(h.emit)
     assert.calledWithExactly(h.emit, 'exec:order:cancel:all', state.gid, state.orders)
@@ -67,7 +69,7 @@ describe('iceberg:events:orders_order_fill', () => {
 
     await onOrderFill(instance, order)
 
-    assert.calledWithExactly(tracer.createSignal, 'order_filled')
+    assert.calledWithExactly(tracer.createSignal, 'order_filled', null, { order: { gid: 123, id: 87, cid: 4934 } })
     assert.calledWithExactly(tracer.createSignal, 'cancel_all', fillSignal)
     assert.calledWithExactly(h.emit, 'exec:order:cancel:all', state.gid, state.orders)
     assert.calledWithExactly(order.getLastFillAmount)

--- a/test/lib/iceberg/events/self_submit_orders.js
+++ b/test/lib/iceberg/events/self_submit_orders.js
@@ -1,47 +1,57 @@
+/* eslint-disable no-unused-expressions */
 /* eslint-env mocha */
 'use strict'
 
-const Promise = require('bluebird')
-const assert = require('assert')
+const { Order } = require('bfx-api-node-models')
+const { assert, stub } = require('sinon')
+const { expect } = require('chai')
 const onSubmitOrders = require('../../../../lib/iceberg/events/self_submit_orders')
 
 describe('iceberg:events:self_submit_orders', () => {
-  it('submits generated orders', (done) => {
-    onSubmitOrders({
-      state: {
-        gid: 41,
-        remainingAmount: 0.05,
-        args: {
-          excessAsHidden: false,
-          sliceAmount: 0.1,
-          amount: 1,
-          price: 1000,
-          orderType: 'EXCHANGE MARKET',
-          symbol: 'tBTCUSD'
-        }
-      },
+  const args = {
+    excessAsHidden: false,
+    sliceAmount: 0.1,
+    amount: 1,
+    price: 1000,
+    orderType: 'EXCHANGE MARKET',
+    symbol: 'tBTCUSD'
+  }
+  const state = {
+    gid: 41,
+    remainingAmount: 0.05,
+    args
+  }
+  const tracer = { createSignal: stub() }
+  const h = { emit: stub(), tracer }
+  const instance = { state, h }
 
-      h: {
-        timeout: () => {
-          return [null, () => {}]
-        },
-        updateState: () => {},
-        emit: (eName, gid, orders) => {
-          return new Promise((resolve) => {
-            assert.strictEqual(eName, 'exec:order:submit:all')
-            assert.strictEqual(gid, 41)
-            assert.strictEqual(orders.length, 1)
+  it('submits generated orders', async () => {
+    await onSubmitOrders(instance, null)
 
-            const [order] = orders
-            assert.strictEqual(order.symbol, 'tBTCUSD')
-            assert.strictEqual(order.type, 'EXCHANGE MARKET')
-            assert.strictEqual(order.price, 1000)
-            assert.strictEqual(order.amount, 0.05)
+    assert.calledOnce(h.emit)
+    const [eventName, gid, orders] = h.emit.firstCall.args
+    expect(eventName).to.eq('exec:order:submit:all')
+    expect(gid).to.eq(state.gid)
+    expect(orders).to.have.length(1)
 
-            resolve()
-          }).then(done).catch(done)
-        }
-      }
-    })
+    const [order] = orders
+    expect(order).to.be.instanceOf(Order)
+    expect(order.symbol).to.be.eq(args.symbol)
+    expect(order.price).to.be.eq(args.price)
+    expect(order.cid).to.be.a('number')
+    expect(order.type).to.be.eq(args.orderType)
+    expect(order.amount).to.be.eq(0.05)
+    expect(order.meta).to.be.undefined
+
+    assert.calledOnce(tracer.createSignal)
+    const [name, origin, meta] = tracer.createSignal.firstCall.args
+    expect(name).to.eq('order')
+    expect(origin).to.be.null
+    expect(meta.symbol).to.be.eq(args.symbol)
+    expect(meta.price).to.be.eq(args.price)
+    expect(meta.cid).to.be.a('number')
+    expect(meta.type).to.be.eq(args.orderType)
+    expect(meta.amount).to.be.eq(0.05)
+    expect(meta.meta).to.be.undefined
   })
 })

--- a/test/lib/iceberg/util/generate_orders.js
+++ b/test/lib/iceberg/util/generate_orders.js
@@ -6,19 +6,26 @@ const _isFinite = require('lodash/isFinite')
 const generateOrders = require('../../../../lib/iceberg/util/generate_orders')
 const { Config } = require('bfx-api-node-core')
 const { DUST } = Config
-
-const args = {
-  orderType: 'LIMIT',
-  symbol: 'tBTCUSD',
-  amount: 1,
-  sliceAmount: 0.1,
-  excessAsHidden: false,
-  price: 1000
-}
+const { stub } = require('sinon')
 
 describe('iceberg:util:generate_orders', () => {
+  const tracer = {
+    createSignal: stub()
+  }
+  const h = { tracer }
+  const args = {
+    orderType: 'LIMIT',
+    symbol: 'tBTCUSD',
+    amount: 1,
+    sliceAmount: 0.1,
+    excessAsHidden: false,
+    price: 1000
+  }
+
   it('generates valid slice order', () => {
-    const orders = generateOrders({ remainingAmount: args.amount, args })
+    const state = { remainingAmount: args.amount, args }
+    const instance = { state, h }
+    const orders = generateOrders(instance)
     const [slice] = orders
 
     assert.strictEqual(orders.length, 1)
@@ -39,26 +46,32 @@ describe('iceberg:util:generate_orders', () => {
       price: 1000
     }
 
-    const orders = generateOrders({ remainingAmount: 0.3, args: order })
+    const state = { remainingAmount: 0.3, args: order }
+    const instance = { state, h }
+    const orders = generateOrders(instance)
     const [hidden] = orders
 
     assert.strictEqual(hidden.amount, 0.2, 'not -0.19999999999999998')
   })
 
   it('caps slice order at remainingAmount if less than slice', () => {
-    const orders = generateOrders({ remainingAmount: 0.05, args })
+    const state = { remainingAmount: 0.05, args }
+    const instance = { state, h }
+    const orders = generateOrders(instance)
     const [slice] = orders
     assert.strictEqual(slice.amount, 0.05)
   })
 
   it('generates hidden order if excess flag is enabled', () => {
-    const orders = generateOrders({
+    const state = {
       remainingAmount: args.amount,
       args: {
         ...args,
         excessAsHidden: true
       }
-    })
+    }
+    const instance = { state, h }
+    const orders = generateOrders(instance)
 
     const [hidden] = orders
     assert.strictEqual(orders.length, 2)
@@ -70,35 +83,41 @@ describe('iceberg:util:generate_orders', () => {
   })
 
   it('caps excess order at remaining amount after slice', () => {
-    const orders = generateOrders({
+    const state = {
       remainingAmount: 0.15,
       args: {
         ...args,
         excessAsHidden: true
       }
-    })
+    }
+    const instance = { state, h }
+    const orders = generateOrders(instance)
 
     const [hidden] = orders
     assert((hidden.amount - 0.05) < DUST)
   })
 
   it('generates no hidden order if amount after slice is less than dust', () => {
-    const orders = generateOrders({
+    const state = {
       remainingAmount: 0.10000001,
       args: {
         ...args,
         excessAsHidden: true
       }
-    })
+    }
+    const instance = { state, h }
+    const orders = generateOrders(instance)
 
     assert.strictEqual(orders.length, 1)
   })
 
   it('generates no orders if remaining amount is less than dust', () => {
-    const orders = generateOrders({
+    const state = {
       remainingAmount: 0.00000001,
       args
-    })
+    }
+    const instance = { state, h }
+    const orders = generateOrders(instance)
 
     assert.strictEqual(orders.length, 0)
   })


### PR DESCRIPTION
We need to improve the analyses of how a given algo order is working under the hood, and we need to visualize better how the signals are handled and what a given event (like an order fill) can cause.

We introduced a signal tracer tool to log this data locally to solve that. The file later can be parsed and investigated.

The implementation is heavily inspired by the OpenTelemetry libraries, where data is represented by a graph of spans displayed on a timeline.

-----

Examples of visualization: https://www.loom.com/share/b8a4c5adf78149578a17138f92429b68

PS: the visualization tool is under development