### PR TITLE
add algoOrderId in meta to differentiate between saved orders

### DIFF
--- a/lib/host/init_ao_state.js
+++ b/lib/host/init_ao_state.js
@@ -35,6 +35,12 @@ const AsyncEventEmitter = require('../async_event_emitter')
 module.exports = (aoDef = {}, args = {}, pairConfig = {}) => {
   const { meta = {}, id, name, headersForLogFile } = aoDef
   const { validateParams, processParams, initState, genOrderLabel } = meta
+
+  args.meta = {
+    ...args.meta || {},
+    algoOrderId: id
+  }
+
   const params = _isFunction(processParams)
     ? processParams(args)
     : args


### PR DESCRIPTION
Add `algoOrderId` property in meta to filter out the orders by specific algo orders. 