### PR TITLE
Revert twap trade beyond end

### DIFF
--- a/lib/twap/events/self_interval_tick.js
+++ b/lib/twap/events/self_interval_tick.js
@@ -65,9 +65,8 @@ const onSelfIntervalTick = async (instance = {}, origin) => {
       (amount > 0 && (currentSumAmount > amount)) ||
       (amount < 0 && (currentSumAmount < amount))
     ) {
-      tickSignal.meta.currentSumAmount = currentSumAmount
       debug('next tick would exceed total order amount, refusing')
-      return emit('exec:stop', null, { origin: tickSignal })
+      return
     }
   }
 

--- a/test/lib/host/init_ao_state.js
+++ b/test/lib/host/init_ao_state.js
@@ -46,15 +46,14 @@ describe('host:init_ao_state', () => {
   })
 
   it('provides necessary default data', () => {
-    const state = initAOState({ name: 'test', id: 'some-id' }, 42)
-
+    const state = initAOState({ name: 'test', id: 'some-id' }, { arg1: 42 })
     assert.ok(_isArray(state.channels) && _isEmpty(state.channels))
     assert.ok(_isObject(state.orders) && _isEmpty(state.orders))
     assert.ok(_isObject(state.cancelledOrders) && _isEmpty(state.cancelledOrders))
     assert.ok(_isObject(state.allOrders) && _isEmpty(state.allOrders))
     assert.ok(state.ev instanceof AsyncEventEmitter)
     assert.ok(_isString(state.label) && !_isEmpty(state.name))
-    assert.strictEqual(state.args, 42)
+    assert.deepStrictEqual(state.args, { arg1: 42, meta: { algoOrderId: 'some-id' } })
     assert.strictEqual(state.id, 'some-id')
   })
 })


### PR DESCRIPTION
TWAP algo should not be stopped in case of `tradeBeyondEnd` option.

Task: https://app.asana.com/0/1201849173362898/1202960193464620