### PR TITLE
Refactor signal types

### DIFF
--- a/lib/iceberg/events/life_start.js
+++ b/lib/iceberg/events/life_start.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const _debounce = require('lodash/debounce')
+const { types: { StartSignal } } = require('bfx-hf-signals')
 
 /**
  * @memberOf module:Iceberg
@@ -22,7 +23,7 @@ const onLifeStart = async (instance = {}) => {
     emitSelf('submit_orders', origin)
   }, 500)
 
-  const startSignal = tracer.createSignal('start', null, { args })
+  const startSignal = tracer.collect(new StartSignal({ args }))
 
   emitSelf('submit_orders', startSignal)
 }

--- a/lib/iceberg/events/life_stop.js
+++ b/lib/iceberg/events/life_stop.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { types: { StopSignal, CancelAllSignal } } = require('bfx-hf-signals')
+
 /**
  * Cancels any pending order submits prior to teardown
  *
@@ -25,9 +27,9 @@ const onLifeStop = async (instance = {}, opts = {}) => {
     debug('cleared timeout')
   }
 
-  const stopSignal = tracer.createSignal('stop', origin)
+  const stopSignal = tracer.collect(new StopSignal(origin))
 
-  tracer.createSignal('cancel_all', stopSignal)
+  tracer.collect(new CancelAllSignal(stopSignal))
   await emit('exec:order:cancel:all', gid, orders)
 }
 

--- a/lib/iceberg/events/orders_order_cancel.js
+++ b/lib/iceberg/events/orders_order_cancel.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { types: { OrderCancelledSignal } } = require('bfx-hf-signals')
+
 /**
  * Called when an atomic order cancellation is detected. Cancels any open
  * orders and emits the `'exec:stop'` event.
@@ -14,13 +16,10 @@
 const onOrdersOrderCancel = async (instance = {}, order) => {
   const { h = {} } = instance
   const { emit, debug, tracer } = h
-  const { id, cid, gid } = order || {}
 
   debug('detected atomic cancellation, stopping...')
 
-  const signal = tracer.createSignal('order_cancelled', null, {
-    order: { id, cid, gid }
-  })
+  const signal = tracer.collect(new OrderCancelledSignal(order))
 
   await emit('exec:stop', null, { origin: signal })
 }

--- a/lib/iceberg/events/orders_order_fill.js
+++ b/lib/iceberg/events/orders_order_fill.js
@@ -3,6 +3,7 @@
 const { Config } = require('bfx-api-node-core')
 const { DUST } = Config
 const { nBN } = require('@bitfinex/lib-js-util-math')
+const { types: { OrderFilledSignal, CancelAllSignal } } = require('bfx-hf-signals')
 
 /**
  * Called when an order is filled. Cancels any remaining open orders (slice or
@@ -22,13 +23,10 @@ const onOrdersOrderFill = async (instance = {}, order) => {
   const { emit, updateState, debug, debouncedSubmitOrders, tracer } = h
   const { amount } = args
   const m = amount < 0 ? -1 : 1
-  const { id, cid } = order
 
-  const fillSignal = tracer.createSignal('order_filled', null, {
-    order: { id, cid, gid }
-  })
+  const fillSignal = tracer.collect(new OrderFilledSignal(order))
 
-  tracer.createSignal('cancel_all', fillSignal)
+  tracer.collect(new CancelAllSignal(fillSignal))
   await emit('exec:order:cancel:all', gid, orders)
 
   const fillAmount = order.getLastFillAmount()

--- a/lib/iceberg/util/generate_orders.js
+++ b/lib/iceberg/util/generate_orders.js
@@ -5,6 +5,7 @@ const genCID = require('../../util/gen_client_id')
 const { Config } = require('bfx-api-node-core')
 const { DUST } = Config
 const { nBN } = require('@bitfinex/lib-js-util-math')
+const { types: { OrderSignal } } = require('bfx-hf-signals')
 
 /**
  * Returns an order set for the provided Iceberg instance, including a slice
@@ -52,32 +53,30 @@ const generateOrders = (instance, origin) => {
       (m === 1 && rem >= DUST) ||
       (m === -1 && rem <= DUST)
     ) {
-      const orderParams = {
+      const order = new Order({
         ...sharedOrderParams,
         cid: genCID(),
         type: orderType,
         amount: rem,
         hidden: true,
         meta
-      }
+      })
 
-      tracer.createSignal('order', origin, orderParams)
-
-      orders.push(new Order(orderParams))
+      tracer.collect(new OrderSignal(order, origin))
+      orders.push(order)
     }
   }
 
-  const orderParams = {
+  const order = new Order({
     ...sharedOrderParams,
     cid: genCID(),
     type: orderType,
     amount: sliceOrderAmount,
     meta
-  }
+  })
 
-  tracer.createSignal('order', origin, orderParams)
-
-  orders.push(new Order(orderParams))
+  tracer.collect(new OrderSignal(order, origin))
+  orders.push(order)
 
   return orders
 }

--- a/lib/twap/events/data_managed_book.js
+++ b/lib/twap/events/data_managed_book.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const { OrderBook } = require('bfx-api-node-models')
+const { types: { OrderbookDataSignal } } = require('bfx-hf-signals')
 const hasOBTarget = require('../util/has_ob_target')
 
 /**
@@ -35,14 +36,9 @@ const onDataManagedBook = async (instance = {}, book, meta) => {
   const activeOrderSet = new Set(activeOrdersIds)
   const externalBook = book.serialize().filter(([orderId]) => !activeOrderSet.has(orderId))
 
-  tracer.createSignal('data_orderbook', null, {
-    activeOrdersIds,
-    book: {
-      raw: book.raw,
-      bids: book.bids,
-      asks: book.asks
-    }
-  })
+  const bookSignal = new OrderbookDataSignal(book)
+  bookSignal.meta.activeOrderIds = activeOrdersIds
+  tracer.collect(book)
 
   await updateState(instance, {
     lastBook: new OrderBook(externalBook, book.raw)

--- a/lib/twap/events/data_trades.js
+++ b/lib/twap/events/data_trades.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const hasTradeTarget = require('../util/has_trade_target')
+const { types: { TradeDataSignal } } = require('bfx-hf-signals')
 
 /**
  * Saves the last trade on the instance state to be used in price matching.
@@ -34,9 +35,7 @@ const onDataTrades = async (instance = {}, trades, meta) => {
 
   debug('recv last price: %f [%j]', price, lastTrade)
 
-  tracer.createSignal('data_trades', null, {
-    trades: Object.values(trades)
-  })
+  tracer.collect(new TradeDataSignal(trades))
 
   await updateState(instance, { lastTrade })
 }

--- a/lib/twap/events/life_start.js
+++ b/lib/twap/events/life_start.js
@@ -2,6 +2,7 @@
 
 const _isFinite = require('lodash/isFinite')
 const _isString = require('lodash/isString')
+const { types: { StartSignal } } = require('bfx-hf-signals')
 const getMinMaxDistortedAmount = require('../../util/get_min_max_distorted_amount')
 
 /**
@@ -38,13 +39,13 @@ const onLifeStart = async (instance = {}) => {
 
   await updateState(instance, { minDistortedAmount, maxDistortedAmount })
 
-  const startSignal = tracer.createSignal('start', null, {
+  const startSignal = tracer.collect(new StartSignal({
     args,
     conditionMonitoringMode,
     softMatchMode,
     minDistortedAmount,
     maxDistortedAmount
-  })
+  }))
 
   try {
     await subscribeDataChannels(state, { timeout: 30 * 1000 })

--- a/lib/twap/events/life_stop.js
+++ b/lib/twap/events/life_stop.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { types: { StopSignal, CancelAllSignal } } = require('bfx-hf-signals')
+
 /**
  * Clears the tick interval prior to teardown
  *
@@ -24,8 +26,8 @@ const onLifeStop = async (instance = {}, opts = {}) => {
     debug('cleared interval/timeout')
   }
 
-  const stopSignal = tracer.createSignal('stop', origin)
-  tracer.createSignal('cancel_all', stopSignal)
+  const stopSignal = tracer.collect(new StopSignal(origin))
+  tracer.collect(new CancelAllSignal(stopSignal))
 
   await emit('exec:order:cancel:all', gid, orders)
 }

--- a/lib/twap/events/orders_order_cancel.js
+++ b/lib/twap/events/orders_order_cancel.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { types: { OrderCancelledSignal } } = require('bfx-hf-signals')
+
 /**
  * Triggered when an atomic order cancellation is detected; cancels any open
  * orders and emits the `exec:stop` event to trigger teardown.
@@ -16,13 +18,10 @@
 const onOrdersOrderCancel = async (instance = {}, order) => {
   const { h = {} } = instance
   const { emit, debug, tracer } = h
-  const { id, cid, gid } = order || {}
 
   debug('detected atomic cancellation, stopping...')
 
-  const signal = tracer.createSignal('order_cancelled', null, {
-    order: { id, cid, gid }
-  })
+  const signal = tracer.collect(new OrderCancelledSignal(order))
 
   await emit('exec:stop', null, { origin: signal })
 }

--- a/lib/twap/events/orders_order_fill.js
+++ b/lib/twap/events/orders_order_fill.js
@@ -3,6 +3,7 @@
 const { Config } = require('bfx-api-node-core')
 const { DUST } = Config
 const { nBN } = require('@bitfinex/lib-js-util-math')
+const { types: { OrderFilledSignal } } = require('bfx-hf-signals')
 
 /**
  * Triggered when an atomic order fills. Updates the remaining amount on the
@@ -22,11 +23,8 @@ const onOrdersOrderFill = async (instance = {}, order) => {
   const { emit, updateState, debug, tracer } = h
   const { amount } = args
   const m = amount < 0 ? -1 : 1
-  const { id, cid, gid } = order
 
-  const fillSignal = tracer.createSignal('order_filled', null, {
-    order: { id, cid, gid }
-  })
+  const fillSignal = tracer.collect(new OrderFilledSignal(order))
   const fillAmount = order.getLastFillAmount()
   const remainingAmount = nBN(state.remainingAmount).minus(fillAmount).toNumber()
   const absRem = m < 0 ? remainingAmount * -1 : remainingAmount

--- a/lib/twap/events/self_interval_tick.js
+++ b/lib/twap/events/self_interval_tick.js
@@ -3,6 +3,8 @@
 const _isEmpty = require('lodash/isEmpty')
 const _isFinite = require('lodash/isFinite')
 const { nBN } = require('@bitfinex/lib-js-util-math')
+const { types: { OrderSignal } } = require('bfx-hf-signals')
+
 const hasTradeTarget = require('../util/has_trade_target')
 const hasOBTarget = require('../util/has_ob_target')
 const generateOrder = require('../util/generate_order')
@@ -110,14 +112,7 @@ const onSelfIntervalTick = async (instance = {}, origin) => {
       await emit('exec:log_algo_data', gid, lastBook.serialize(), `OB_for_order_${order.cid}`)
     }
 
-    tracer.createSignal('order', tickSignal, {
-      symbol: order.symbol,
-      price: order.price,
-      lev: order.lev,
-      cid: order.cid,
-      amount: order.amount,
-      type: order.type
-    })
+    tracer.collect(new OrderSignal(order, tickSignal))
 
     await emit('exec:order:submit:all', gid, [order], 0)
   }

--- a/lib/twap/events/self_interval_tick.js
+++ b/lib/twap/events/self_interval_tick.js
@@ -3,7 +3,7 @@
 const _isEmpty = require('lodash/isEmpty')
 const _isFinite = require('lodash/isFinite')
 const { nBN } = require('@bitfinex/lib-js-util-math')
-const { types: { OrderSignal } } = require('bfx-hf-signals')
+const { types: { OrderSignal, TickSignal, CancelAllSignal } } = require('bfx-hf-signals')
 
 const hasTradeTarget = require('../util/has_trade_target')
 const hasOBTarget = require('../util/has_ob_target')
@@ -31,7 +31,7 @@ const onSelfIntervalTick = async (instance = {}, origin) => {
     orderType, sliceInterval
   } = args
 
-  const tickSignal = tracer.createSignal('tick', origin, args)
+  const tickSignal = tracer.collect(new TickSignal(origin, args))
 
   async function scheduleTick () {
     debug('scheduling interval (%f s)', sliceInterval / 1000)
@@ -50,7 +50,7 @@ const onSelfIntervalTick = async (instance = {}, origin) => {
   const hasOrders = !_isEmpty(orders)
 
   if (!tradeBeyondEnd && hasOrders) {
-    tracer.createSignal('cancel_all', tickSignal, { tradeBeyondEnd, hasOrders })
+    tracer.collect(new CancelAllSignal(tickSignal, { tradeBeyondEnd, hasOrders }))
     await emit('exec:order:cancel:all', gid, orders)
   }
 

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "bfx-api-node-rest": "^4.6.0",
     "bfx-api-node-util": "^1.0.2",
     "bfx-hf-indicators": "git+https://github.com/bitfinexcom/bfx-hf-indicators.git#v2.1.1",
-    "bfx-hf-signals": "git+https://github.com/tarcisiozf/bfx-hf-signals.git#new-signal-types",
+    "bfx-hf-signals": "git+https://github.com/bitfinexcom/bfx-hf-signals.git#v1.1.0",
     "bfx-hf-util": "github:bitfinexcom/bfx-hf-util#v1.0.12",
     "bluebird": "^3.5.5",
     "debug": "^4.3.1",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "bfx-api-node-rest": "^4.6.0",
     "bfx-api-node-util": "^1.0.2",
     "bfx-hf-indicators": "git+https://github.com/bitfinexcom/bfx-hf-indicators.git#v2.1.1",
-    "bfx-hf-signals": "git+https://github.com/bitfinexcom/bfx-hf-signals.git#v1.0.0",
+    "bfx-hf-signals": "git+https://github.com/tarcisiozf/bfx-hf-signals.git#new-signal-types",
     "bfx-hf-util": "github:bitfinexcom/bfx-hf-util#v1.0.12",
     "bluebird": "^3.5.5",
     "debug": "^4.3.1",

--- a/test/lib/iceberg/events/life_start.js
+++ b/test/lib/iceberg/events/life_start.js
@@ -2,24 +2,29 @@
 'use strict'
 
 const { stub, assert } = require('sinon')
+const { expect } = require('chai')
+const { StartSignal } = require('bfx-hf-signals/lib/types')
 
 const onLifeStart = require('../../../../lib/iceberg/events/life_start')
 
 describe('iceberg:events:life_start', () => {
   const emitSelf = stub()
-  const createSignal = stub()
+  const collect = stub()
 
-  const tracer = { createSignal }
+  const tracer = { collect }
   const h = { emitSelf, tracer }
   const instance = { h }
 
   it('submits orders on startup', async () => {
     const fakeSignal = {}
-    createSignal.returns(fakeSignal)
+    collect.returns(fakeSignal)
 
     await onLifeStart(instance)
 
-    assert.calledWithExactly(createSignal, 'start', null, { args: {} })
+    assert.calledOnce(collect)
+    const [signal] = collect.firstCall.args
+    expect(signal).to.be.instanceOf(StartSignal)
+    expect(signal.meta).to.eql({ args: {} })
     assert.calledWithExactly(emitSelf, 'submit_orders', fakeSignal)
   })
 })

--- a/test/lib/iceberg/events/life_stop.js
+++ b/test/lib/iceberg/events/life_stop.js
@@ -5,6 +5,7 @@
 const { expect } = require('chai')
 const { stub, assert } = require('sinon')
 const onLifeStop = require('../../../../lib/iceberg/events/life_stop')
+const { StopSignal, CancelAllSignal } = require('bfx-hf-signals/lib/types')
 
 describe('iceberg:events:life_stop', () => {
   const state = {
@@ -13,7 +14,7 @@ describe('iceberg:events:life_stop', () => {
     timeout: setTimeout(() => {}, 10000)
   }
   const tracer = {
-    createSignal: stub()
+    collect: stub()
   }
   const h = {
     tracer,
@@ -29,15 +30,18 @@ describe('iceberg:events:life_stop', () => {
 
   it('cancels all orders when iceberg algo stopped', async () => {
     const fakeSignal = { id: 2 }
-    tracer.createSignal.onCall(0).returns(fakeSignal)
+    tracer.collect.onCall(0).returns(fakeSignal)
 
     await onLifeStop(instance, opts)
 
     assert.calledWithExactly(h.debouncedSubmitOrders.cancel)
     expect(state.timeout._destroyed).to.be.true
     assert.calledWithExactly(h.updateState, instance, { timeout: null })
-    assert.calledWithExactly(tracer.createSignal, 'stop', opts.origin)
-    assert.calledWithExactly(tracer.createSignal, 'cancel_all', fakeSignal)
+    const [[stopSignal], [cancelAllSignal]] = tracer.collect.args
+    expect(stopSignal).to.be.instanceOf(StopSignal)
+    expect(stopSignal.parent).to.eq(opts.origin)
+    expect(cancelAllSignal).to.be.instanceOf(CancelAllSignal)
+    expect(cancelAllSignal.parent).to.eq(fakeSignal)
     assert.calledWithExactly(h.emit, 'exec:order:cancel:all', state.gid, state.orders)
   })
 })

--- a/test/lib/iceberg/events/self_submit_orders.js
+++ b/test/lib/iceberg/events/self_submit_orders.js
@@ -24,9 +24,10 @@ describe('iceberg:events:self_submit_orders', () => {
   const tracer = { collect: stub() }
   const h = { emit: stub(), tracer }
   const instance = { state, h }
+  const origin = { id: 10 }
 
   it('submits generated orders', async () => {
-    await onSubmitOrders(instance, null)
+    await onSubmitOrders(instance, origin)
 
     assert.calledOnce(h.emit)
     const [eventName, gid, orders] = h.emit.firstCall.args
@@ -46,7 +47,7 @@ describe('iceberg:events:self_submit_orders', () => {
     assert.calledOnce(tracer.collect)
     const [signal] = tracer.collect.firstCall.args
     expect(signal.name).to.eq('order')
-    expect(signal.parent).to.be.null
+    expect(signal.parent).to.eq(origin)
     expect(signal.meta.symbol).to.be.eq(args.symbol)
     expect(signal.meta.price).to.be.eq(args.price)
     expect(signal.meta.cid).to.be.a('number')

--- a/test/lib/iceberg/events/self_submit_orders.js
+++ b/test/lib/iceberg/events/self_submit_orders.js
@@ -21,7 +21,7 @@ describe('iceberg:events:self_submit_orders', () => {
     remainingAmount: 0.05,
     args
   }
-  const tracer = { createSignal: stub() }
+  const tracer = { collect: stub() }
   const h = { emit: stub(), tracer }
   const instance = { state, h }
 
@@ -43,15 +43,15 @@ describe('iceberg:events:self_submit_orders', () => {
     expect(order.amount).to.be.eq(0.05)
     expect(order.meta).to.be.undefined
 
-    assert.calledOnce(tracer.createSignal)
-    const [name, origin, meta] = tracer.createSignal.firstCall.args
-    expect(name).to.eq('order')
-    expect(origin).to.be.null
-    expect(meta.symbol).to.be.eq(args.symbol)
-    expect(meta.price).to.be.eq(args.price)
-    expect(meta.cid).to.be.a('number')
-    expect(meta.type).to.be.eq(args.orderType)
-    expect(meta.amount).to.be.eq(0.05)
-    expect(meta.meta).to.be.undefined
+    assert.calledOnce(tracer.collect)
+    const [signal] = tracer.collect.firstCall.args
+    expect(signal.name).to.eq('order')
+    expect(signal.parent).to.be.null
+    expect(signal.meta.symbol).to.be.eq(args.symbol)
+    expect(signal.meta.price).to.be.eq(args.price)
+    expect(signal.meta.cid).to.be.a('number')
+    expect(signal.meta.type).to.be.eq(args.orderType)
+    expect(signal.meta.amount).to.be.eq(0.05)
+    expect(signal.meta.meta).to.be.undefined
   })
 })

--- a/test/lib/iceberg/util/generate_orders.js
+++ b/test/lib/iceberg/util/generate_orders.js
@@ -10,7 +10,7 @@ const { stub } = require('sinon')
 
 describe('iceberg:util:generate_orders', () => {
   const tracer = {
-    createSignal: stub()
+    collect: stub()
   }
   const h = { tracer }
   const args = {

--- a/test/lib/iceberg/util/generate_orders.js
+++ b/test/lib/iceberg/util/generate_orders.js
@@ -21,11 +21,12 @@ describe('iceberg:util:generate_orders', () => {
     excessAsHidden: false,
     price: 1000
   }
+  const origin = { id: 10 }
 
   it('generates valid slice order', () => {
     const state = { remainingAmount: args.amount, args }
     const instance = { state, h }
-    const orders = generateOrders(instance)
+    const orders = generateOrders(instance, origin)
     const [slice] = orders
 
     assert.strictEqual(orders.length, 1)
@@ -48,7 +49,7 @@ describe('iceberg:util:generate_orders', () => {
 
     const state = { remainingAmount: 0.3, args: order }
     const instance = { state, h }
-    const orders = generateOrders(instance)
+    const orders = generateOrders(instance, origin)
     const [hidden] = orders
 
     assert.strictEqual(hidden.amount, 0.2, 'not -0.19999999999999998')
@@ -57,7 +58,7 @@ describe('iceberg:util:generate_orders', () => {
   it('caps slice order at remainingAmount if less than slice', () => {
     const state = { remainingAmount: 0.05, args }
     const instance = { state, h }
-    const orders = generateOrders(instance)
+    const orders = generateOrders(instance, origin)
     const [slice] = orders
     assert.strictEqual(slice.amount, 0.05)
   })
@@ -71,7 +72,7 @@ describe('iceberg:util:generate_orders', () => {
       }
     }
     const instance = { state, h }
-    const orders = generateOrders(instance)
+    const orders = generateOrders(instance, origin)
 
     const [hidden] = orders
     assert.strictEqual(orders.length, 2)
@@ -91,7 +92,7 @@ describe('iceberg:util:generate_orders', () => {
       }
     }
     const instance = { state, h }
-    const orders = generateOrders(instance)
+    const orders = generateOrders(instance, origin)
 
     const [hidden] = orders
     assert((hidden.amount - 0.05) < DUST)
@@ -106,7 +107,7 @@ describe('iceberg:util:generate_orders', () => {
       }
     }
     const instance = { state, h }
-    const orders = generateOrders(instance)
+    const orders = generateOrders(instance, origin)
 
     assert.strictEqual(orders.length, 1)
   })

--- a/test/lib/twap/events/data_managed_book.js
+++ b/test/lib/twap/events/data_managed_book.js
@@ -82,7 +82,7 @@ describe('twap:events:data_managed_book', () => {
 
       h: {
         debug: () => {},
-        tracer: { createSignal: () => {} },
+        tracer: { collect: () => {} },
         updateState: (instance, state) => {
           return new Promise((resolve) => {
             assert.ok(state.lastBook instanceof OrderBook)

--- a/test/lib/twap/events/data_trades.js
+++ b/test/lib/twap/events/data_trades.js
@@ -69,7 +69,7 @@ describe('twap:events:data_trades', () => {
       },
 
       h: {
-        tracer: { createSignal: () => {} },
+        tracer: { collect: () => {} },
         debug: () => {},
         updateState: (instance, state) => {
           return new Promise((resolve) => {

--- a/test/lib/twap/events/life_start.js
+++ b/test/lib/twap/events/life_start.js
@@ -18,7 +18,7 @@ describe('twap:events:life_start', () => {
       },
 
       h: {
-        tracer: { createSignal: () => {} },
+        tracer: { collect: () => {} },
         debug: () => {},
         subscribeDataChannels: async () => {},
         updateState: (instance, state) => {

--- a/test/lib/twap/events/life_stop.js
+++ b/test/lib/twap/events/life_stop.js
@@ -10,7 +10,7 @@ describe('twap:events:life_stop', () => {
 
     await onLifeStop({
       h: {
-        tracer: { createSignal: () => {} },
+        tracer: { collect: () => {} },
         updateState: () => {},
         debug: () => {},
         emit: (eventName) => {

--- a/test/lib/twap/events/orders_order_cancel.js
+++ b/test/lib/twap/events/orders_order_cancel.js
@@ -5,16 +5,22 @@ const assert = require('assert')
 const onOrderCancel = require('../../../../lib/twap/events/orders_order_cancel')
 
 describe('twap:events:orders_order_cancel', () => {
-  it('submits all known orders for cancellation & stops operation', (done) => {
-    onOrderCancel({
-      h: {
-        tracer: { createSignal: () => {} },
-        debug: () => {},
-        emit: async (eName) => {
-          assert.strictEqual(eName, 'exec:stop')
-          done()
-        }
+  const instance = {
+    h: {
+      tracer: { collect: () => {} },
+      debug: () => {},
+      emit: async (eName) => {
+        assert.strictEqual(eName, 'exec:stop')
       }
-    })
+    }
+  }
+  const order = {
+    id: 87,
+    cid: 4934,
+    gid: 123
+  }
+
+  it('submits all known orders for cancellation & stops operation', async () => {
+    await onOrderCancel(instance, order)
   })
 })

--- a/test/lib/twap/events/orders_order_fill.js
+++ b/test/lib/twap/events/orders_order_fill.js
@@ -18,7 +18,7 @@ describe('twap:events:orders_order_fill', () => {
     },
 
     h: {
-      tracer: { createSignal: () => ({ meta: {} }) },
+      tracer: { collect: () => ({ meta: {} }) },
       debug: () => {},
       updateState: async () => {},
       emitSelf: async () => {},

--- a/test/lib/twap/events/self_interval_tick.js
+++ b/test/lib/twap/events/self_interval_tick.js
@@ -25,9 +25,11 @@ const timeout = (ms) => {
   return [id, () => p]
 }
 
-const tracer = { createSignal: (name, origin, meta) => ({ meta: {} }) }
+const tracer = { collect: () => ({ meta: {} }) }
 
 describe('twap:events:self_interval_tick', () => {
+  const origin = { id: 10 }
+
   it('submits order for float order amount', async () => {
     let orderSubmitted = false
     const instance = {
@@ -53,7 +55,7 @@ describe('twap:events:self_interval_tick', () => {
         }
       }
     }
-    await onIntervalTick(instance)
+    await onIntervalTick(instance, origin)
     assert.ok(orderSubmitted, 'did not submit order for float amounts')
   })
 
@@ -82,7 +84,7 @@ describe('twap:events:self_interval_tick', () => {
         },
         emit: () => {}
       }
-    })
+    }, origin)
   })
 
   it('cancels if not trading beyond end period and there are orders', (done) => {
@@ -113,7 +115,7 @@ describe('twap:events:self_interval_tick', () => {
           }).then(done).catch(done)
         }
       }
-    })
+    }, origin)
   })
 
   it('does not submit orders if book price data needed & unavailable', (done) => {
@@ -138,7 +140,7 @@ describe('twap:events:self_interval_tick', () => {
           }).catch(done)
         }
       }
-    })
+    }, origin)
 
     done()
   })
@@ -165,7 +167,7 @@ describe('twap:events:self_interval_tick', () => {
           }).catch(done)
         }
       }
-    })
+    }, origin)
 
     done()
   })
@@ -208,7 +210,7 @@ describe('twap:events:self_interval_tick', () => {
           }).then(done).catch(done)
         }
       }
-    })
+    }, origin)
   })
 
   it('submits order if trade price data needed, available, and matched', (done) => {
@@ -245,7 +247,7 @@ describe('twap:events:self_interval_tick', () => {
           }).then(done).catch(done)
         }
       }
-    })
+    }, origin)
   })
 
   it('does not submit order if trade price data needed, available, but not matched', (done) => {
@@ -272,7 +274,7 @@ describe('twap:events:self_interval_tick', () => {
           }).catch(done)
         }
       }
-    })
+    }, origin)
 
     done()
   })
@@ -304,7 +306,7 @@ describe('twap:events:self_interval_tick', () => {
           }).catch(done)
         }
       }
-    })
+    }, origin)
 
     done()
   })


### PR DESCRIPTION
Reuse types from the signal lib. more info at: https://github.com/bitfinexcom/bfx-hf-signals/pull/2

PREVIOUSLY OPEN HERE: https://github.com/bitfinexcom/bfx-hf-algo/pull/203